### PR TITLE
Add i18n for strategy builder and backtest pages

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -16,7 +16,13 @@
     "no": "No",
     "version": "Version {version}",
     "copyright": "\u00a9 {year} Quant Investment. All rights reserved.",
-    "collapse": "Collapse"
+    "collapse": "Collapse",
+    "enabled": "Enabled",
+    "disabled": "Disabled",
+    "up": "Up",
+    "down": "Down",
+    "below": "Below",
+    "above": "Above"
   },
   "nav": {
     "dashboard": "Dashboard",
@@ -152,11 +158,53 @@
     "deployStrategy": "Deploy Strategy",
     "nodes": "Nodes",
     "filters": "Filters",
+    "matched": "Matched",
     "results": "Results ({count} matched)",
     "hide": "Hide",
     "show": "Show",
     "lastRunJustNow": "Last run: Just now",
-    "lastRunNever": "Last run: Never"
+    "lastRunNever": "Last run: Never",
+    "stocksMatched": "{count} stocks matched",
+    "executionFailed": "Execution failed",
+    "moreErrors": "+{count} more",
+    "kospiData": "KOSPI Data",
+    "ticker": "Ticker",
+    "name": "Name",
+    "price": "Price",
+    "status": "Status",
+
+    "inputBadge": "Input",
+    "screeningBadge": "Screening",
+    "outputBadge": "Output",
+    "marketSelection": "Market Selection",
+    "composite": "{universe} Composite",
+    "condition": "Condition",
+    "finalSelection": "Final Selection",
+    "estimatedItems": "{count} estimated items",
+    "connectAndRun": "Connect nodes and run",
+
+    "searchPlaceholder": "Search components...",
+    "inputNodes": "Input Nodes",
+    "filterNodes": "Filter Nodes",
+    "logicOperators": "Logic Operators",
+    "andGate": "AND Gate",
+    "orGate": "OR Gate",
+    "notGate": "NOT Gate",
+    "finalOutput": "Final Output",
+
+    "nodeProperties": "Node Properties",
+    "displayName": "Display Name",
+    "stockUniverse": "Stock Universe",
+    "conditionLogic": "Condition Logic",
+    "selectCondition": "Select condition...",
+    "quickInsight": "Quick Insight",
+    "logicOperator": "Logic Operator",
+    "andAllMustMatch": "AND (all must match)",
+    "orAnyMustMatch": "OR (any must match)",
+    "notInvertFirst": "NOT (invert first input)",
+    "outputInstruction": "Connect condition nodes to this output, then click \"Deploy Strategy\" to execute the screening.",
+    "removeNode": "Remove Node",
+    "applyChanges": "Apply Changes"
   },
   "analysis": {
     "title": "Charts & Analysis",
@@ -198,7 +246,170 @@
     "maxConsecWins": "Max Consec. Wins",
     "maxConsecLosses": "Max Consec. Losses",
     "individualTrades": "Individual Trades",
-    "failed": "Backtest failed. Please check your inputs and try again."
+    "failed": "Backtest failed. Please check your inputs and try again.",
+    "totalReturn": "Total Return",
+    "sharpeRatio": "Sharpe Ratio",
+    "maxDrawdown": "Max Drawdown",
+    "winRate": "Win Rate",
+    "cagr": "CAGR",
+    "profitFactor": "Profit Factor",
+    "entry": "Entry",
+    "exit": "Exit",
+    "entryPrice": "Entry Price",
+    "exitPrice": "Exit Price",
+    "pnl": "P&L",
+    "return": "Return",
+    "totalTrades": "Total ({count} trades)"
+  },
+  "conditions": {
+    "categories": {
+      "price": "Price",
+      "volume": "Volume",
+      "movingAverage": "Moving Average",
+      "rsi": "RSI",
+      "accumulation": "Accumulation",
+      "breakout": "Breakout"
+    },
+    "min_price": {
+      "label": "Min Price",
+      "desc": "Stock price >= threshold",
+      "params": { "min_price": "Minimum price" }
+    },
+    "max_price": {
+      "label": "Max Price",
+      "desc": "Stock price <= threshold",
+      "params": { "max_price": "Maximum price" }
+    },
+    "price_range": {
+      "label": "Price Range",
+      "desc": "Stock price within range",
+      "params": { "min_price": "Min price", "max_price": "Max price" }
+    },
+    "price_change": {
+      "label": "Price Change %",
+      "desc": "Price change over N days",
+      "params": { "min_change_pct": "Min change %", "max_change_pct": "Max change %", "days": "Period (days)" }
+    },
+    "min_volume": {
+      "label": "Min Volume",
+      "desc": "Volume >= threshold",
+      "params": { "min_volume": "Minimum volume" }
+    },
+    "volume_above_avg": {
+      "label": "Volume Above Avg",
+      "desc": "Volume above moving average",
+      "params": { "multiplier": "Avg multiplier", "period": "Average period" }
+    },
+    "volume_spike": {
+      "label": "Volume Spike",
+      "desc": "Sudden volume increase",
+      "params": { "multiplier": "Spike multiplier", "period": "Average period" }
+    },
+    "ma_touch": {
+      "label": "MA Touch",
+      "desc": "Price near moving average",
+      "params": { "period": "MA period", "threshold": "Touch threshold (ratio)" }
+    },
+    "above_ma": {
+      "label": "Above MA",
+      "desc": "Price above moving average",
+      "params": { "period": "MA period", "min_distance_pct": "Min distance %" }
+    },
+    "below_ma": {
+      "label": "Below MA",
+      "desc": "Price below moving average",
+      "params": { "period": "MA period", "max_distance_pct": "Max distance %" }
+    },
+    "ma_cross_up": {
+      "label": "MA Cross Up",
+      "desc": "Golden cross",
+      "params": { "short_period": "Short MA period", "long_period": "Long MA period", "lookback_days": "Lookback days" }
+    },
+    "ma_cross_down": {
+      "label": "MA Cross Down",
+      "desc": "Death cross",
+      "params": { "short_period": "Short MA period", "long_period": "Long MA period", "lookback_days": "Lookback days" }
+    },
+    "rsi_oversold": {
+      "label": "RSI Oversold",
+      "desc": "RSI below threshold",
+      "params": { "threshold": "RSI threshold", "period": "RSI period" }
+    },
+    "rsi_overbought": {
+      "label": "RSI Overbought",
+      "desc": "RSI above threshold",
+      "params": { "threshold": "RSI threshold", "period": "RSI period" }
+    },
+    "rsi_range": {
+      "label": "RSI Range",
+      "desc": "RSI within range",
+      "params": { "lower": "Lower bound", "upper": "Upper bound", "period": "RSI period" }
+    },
+    "bollinger_width": {
+      "label": "Bollinger Width",
+      "desc": "BB width contraction",
+      "params": { "max_width_pct": "Max BB width %", "period": "BB period", "std_dev": "Std deviation" }
+    },
+    "volume_below_avg": {
+      "label": "Volume Below Avg",
+      "desc": "Quiet volume zone",
+      "params": { "multiplier": "Max ratio to avg", "period": "Average period" }
+    },
+    "price_flat": {
+      "label": "Price Flat",
+      "desc": "Price consolidation",
+      "params": { "max_range_pct": "Max range %", "period": "Period" }
+    },
+    "obv_trend": {
+      "label": "OBV Trend",
+      "desc": "On-Balance Volume trend",
+      "params": { "direction": "Trend direction (up/down)", "lookback": "Lookback period" }
+    },
+    "stochastic_level": {
+      "label": "Stochastic Level",
+      "desc": "Stochastic oscillator level",
+      "params": { "threshold": "Level threshold", "condition": "below or above", "k_period": "%K period", "d_period": "%D period" }
+    },
+    "vpci_trend": {
+      "label": "VPCI Trend",
+      "desc": "VPCI trend direction",
+      "params": { "direction": "Trend direction (up/down)", "short_period": "Short period", "long_period": "Long period", "lookback": "Lookback period" }
+    },
+    "obv_divergence": {
+      "label": "OBV Divergence",
+      "desc": "Price flat + OBV rising",
+      "params": { "price_max_range_pct": "Price range %", "obv_min_change_pct": "OBV change %", "period": "Period" }
+    },
+    "stochastic_divergence": {
+      "label": "Stochastic Divergence",
+      "desc": "Bullish stochastic divergence",
+      "params": { "k_period": "%K period", "d_period": "%D period", "lookback": "Lookback period", "divergence_threshold": "Threshold %" }
+    },
+    "vpci_divergence": {
+      "label": "VPCI Divergence",
+      "desc": "Price flat + VPCI rising",
+      "params": { "price_max_range_pct": "Price range %", "short_period": "Short period", "long_period": "Long period", "lookback": "Lookback period" }
+    },
+    "bottom_breakout": {
+      "label": "Bottom Breakout",
+      "desc": "N-day low breakout",
+      "params": { "lookback_days": "Lookback days", "breakout_pct": "Breakout %" }
+    },
+    "fresh_breakout": {
+      "label": "Fresh Breakout",
+      "desc": "First-time breakout",
+      "params": { "lookback_days": "Lookback days", "breakout_pct": "Breakout %" }
+    },
+    "breakout_with_volume": {
+      "label": "Breakout + Volume",
+      "desc": "Breakout with volume confirmation",
+      "params": { "lookback_days": "Lookback days", "breakout_pct": "Breakout %", "volume_ratio": "Volume ratio", "volume_avg_days": "Volume avg days", "fresh_only": "Fresh breakout only" }
+    },
+    "resistance_breakout": {
+      "label": "Resistance Breakout",
+      "desc": "Resistance level breakout",
+      "params": { "lookback_days": "Lookback days", "breakout_margin_pct": "Margin above resistance %" }
+    }
   },
   "markets": {
     "us": "US Market",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -16,7 +16,13 @@
     "no": "아니오",
     "version": "버전 {version}",
     "copyright": "\u00a9 {year} Quant Investment. All rights reserved.",
-    "collapse": "접기"
+    "collapse": "접기",
+    "enabled": "활성",
+    "disabled": "비활성",
+    "up": "상승",
+    "down": "하락",
+    "below": "이하",
+    "above": "이상"
   },
   "nav": {
     "dashboard": "대시보드",
@@ -152,11 +158,53 @@
     "deployStrategy": "전략 배포",
     "nodes": "노드",
     "filters": "필터",
+    "matched": "매치",
     "results": "결과 ({count}개 매치)",
     "hide": "숨기기",
     "show": "보기",
     "lastRunJustNow": "마지막 실행: 방금",
-    "lastRunNever": "마지막 실행: 없음"
+    "lastRunNever": "마지막 실행: 없음",
+    "stocksMatched": "{count}개 종목 매치",
+    "executionFailed": "실행 실패",
+    "moreErrors": "+{count}개 추가",
+    "kospiData": "KOSPI 데이터",
+    "ticker": "종목코드",
+    "name": "종목명",
+    "price": "가격",
+    "status": "상태",
+
+    "inputBadge": "입력",
+    "screeningBadge": "스크리닝",
+    "outputBadge": "출력",
+    "marketSelection": "시장 선택",
+    "composite": "{universe} 종합",
+    "condition": "조건",
+    "finalSelection": "최종 선택",
+    "estimatedItems": "예상 {count}개",
+    "connectAndRun": "노드를 연결하고 실행하세요",
+
+    "searchPlaceholder": "컴포넌트 검색...",
+    "inputNodes": "입력 노드",
+    "filterNodes": "필터 노드",
+    "logicOperators": "논리 연산자",
+    "andGate": "AND 게이트",
+    "orGate": "OR 게이트",
+    "notGate": "NOT 게이트",
+    "finalOutput": "최종 출력",
+
+    "nodeProperties": "노드 속성",
+    "displayName": "표시 이름",
+    "stockUniverse": "종목 유니버스",
+    "conditionLogic": "조건 로직",
+    "selectCondition": "조건 선택...",
+    "quickInsight": "요약 정보",
+    "logicOperator": "논리 연산자",
+    "andAllMustMatch": "AND (모두 충족)",
+    "orAnyMustMatch": "OR (하나 이상 충족)",
+    "notInvertFirst": "NOT (첫 번째 입력 반전)",
+    "outputInstruction": "조건 노드를 이 출력에 연결한 후 \"전략 배포\"를 클릭하여 스크리닝을 실행하세요.",
+    "removeNode": "노드 삭제",
+    "applyChanges": "변경 적용"
   },
   "analysis": {
     "title": "차트 & 분석",
@@ -198,7 +246,170 @@
     "maxConsecWins": "최대 연속 수익",
     "maxConsecLosses": "최대 연속 손실",
     "individualTrades": "개별 거래",
-    "failed": "백테스트에 실패했습니다. 입력값을 확인하고 다시 시도해 주세요."
+    "failed": "백테스트에 실패했습니다. 입력값을 확인하고 다시 시도해 주세요.",
+    "totalReturn": "총 수익률",
+    "sharpeRatio": "샤프 비율",
+    "maxDrawdown": "최대 낙폭",
+    "winRate": "승률",
+    "cagr": "연평균 수익률",
+    "profitFactor": "수익 팩터",
+    "entry": "진입",
+    "exit": "청산",
+    "entryPrice": "진입가",
+    "exitPrice": "청산가",
+    "pnl": "손익",
+    "return": "수익률",
+    "totalTrades": "합계 ({count}건)"
+  },
+  "conditions": {
+    "categories": {
+      "price": "가격",
+      "volume": "거래량",
+      "movingAverage": "이동평균",
+      "rsi": "RSI",
+      "accumulation": "매집",
+      "breakout": "돌파"
+    },
+    "min_price": {
+      "label": "최소 가격",
+      "desc": "주가 >= 기준값",
+      "params": { "min_price": "최소 가격" }
+    },
+    "max_price": {
+      "label": "최대 가격",
+      "desc": "주가 <= 기준값",
+      "params": { "max_price": "최대 가격" }
+    },
+    "price_range": {
+      "label": "가격 범위",
+      "desc": "주가가 범위 내",
+      "params": { "min_price": "최소 가격", "max_price": "최대 가격" }
+    },
+    "price_change": {
+      "label": "가격 변동률",
+      "desc": "N일간 가격 변동",
+      "params": { "min_change_pct": "최소 변동 %", "max_change_pct": "최대 변동 %", "days": "기간 (일)" }
+    },
+    "min_volume": {
+      "label": "최소 거래량",
+      "desc": "거래량 >= 기준값",
+      "params": { "min_volume": "최소 거래량" }
+    },
+    "volume_above_avg": {
+      "label": "평균 이상 거래량",
+      "desc": "이동평균 대비 거래량 초과",
+      "params": { "multiplier": "평균 배수", "period": "평균 기간" }
+    },
+    "volume_spike": {
+      "label": "거래량 급증",
+      "desc": "갑작스러운 거래량 증가",
+      "params": { "multiplier": "급증 배수", "period": "평균 기간" }
+    },
+    "ma_touch": {
+      "label": "MA 터치",
+      "desc": "이동평균선 근접",
+      "params": { "period": "MA 기간", "threshold": "터치 임계값 (비율)" }
+    },
+    "above_ma": {
+      "label": "MA 위",
+      "desc": "이동평균선 상방",
+      "params": { "period": "MA 기간", "min_distance_pct": "최소 이격도 %" }
+    },
+    "below_ma": {
+      "label": "MA 아래",
+      "desc": "이동평균선 하방",
+      "params": { "period": "MA 기간", "max_distance_pct": "최대 이격도 %" }
+    },
+    "ma_cross_up": {
+      "label": "MA 골든크로스",
+      "desc": "골든크로스",
+      "params": { "short_period": "단기 MA 기간", "long_period": "장기 MA 기간", "lookback_days": "확인 기간" }
+    },
+    "ma_cross_down": {
+      "label": "MA 데드크로스",
+      "desc": "데드크로스",
+      "params": { "short_period": "단기 MA 기간", "long_period": "장기 MA 기간", "lookback_days": "확인 기간" }
+    },
+    "rsi_oversold": {
+      "label": "RSI 과매도",
+      "desc": "RSI 기준값 이하",
+      "params": { "threshold": "RSI 기준값", "period": "RSI 기간" }
+    },
+    "rsi_overbought": {
+      "label": "RSI 과매수",
+      "desc": "RSI 기준값 이상",
+      "params": { "threshold": "RSI 기준값", "period": "RSI 기간" }
+    },
+    "rsi_range": {
+      "label": "RSI 범위",
+      "desc": "RSI가 범위 내",
+      "params": { "lower": "하한값", "upper": "상한값", "period": "RSI 기간" }
+    },
+    "bollinger_width": {
+      "label": "볼린저 밴드 폭",
+      "desc": "BB 밴드 수축",
+      "params": { "max_width_pct": "최대 BB 폭 %", "period": "BB 기간", "std_dev": "표준편차" }
+    },
+    "volume_below_avg": {
+      "label": "평균 이하 거래량",
+      "desc": "거래량 침체 구간",
+      "params": { "multiplier": "평균 대비 최대 비율", "period": "평균 기간" }
+    },
+    "price_flat": {
+      "label": "가격 횡보",
+      "desc": "가격 횡보 구간",
+      "params": { "max_range_pct": "최대 변동폭 %", "period": "기간" }
+    },
+    "obv_trend": {
+      "label": "OBV 추세",
+      "desc": "거래량 가중 추세",
+      "params": { "direction": "추세 방향 (상승/하락)", "lookback": "확인 기간" }
+    },
+    "stochastic_level": {
+      "label": "스토캐스틱 레벨",
+      "desc": "스토캐스틱 오실레이터 수준",
+      "params": { "threshold": "레벨 기준값", "condition": "이하 또는 이상", "k_period": "%K 기간", "d_period": "%D 기간" }
+    },
+    "vpci_trend": {
+      "label": "VPCI 추세",
+      "desc": "VPCI 추세 방향",
+      "params": { "direction": "추세 방향 (상승/하락)", "short_period": "단기 기간", "long_period": "장기 기간", "lookback": "확인 기간" }
+    },
+    "obv_divergence": {
+      "label": "OBV 다이버전스",
+      "desc": "가격 횡보 + OBV 상승",
+      "params": { "price_max_range_pct": "가격 변동폭 %", "obv_min_change_pct": "OBV 변화 %", "period": "기간" }
+    },
+    "stochastic_divergence": {
+      "label": "스토캐스틱 다이버전스",
+      "desc": "강세 스토캐스틱 다이버전스",
+      "params": { "k_period": "%K 기간", "d_period": "%D 기간", "lookback": "확인 기간", "divergence_threshold": "임계값 %" }
+    },
+    "vpci_divergence": {
+      "label": "VPCI 다이버전스",
+      "desc": "가격 횡보 + VPCI 상승",
+      "params": { "price_max_range_pct": "가격 변동폭 %", "short_period": "단기 기간", "long_period": "장기 기간", "lookback": "확인 기간" }
+    },
+    "bottom_breakout": {
+      "label": "저점 돌파",
+      "desc": "N일 저점 돌파",
+      "params": { "lookback_days": "확인 기간", "breakout_pct": "돌파 %" }
+    },
+    "fresh_breakout": {
+      "label": "신규 돌파",
+      "desc": "최초 돌파",
+      "params": { "lookback_days": "확인 기간", "breakout_pct": "돌파 %" }
+    },
+    "breakout_with_volume": {
+      "label": "돌파 + 거래량",
+      "desc": "거래량 동반 돌파",
+      "params": { "lookback_days": "확인 기간", "breakout_pct": "돌파 %", "volume_ratio": "거래량 배수", "volume_avg_days": "거래량 평균 기간", "fresh_only": "신규 돌파만" }
+    },
+    "resistance_breakout": {
+      "label": "저항선 돌파",
+      "desc": "저항 수준 돌파",
+      "params": { "lookback_days": "확인 기간", "breakout_margin_pct": "저항선 위 마진 %" }
+    }
   },
   "markets": {
     "us": "미국 시장",

--- a/web/src/app/[locale]/strategy/page.tsx
+++ b/web/src/app/[locale]/strategy/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useCallback, useRef, useMemo } from 'react';
+import { useTranslations } from 'next-intl';
 import {
   ReactFlow,
   addEdge,
@@ -68,6 +69,7 @@ function getNodeData(node: Node): StrategyNodeData {
 }
 
 export default function StrategyPage() {
+  const t = useTranslations('strategy');
   const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
@@ -201,11 +203,11 @@ export default function StrategyPage() {
           );
         },
         onError: (error) => {
-          setErrors([error instanceof Error ? error.message : 'Execution failed']);
+          setErrors([error instanceof Error ? error.message : t('executionFailed')]);
         },
       }
     );
-  }, [nodes, edges, runStrategy, setNodes]);
+  }, [nodes, edges, runStrategy, setNodes, t]);
 
   const handleClear = useCallback(() => {
     setNodes(initialNodes);
@@ -236,16 +238,16 @@ export default function StrategyPage() {
         <div className="flex items-center gap-2">
           <Zap className="h-4 w-4 text-[#1313ec]" />
           <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
-            QuantCanvas
+            {t('title')}
           </span>
         </div>
         <span className="text-gray-300 dark:text-gray-600">|</span>
         <span className="text-sm text-gray-500 dark:text-gray-400">
-          My Strategies
+          {t('myStrategies')}
         </span>
         <span className="text-gray-300 dark:text-gray-600">/</span>
         <span className="text-sm text-gray-700 dark:text-gray-200 font-medium">
-          Untitled Strategy
+          {t('untitled')}
         </span>
 
         <div className="flex-1" />
@@ -254,12 +256,12 @@ export default function StrategyPage() {
         {errors.length > 0 && (
           <div className="text-sm text-red-500">
             {errors[0]}
-            {errors.length > 1 && ` (+${errors.length - 1} more)`}
+            {errors.length > 1 && ` (${t('moreErrors', { count: errors.length - 1 })})`}
           </div>
         )}
         {results && (
           <div className="text-sm text-emerald-600 dark:text-emerald-400 font-medium">
-            {results.length} stocks matched
+            {t('stocksMatched', { count: results.length })}
           </div>
         )}
 
@@ -269,14 +271,14 @@ export default function StrategyPage() {
           className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
         >
           <RotateCcw className="h-3.5 w-3.5" />
-          Reset
+          {t('reset')}
         </button>
         <button
           type="button"
           className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
         >
           <Save className="h-3.5 w-3.5" />
-          Save Strategy
+          {t('saveStrategy')}
         </button>
         <button
           type="button"
@@ -284,7 +286,7 @@ export default function StrategyPage() {
           className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
         >
           <TestTube className="h-3.5 w-3.5" />
-          Backtest
+          {t('backtest')}
         </button>
         <button
           type="button"
@@ -297,7 +299,7 @@ export default function StrategyPage() {
           ) : (
             <Zap className="h-4 w-4" />
           )}
-          Deploy Strategy
+          {t('deployStrategy')}
         </button>
       </div>
 
@@ -359,17 +361,17 @@ export default function StrategyPage() {
       {/* Bottom status bar */}
       <div className="flex items-center justify-between px-4 py-1.5 border-t border-[#e1e3e5] dark:border-[#2e2e30] bg-white dark:bg-[#0b0b0c] text-[11px] text-gray-400 dark:text-gray-500">
         <div className="flex items-center gap-4">
-          <span>Nodes: {nodeCount}</span>
-          <span>Filters: {conditionCount}</span>
+          <span>{t('nodes')}: {nodeCount}</span>
+          <span>{t('filters')}: {conditionCount}</span>
           {results && (
             <span className="text-emerald-600 dark:text-emerald-400 font-medium">
-              Matched: {results.length}
+              {t('matched')}: {results.length}
             </span>
           )}
         </div>
         <div className="flex items-center gap-4">
-          <span>KOSPI Data</span>
-          <span>Last run: {results ? 'Just now' : 'Never'}</span>
+          <span>{t('kospiData')}</span>
+          <span>{results ? t('lastRunJustNow') : t('lastRunNever')}</span>
         </div>
       </div>
 
@@ -378,16 +380,16 @@ export default function StrategyPage() {
         <div className="border-t border-[#e1e3e5] dark:border-[#2e2e30] bg-white dark:bg-[#0b0b0c] max-h-64 overflow-y-auto">
           <div className="px-4 py-2 border-b border-[#e1e3e5] dark:border-[#2e2e30]">
             <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
-              Results ({results.length} matched)
+              {t('results', { count: results.length })}
             </span>
           </div>
           <table className="w-full text-sm">
             <thead>
               <tr className="text-left text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider border-b border-[#e1e3e5] dark:border-[#2e2e30]">
-                <th className="px-4 py-2">Ticker</th>
-                <th className="px-4 py-2">Name</th>
-                <th className="px-4 py-2 text-right">Price</th>
-                <th className="px-4 py-2 text-center">Status</th>
+                <th className="px-4 py-2">{t('ticker')}</th>
+                <th className="px-4 py-2">{t('name')}</th>
+                <th className="px-4 py-2 text-right">{t('price')}</th>
+                <th className="px-4 py-2 text-center">{t('status')}</th>
               </tr>
             </thead>
             <tbody>

--- a/web/src/components/backtest/BacktestPanel.tsx
+++ b/web/src/components/backtest/BacktestPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import { X, Loader2, AlertCircle, TrendingUp, BarChart3 } from 'lucide-react';
+import { useTranslations } from 'next-intl';
 import { useBacktestStrategies, useRunBacktest } from '@/hooks/useBacktest';
 import type {
   BacktestStrategy,
@@ -16,12 +17,12 @@ interface BacktestPanelProps {
 }
 
 const PERIODS = [
-  { value: '1mo', label: '1 Month' },
-  { value: '3mo', label: '3 Months' },
-  { value: '6mo', label: '6 Months' },
-  { value: '1y', label: '1 Year' },
-  { value: '2y', label: '2 Years' },
-  { value: '5y', label: '5 Years' },
+  { value: '1mo', labelKey: 'period1m' },
+  { value: '3mo', labelKey: 'period3m' },
+  { value: '6mo', labelKey: 'period6m' },
+  { value: '1y', labelKey: 'period1y' },
+  { value: '2y', labelKey: 'period2y' },
+  { value: '5y', labelKey: 'period5y' },
 ];
 
 /**
@@ -29,6 +30,7 @@ const PERIODS = [
  * Uses viewBox so it scales to the container width while maintaining a fixed aspect ratio.
  */
 function EquityCurve({ points }: { points: Array<{ date: string; equity: number }> }) {
+  const t = useTranslations('backtest');
   if (!points || points.length < 2) return null;
 
   const width = 360;
@@ -69,7 +71,7 @@ function EquityCurve({ points }: { points: Array<{ date: string; equity: number 
   return (
     <div className="rounded-lg border border-[#e1e3e5] dark:border-[#2e2e30] bg-white dark:bg-[#1e1e1f] p-3">
       <div className="text-[10px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider mb-2">
-        Equity Curve
+        {t('equityCurve')}
       </div>
       <svg
         viewBox={`0 0 ${width} ${height}`}
@@ -108,11 +110,12 @@ function TradeSummary({
   maxConsecutiveWins: number;
   maxConsecutiveLosses: number;
 }) {
+  const t = useTranslations('backtest');
   return (
     <div className="grid grid-cols-2 gap-2.5">
       <div className="rounded-lg border border-[#e1e3e5] dark:border-[#2e2e30] bg-white dark:bg-[#1e1e1f] px-3 py-2">
         <div className="text-[10px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">
-          Trades
+          {t('trades')}
         </div>
         <div className="text-sm font-bold text-gray-900 dark:text-gray-100">
           {numTrades}
@@ -120,7 +123,7 @@ function TradeSummary({
       </div>
       <div className="rounded-lg border border-[#e1e3e5] dark:border-[#2e2e30] bg-white dark:bg-[#1e1e1f] px-3 py-2">
         <div className="text-[10px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">
-          Avg Return
+          {t('avgReturn')}
         </div>
         <div
           className={`text-sm font-bold ${
@@ -135,7 +138,7 @@ function TradeSummary({
       </div>
       <div className="rounded-lg border border-[#e1e3e5] dark:border-[#2e2e30] bg-white dark:bg-[#1e1e1f] px-3 py-2">
         <div className="text-[10px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">
-          Max Consec. Wins
+          {t('maxConsecWins')}
         </div>
         <div className="text-sm font-bold text-emerald-600 dark:text-emerald-400">
           {maxConsecutiveWins}
@@ -143,7 +146,7 @@ function TradeSummary({
       </div>
       <div className="rounded-lg border border-[#e1e3e5] dark:border-[#2e2e30] bg-white dark:bg-[#1e1e1f] px-3 py-2">
         <div className="text-[10px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">
-          Max Consec. Losses
+          {t('maxConsecLosses')}
         </div>
         <div className="text-sm font-bold text-red-600 dark:text-red-400">
           {maxConsecutiveLosses}
@@ -154,6 +157,7 @@ function TradeSummary({
 }
 
 export default function BacktestPanel({ isOpen, onClose }: BacktestPanelProps) {
+  const t = useTranslations('backtest');
   // --- Form state ---
   const [ticker, setTicker] = useState('');
   const [selectedStrategy, setSelectedStrategy] = useState('');
@@ -260,7 +264,7 @@ export default function BacktestPanel({ isOpen, onClose }: BacktestPanelProps) {
           <div className="flex items-center gap-2">
             <BarChart3 className="h-4 w-4 text-[#1313ec]" />
             <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
-              Backtest Strategy
+              {t('title')}
             </h2>
           </div>
           <button
@@ -279,13 +283,13 @@ export default function BacktestPanel({ isOpen, onClose }: BacktestPanelProps) {
             {/* Ticker */}
             <div>
               <label className="block text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider mb-1.5">
-                Ticker
+                {t('ticker')}
               </label>
               <input
                 type="text"
                 value={ticker}
                 onChange={(e) => setTicker(e.target.value)}
-                placeholder="e.g. AAPL or 005930.KS"
+                placeholder={t('tickerPlaceholder')}
                 className={inputCls}
               />
             </div>
@@ -293,12 +297,12 @@ export default function BacktestPanel({ isOpen, onClose }: BacktestPanelProps) {
             {/* Strategy selector */}
             <div>
               <label className="block text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider mb-1.5">
-                Strategy
+                {t('strategy')}
               </label>
               {strategiesLoading ? (
                 <div className="flex items-center gap-2 text-xs text-gray-400 py-2">
                   <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                  Loading strategies...
+                  {t('loadingStrategies')}
                 </div>
               ) : (
                 <select
@@ -323,7 +327,7 @@ export default function BacktestPanel({ isOpen, onClose }: BacktestPanelProps) {
             {/* Period */}
             <div>
               <label className="block text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider mb-1.5">
-                Period
+                {t('period')}
               </label>
               <select
                 value={period}
@@ -332,7 +336,7 @@ export default function BacktestPanel({ isOpen, onClose }: BacktestPanelProps) {
               >
                 {PERIODS.map((p) => (
                   <option key={p.value} value={p.value}>
-                    {p.label}
+                    {t(p.labelKey)}
                   </option>
                 ))}
               </select>
@@ -341,7 +345,7 @@ export default function BacktestPanel({ isOpen, onClose }: BacktestPanelProps) {
             {/* Initial Cash */}
             <div>
               <label className="block text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider mb-1.5">
-                Initial Cash
+                {t('initialCash')}
               </label>
               <input
                 type="number"
@@ -355,7 +359,7 @@ export default function BacktestPanel({ isOpen, onClose }: BacktestPanelProps) {
             {currentStrategy && currentStrategy.params.length > 0 && (
               <div className="space-y-3">
                 <div className="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">
-                  Strategy Parameters
+                  {t('strategyParams')}
                 </div>
                 {currentStrategy.params.map((param) => (
                   <div key={param.name}>
@@ -376,8 +380,8 @@ export default function BacktestPanel({ isOpen, onClose }: BacktestPanelProps) {
                         />
                         <span className="text-gray-600 dark:text-gray-300">
                           {Boolean(strategyParams[param.name] ?? param.default)
-                            ? 'Enabled'
-                            : 'Disabled'}
+                            ? t('enabled')
+                            : t('disabled')}
                         </span>
                       </label>
                     ) : param.type === 'str' ? (
@@ -434,12 +438,12 @@ export default function BacktestPanel({ isOpen, onClose }: BacktestPanelProps) {
               {runBacktest.isPending ? (
                 <>
                   <Loader2 className="h-4 w-4 animate-spin" />
-                  Running backtest...
+                  {t('running')}
                 </>
               ) : (
                 <>
                   <TrendingUp className="h-4 w-4" />
-                  Run Backtest
+                  {t('runBacktest')}
                 </>
               )}
             </button>
@@ -452,7 +456,7 @@ export default function BacktestPanel({ isOpen, onClose }: BacktestPanelProps) {
               <div className="text-sm text-red-700 dark:text-red-300">
                 {runBacktest.error instanceof Error
                   ? runBacktest.error.message
-                  : 'Backtest failed. Please check your inputs and try again.'}
+                  : t('failed')}
               </div>
             </div>
           )}
@@ -461,8 +465,8 @@ export default function BacktestPanel({ isOpen, onClose }: BacktestPanelProps) {
           {runBacktest.isPending && (
             <div className="flex flex-col items-center justify-center py-10 text-gray-400 dark:text-gray-500">
               <Loader2 className="h-8 w-8 animate-spin mb-3" />
-              <span className="text-sm">Running backtest...</span>
-              <span className="text-xs mt-1">This may take a few seconds</span>
+              <span className="text-sm">{t('running')}</span>
+              <span className="text-xs mt-1">{t('runningNote')}</span>
             </div>
           )}
 
@@ -473,7 +477,7 @@ export default function BacktestPanel({ isOpen, onClose }: BacktestPanelProps) {
               <div className="flex items-center gap-2">
                 <BarChart3 className="h-4 w-4 text-[#1313ec]" />
                 <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
-                  Results
+                  {t('results')}
                 </span>
                 <span className="text-xs text-gray-400 dark:text-gray-500">
                   {result.ticker} / {result.strategy} / {result.period}
@@ -498,7 +502,7 @@ export default function BacktestPanel({ isOpen, onClose }: BacktestPanelProps) {
               {result.trades.length > 0 && (
                 <div>
                   <div className="text-[10px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider mb-2">
-                    Individual Trades
+                    {t('individualTrades')}
                   </div>
                   <TradesTable trades={result.trades} />
                 </div>

--- a/web/src/components/backtest/MetricsCards.tsx
+++ b/web/src/components/backtest/MetricsCards.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import type { BacktestMetrics } from '@/lib/api';
+import { useTranslations } from 'next-intl';
 
 interface MetricsCardsProps {
   metrics: BacktestMetrics;
 }
 
 interface MetricCardDef {
-  label: string;
+  labelKey: string;
   key: keyof BacktestMetrics;
   format: (v: number) => string;
   colorMode: 'pnl' | 'neutral';
@@ -15,37 +16,37 @@ interface MetricCardDef {
 
 const METRIC_CARDS: MetricCardDef[] = [
   {
-    label: 'Total Return',
+    labelKey: 'totalReturn',
     key: 'total_return',
     format: (v) => `${(v * 100).toFixed(2)}%`,
     colorMode: 'pnl',
   },
   {
-    label: 'Sharpe Ratio',
+    labelKey: 'sharpeRatio',
     key: 'sharpe_ratio',
     format: (v) => v.toFixed(2),
     colorMode: 'pnl',
   },
   {
-    label: 'Max Drawdown',
+    labelKey: 'maxDrawdown',
     key: 'max_drawdown',
     format: (v) => `${(v * 100).toFixed(2)}%`,
     colorMode: 'pnl',
   },
   {
-    label: 'Win Rate',
+    labelKey: 'winRate',
     key: 'win_rate',
     format: (v) => `${(v * 100).toFixed(1)}%`,
     colorMode: 'neutral',
   },
   {
-    label: 'CAGR',
+    labelKey: 'cagr',
     key: 'cagr',
     format: (v) => `${(v * 100).toFixed(2)}%`,
     colorMode: 'pnl',
   },
   {
-    label: 'Profit Factor',
+    labelKey: 'profitFactor',
     key: 'profit_factor',
     format: (v) => v.toFixed(2),
     colorMode: 'pnl',
@@ -62,6 +63,7 @@ function getValueColor(value: number, mode: 'pnl' | 'neutral'): string {
 }
 
 export default function MetricsCards({ metrics }: MetricsCardsProps) {
+  const t = useTranslations('backtest');
   return (
     <div className="grid grid-cols-2 gap-2.5">
       {METRIC_CARDS.map((card) => {
@@ -72,7 +74,7 @@ export default function MetricsCards({ metrics }: MetricsCardsProps) {
             className="rounded-lg border border-[#e1e3e5] dark:border-[#2e2e30] bg-white dark:bg-[#1e1e1f] p-3 shadow-sm"
           >
             <div className="text-[10px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider mb-1">
-              {card.label}
+              {t(card.labelKey)}
             </div>
             <div
               className={`text-lg font-bold ${getValueColor(value, card.colorMode)}`}

--- a/web/src/components/backtest/TradesTable.tsx
+++ b/web/src/components/backtest/TradesTable.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { BacktestTrade } from '@/lib/api';
+import { useTranslations } from 'next-intl';
 
 interface TradesTableProps {
   trades: BacktestTrade[];
@@ -33,10 +34,11 @@ function formatReturn(pct: number): string {
 }
 
 export default function TradesTable({ trades }: TradesTableProps) {
-  const totalPnl = trades.reduce((sum, t) => sum + t.pnl, 0);
+  const t = useTranslations('backtest');
+  const totalPnl = trades.reduce((sum, tr) => sum + tr.pnl, 0);
   const avgReturn =
     trades.length > 0
-      ? trades.reduce((sum, t) => sum + t.return_pct, 0) / trades.length
+      ? trades.reduce((sum, tr) => sum + tr.return_pct, 0) / trades.length
       : 0;
 
   return (
@@ -45,12 +47,12 @@ export default function TradesTable({ trades }: TradesTableProps) {
         <table className="w-full text-xs">
           <thead className="sticky top-0 bg-gray-50 dark:bg-[#1e1e1f] z-10">
             <tr className="text-left text-[10px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider border-b border-[#e1e3e5] dark:border-[#2e2e30]">
-              <th className="px-3 py-2">Entry</th>
-              <th className="px-3 py-2">Exit</th>
-              <th className="px-3 py-2 text-right">Entry Price</th>
-              <th className="px-3 py-2 text-right">Exit Price</th>
-              <th className="px-3 py-2 text-right">P&L</th>
-              <th className="px-3 py-2 text-right">Return</th>
+              <th className="px-3 py-2">{t('entry')}</th>
+              <th className="px-3 py-2">{t('exit')}</th>
+              <th className="px-3 py-2 text-right">{t('entryPrice')}</th>
+              <th className="px-3 py-2 text-right">{t('exitPrice')}</th>
+              <th className="px-3 py-2 text-right">{t('pnl')}</th>
+              <th className="px-3 py-2 text-right">{t('return')}</th>
             </tr>
           </thead>
           <tbody>
@@ -99,7 +101,7 @@ export default function TradesTable({ trades }: TradesTableProps) {
                   colSpan={4}
                   className="px-3 py-2 text-[10px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider"
                 >
-                  Total ({trades.length} trades)
+                  {t('totalTrades', { count: trades.length })}
                 </td>
                 <td
                   className={`px-3 py-2 text-right font-bold ${

--- a/web/src/components/strategy/NodePalette.tsx
+++ b/web/src/components/strategy/NodePalette.tsx
@@ -11,6 +11,7 @@ import {
   GripVertical,
   Search,
 } from 'lucide-react';
+import { useTranslations } from 'next-intl';
 import {
   CATEGORIES,
   getConditionsByCategory,
@@ -18,11 +19,11 @@ import {
 import type { ConditionMeta } from '@/lib/strategy/conditionRegistry';
 
 const SPECIAL_NODES = [
-  { type: 'universe', label: 'Market Selection', icon: Globe, color: 'text-emerald-600 dark:text-emerald-400' },
-  { type: 'logic_and', label: 'AND Gate', icon: GitMerge, color: 'text-[#1313ec] dark:text-blue-400' },
-  { type: 'logic_or', label: 'OR Gate', icon: GitMerge, color: 'text-purple-600 dark:text-purple-400' },
-  { type: 'logic_not', label: 'NOT Gate', icon: GitMerge, color: 'text-red-600 dark:text-red-400' },
-  { type: 'output', label: 'Final Output', icon: Flag, color: 'text-orange-600 dark:text-orange-400' },
+  { type: 'universe', labelKey: 'marketSelection', icon: Globe, color: 'text-emerald-600 dark:text-emerald-400' },
+  { type: 'logic_and', labelKey: 'andGate', icon: GitMerge, color: 'text-[#1313ec] dark:text-blue-400' },
+  { type: 'logic_or', labelKey: 'orGate', icon: GitMerge, color: 'text-purple-600 dark:text-purple-400' },
+  { type: 'logic_not', labelKey: 'notGate', icon: GitMerge, color: 'text-red-600 dark:text-red-400' },
+  { type: 'output', labelKey: 'finalOutput', icon: Flag, color: 'text-orange-600 dark:text-orange-400' },
 ];
 
 function DraggableItem({
@@ -69,6 +70,8 @@ function DraggableItem({
 }
 
 export default function NodePalette() {
+  const t = useTranslations('strategy');
+  const tCond = useTranslations('conditions');
   const [expandedCategories, setExpandedCategories] = useState<Set<string>>(
     new Set(CATEGORIES)
   );
@@ -110,7 +113,7 @@ export default function NodePalette() {
           <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-gray-400" />
           <input
             type="text"
-            placeholder="Search components..."
+            placeholder={t('searchPlaceholder')}
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             className="w-full pl-8 pr-3 py-1.5 text-sm rounded-lg border border-[#e1e3e5] dark:border-[#2e2e30] bg-gray-50 dark:bg-[#1e1e1f] text-gray-700 dark:text-gray-200 placeholder:text-gray-400 dark:placeholder:text-gray-500 focus:outline-none focus:border-[#1313ec] focus:ring-1 focus:ring-[#1313ec]/20 transition-colors"
@@ -123,13 +126,13 @@ export default function NodePalette() {
         {!searchQuery && (
           <div className="mb-2">
             <div className="px-2 py-1.5 text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-widest">
-              Input Nodes
+              {t('inputNodes')}
             </div>
             {SPECIAL_NODES.filter((n) => n.type === 'universe').map((node) => (
               <DraggableItem
                 key={node.type}
                 type={node.type}
-                label={node.label}
+                label={t(node.labelKey)}
                 icon={node.icon}
                 color={node.color}
               />
@@ -141,7 +144,7 @@ export default function NodePalette() {
         <div className="mb-2">
           {!searchQuery && (
             <div className="px-2 py-1.5 text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-widest">
-              Filter Nodes
+              {t('filterNodes')}
             </div>
           )}
           {CATEGORIES.map((category) => {
@@ -161,7 +164,7 @@ export default function NodePalette() {
                   ) : (
                     <ChevronRight className="h-3 w-3" />
                   )}
-                  <span>{category}</span>
+                  <span>{tCond('categories.' + category)}</span>
                   <span className="ml-auto text-[10px] font-normal text-gray-400 dark:text-gray-500 bg-gray-100 dark:bg-gray-800 px-1.5 rounded-full">
                     {conditions.length}
                   </span>
@@ -171,8 +174,8 @@ export default function NodePalette() {
                     <DraggableItem
                       key={cond.key}
                       type="condition"
-                      label={cond.label}
-                      description={cond.description}
+                      label={tCond(cond.key + '.label')}
+                      description={tCond(cond.key + '.desc')}
                       icon={Filter}
                       color="text-[#1313ec] dark:text-blue-400"
                       conditionKey={cond.key}
@@ -187,7 +190,7 @@ export default function NodePalette() {
         {!searchQuery && (
           <div>
             <div className="px-2 py-1.5 text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-widest">
-              Logic Operators
+              {t('logicOperators')}
             </div>
             <div className="flex gap-2 px-2 pt-1">
               {SPECIAL_NODES.filter((n) => n.type.startsWith('logic_')).map((node) => {
@@ -213,7 +216,7 @@ export default function NodePalette() {
                 <DraggableItem
                   key={node.type}
                   type={node.type}
-                  label={node.label}
+                  label={t(node.labelKey)}
                   icon={node.icon}
                   color={node.color}
                 />

--- a/web/src/components/strategy/PropertiesPanel.tsx
+++ b/web/src/components/strategy/PropertiesPanel.tsx
@@ -2,6 +2,7 @@
 
 import type { Node } from '@xyflow/react';
 import { X, Info } from 'lucide-react';
+import { useTranslations } from 'next-intl';
 import type { StrategyNodeData } from '@/lib/strategy/graphSerializer';
 import { getConditionMeta, CONDITION_REGISTRY } from '@/lib/strategy/conditionRegistry';
 import type { ConditionParam } from '@/lib/strategy/conditionRegistry';
@@ -46,15 +47,22 @@ function ParamInput({
   param,
   value,
   onChange,
+  conditionKey,
 }: {
   param: ConditionParam;
   value: unknown;
   onChange: (name: string, value: unknown) => void;
+  conditionKey: string;
 }) {
+  const tCond = useTranslations('conditions');
+  const tCommon = useTranslations('common');
+
+  const paramLabel = tCond(conditionKey + '.params.' + param.name);
+
   if (param.type === 'bool') {
     return (
       <div>
-        <FieldLabel>{param.description}</FieldLabel>
+        <FieldLabel>{paramLabel}</FieldLabel>
         <label className="flex items-center gap-2.5 text-sm cursor-pointer">
           <input
             type="checkbox"
@@ -62,7 +70,7 @@ function ParamInput({
             onChange={(e) => onChange(param.name, e.target.checked)}
             className="rounded border-[#e1e3e5] dark:border-[#2e2e30] text-[#1313ec] focus:ring-[#1313ec]/20"
           />
-          <span className="text-gray-600 dark:text-gray-300">{Boolean(value) ? 'Enabled' : 'Disabled'}</span>
+          <span className="text-gray-600 dark:text-gray-300">{Boolean(value) ? tCommon('enabled') : tCommon('disabled')}</span>
         </label>
       </div>
     );
@@ -72,13 +80,13 @@ function ParamInput({
     if (param.name === 'direction') {
       return (
         <div>
-          <FieldLabel>{param.description}</FieldLabel>
+          <FieldLabel>{paramLabel}</FieldLabel>
           <SelectInput
             value={String(value || param.default || '')}
             onChange={(v) => onChange(param.name, v)}
           >
-            <option value="up">Up</option>
-            <option value="down">Down</option>
+            <option value="up">{tCommon('up')}</option>
+            <option value="down">{tCommon('down')}</option>
           </SelectInput>
         </div>
       );
@@ -86,20 +94,20 @@ function ParamInput({
     if (param.name === 'condition') {
       return (
         <div>
-          <FieldLabel>{param.description}</FieldLabel>
+          <FieldLabel>{paramLabel}</FieldLabel>
           <SelectInput
             value={String(value || param.default || '')}
             onChange={(v) => onChange(param.name, v)}
           >
-            <option value="below">Below</option>
-            <option value="above">Above</option>
+            <option value="below">{tCommon('below')}</option>
+            <option value="above">{tCommon('above')}</option>
           </SelectInput>
         </div>
       );
     }
     return (
       <div>
-        <FieldLabel>{param.description}</FieldLabel>
+        <FieldLabel>{paramLabel}</FieldLabel>
         <input
           type="text"
           value={String(value ?? '')}
@@ -113,7 +121,7 @@ function ParamInput({
   // int or float
   return (
     <div>
-      <FieldLabel>{param.description}</FieldLabel>
+      <FieldLabel>{paramLabel}</FieldLabel>
       <input
         type="number"
         step={param.type === 'float' ? '0.01' : '1'}
@@ -140,6 +148,9 @@ export default function PropertiesPanel({
   onUpdate,
   onClose,
 }: PropertiesPanelProps) {
+  const t = useTranslations('strategy');
+  const tCond = useTranslations('conditions');
+
   if (!node) return null;
 
   const nodeData = node.data;
@@ -154,7 +165,7 @@ export default function PropertiesPanel({
     <div className="w-80 h-full border-l border-[#e1e3e5] dark:border-[#2e2e30] bg-white dark:bg-[#0b0b0c] flex flex-col overflow-hidden">
       <div className="px-4 py-3 border-b border-[#e1e3e5] dark:border-[#2e2e30] flex items-center justify-between">
         <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
-          Node Properties
+          {t('nodeProperties')}
         </h3>
         <button
           type="button"
@@ -170,13 +181,13 @@ export default function PropertiesPanel({
         {nodeData.node_type === 'universe' && (
           <>
             <div>
-              <FieldLabel>Display Name</FieldLabel>
+              <FieldLabel>{t('displayName')}</FieldLabel>
               <div className="text-sm font-medium text-gray-700 dark:text-gray-200 bg-gray-50 dark:bg-[#1e1e1f] px-3 py-2 rounded-lg border border-[#e1e3e5] dark:border-[#2e2e30]">
-                Market Selection
+                {t('marketSelection')}
               </div>
             </div>
             <div>
-              <FieldLabel>Stock Universe</FieldLabel>
+              <FieldLabel>{t('stockUniverse')}</FieldLabel>
               <SelectInput
                 value={nodeData.universe || 'KOSPI'}
                 onChange={(v) => onUpdate(node.id, { universe: v })}
@@ -195,15 +206,15 @@ export default function PropertiesPanel({
         {nodeData.node_type === 'condition' && (
           <>
             <div>
-              <FieldLabel>Display Name</FieldLabel>
+              <FieldLabel>{t('displayName')}</FieldLabel>
               <div className="text-sm font-medium text-gray-700 dark:text-gray-200 bg-gray-50 dark:bg-[#1e1e1f] px-3 py-2 rounded-lg border border-[#e1e3e5] dark:border-[#2e2e30]">
                 {nodeData.condition_type
-                  ? getConditionMeta(nodeData.condition_type)?.label || 'Condition'
-                  : 'Condition'}
+                  ? tCond(nodeData.condition_type + '.label')
+                  : t('condition')}
               </div>
             </div>
             <div>
-              <FieldLabel>Condition Logic</FieldLabel>
+              <FieldLabel>{t('conditionLogic')}</FieldLabel>
               <SelectInput
                 value={nodeData.condition_type || ''}
                 onChange={(key) => {
@@ -221,10 +232,10 @@ export default function PropertiesPanel({
                   });
                 }}
               >
-                <option value="">Select condition...</option>
+                <option value="">{t('selectCondition')}</option>
                 {CONDITION_REGISTRY.map((c) => (
                   <option key={c.key} value={c.key}>
-                    {c.label}
+                    {tCond(c.key + '.label')}
                   </option>
                 ))}
               </SelectInput>
@@ -242,6 +253,7 @@ export default function PropertiesPanel({
                         param={param}
                         value={nodeData.params?.[param.name] ?? param.default}
                         onChange={handleParamChange}
+                        conditionKey={meta.key}
                       />
                     ))}
                   </div>
@@ -251,11 +263,11 @@ export default function PropertiesPanel({
                     <div className="flex items-center gap-1.5 mb-1.5">
                       <Info className="h-3.5 w-3.5 text-[#1313ec] dark:text-blue-400" />
                       <span className="text-xs font-semibold text-[#1313ec] dark:text-blue-400 uppercase">
-                        Quick Insight
+                        {t('quickInsight')}
                       </span>
                     </div>
                     <p className="text-xs text-gray-600 dark:text-gray-300 leading-relaxed">
-                      {meta.description}
+                      {tCond(meta.key + '.desc')}
                     </p>
                   </div>
                 </>
@@ -267,14 +279,14 @@ export default function PropertiesPanel({
         {/* Logic node */}
         {nodeData.node_type === 'logic' && (
           <div>
-            <FieldLabel>Logic Operator</FieldLabel>
+            <FieldLabel>{t('logicOperator')}</FieldLabel>
             <SelectInput
               value={nodeData.logic_operator || 'and'}
               onChange={(v) => onUpdate(node.id, { logic_operator: v })}
             >
-              <option value="and">AND (all must match)</option>
-              <option value="or">OR (any must match)</option>
-              <option value="not">NOT (invert first input)</option>
+              <option value="and">{t('andAllMustMatch')}</option>
+              <option value="or">{t('orAnyMustMatch')}</option>
+              <option value="not">{t('notInvertFirst')}</option>
             </SelectInput>
           </div>
         )}
@@ -282,7 +294,7 @@ export default function PropertiesPanel({
         {/* Output node */}
         {nodeData.node_type === 'output' && (
           <div className="text-sm text-gray-500 dark:text-gray-400 leading-relaxed">
-            Connect condition nodes to this output, then click &quot;Deploy Strategy&quot; to execute the screening.
+            {t('outputInstruction')}
           </div>
         )}
       </div>
@@ -294,14 +306,14 @@ export default function PropertiesPanel({
           onClick={onClose}
           className="px-3 py-1.5 text-xs font-medium text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
         >
-          Remove Node
+          {t('removeNode')}
         </button>
         <button
           type="button"
           onClick={onClose}
           className="px-4 py-1.5 text-xs font-medium rounded-lg bg-[#1313ec] text-white hover:bg-[#1010c0] transition-colors"
         >
-          Apply Changes
+          {t('applyChanges')}
         </button>
       </div>
     </div>

--- a/web/src/components/strategy/nodes/ConditionNode.tsx
+++ b/web/src/components/strategy/nodes/ConditionNode.tsx
@@ -4,16 +4,18 @@ import { memo } from 'react';
 import { Handle, Position } from '@xyflow/react';
 import type { NodeProps } from '@xyflow/react';
 import { Filter } from 'lucide-react';
+import { useTranslations } from 'next-intl';
 import type { StrategyNodeData } from '@/lib/strategy/graphSerializer';
 import { getConditionMeta } from '@/lib/strategy/conditionRegistry';
 
 function ConditionNode({ data, selected }: NodeProps) {
+  const t = useTranslations('strategy');
   const nodeData = data as unknown as StrategyNodeData;
   const meta = nodeData.condition_type
     ? getConditionMeta(nodeData.condition_type)
     : null;
 
-  const label = meta?.label || nodeData.label || 'Condition';
+  const label = meta?.label || nodeData.label || t('condition');
 
   // Show key params as summary
   const paramSummary = nodeData.params
@@ -40,7 +42,7 @@ function ConditionNode({ data, selected }: NodeProps) {
       <div className="flex items-center gap-2 mb-2">
         <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-blue-50 dark:bg-blue-500/10 text-[#1313ec] dark:text-blue-400 text-[10px] font-semibold uppercase tracking-wider">
           <Filter className="h-3 w-3" />
-          Screening
+          {t('screeningBadge')}
         </span>
       </div>
       <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">

--- a/web/src/components/strategy/nodes/OutputNode.tsx
+++ b/web/src/components/strategy/nodes/OutputNode.tsx
@@ -4,9 +4,11 @@ import { memo } from 'react';
 import { Handle, Position } from '@xyflow/react';
 import type { NodeProps } from '@xyflow/react';
 import { Flag } from 'lucide-react';
+import { useTranslations } from 'next-intl';
 import type { StrategyNodeData } from '@/lib/strategy/graphSerializer';
 
 function OutputNode({ data, selected }: NodeProps) {
+  const t = useTranslations('strategy');
   const nodeData = data as unknown as StrategyNodeData;
   const resultCount = nodeData.resultCount;
 
@@ -26,19 +28,19 @@ function OutputNode({ data, selected }: NodeProps) {
       <div className="flex items-center justify-center gap-2 mb-1">
         <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-orange-50 dark:bg-orange-500/10 text-orange-600 dark:text-orange-400 text-[10px] font-semibold uppercase tracking-wider">
           <Flag className="h-3 w-3" />
-          Output
+          {t('outputBadge')}
         </span>
       </div>
       <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">
-        Final Selection
+        {t('finalSelection')}
       </div>
       {resultCount !== undefined && resultCount !== null ? (
         <div className="mt-1.5 text-xs text-gray-500 dark:text-gray-400">
-          <span className="font-semibold text-emerald-600 dark:text-emerald-400">{resultCount}</span> estimated items
+          {t('estimatedItems', { count: resultCount })}
         </div>
       ) : (
         <div className="mt-1 text-xs text-gray-400 dark:text-gray-500">
-          Connect nodes and run
+          {t('connectAndRun')}
         </div>
       )}
     </div>

--- a/web/src/components/strategy/nodes/UniverseNode.tsx
+++ b/web/src/components/strategy/nodes/UniverseNode.tsx
@@ -4,9 +4,11 @@ import { memo } from 'react';
 import { Handle, Position } from '@xyflow/react';
 import type { NodeProps } from '@xyflow/react';
 import { Globe } from 'lucide-react';
+import { useTranslations } from 'next-intl';
 import type { StrategyNodeData } from '@/lib/strategy/graphSerializer';
 
 function UniverseNode({ data, selected }: NodeProps) {
+  const t = useTranslations('strategy');
   const nodeData = data as unknown as StrategyNodeData;
 
   return (
@@ -20,14 +22,14 @@ function UniverseNode({ data, selected }: NodeProps) {
       <div className="flex items-center gap-2 mb-2">
         <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-emerald-50 dark:bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 text-[10px] font-semibold uppercase tracking-wider">
           <Globe className="h-3 w-3" />
-          Input
+          {t('inputBadge')}
         </span>
       </div>
       <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">
-        Market Selection
+        {t('marketSelection')}
       </div>
       <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-        {nodeData.universe || 'KOSPI'} Composite
+        {t('composite', { universe: nodeData.universe || 'KOSPI' })}
       </div>
       <Handle
         type="source"

--- a/web/src/lib/strategy/conditionRegistry.ts
+++ b/web/src/lib/strategy/conditionRegistry.ts
@@ -14,12 +14,12 @@ export interface ConditionMeta {
 }
 
 export const CATEGORIES = [
-  'Price',
-  'Volume',
-  'Moving Average',
-  'RSI',
-  'Accumulation',
-  'Breakout',
+  'price',
+  'volume',
+  'movingAverage',
+  'rsi',
+  'accumulation',
+  'breakout',
 ] as const;
 
 export type Category = (typeof CATEGORIES)[number];
@@ -30,21 +30,21 @@ export const CONDITION_REGISTRY: ConditionMeta[] = [
     key: 'min_price',
     label: 'Min Price',
     description: 'Stock price >= threshold',
-    category: 'Price',
+    category: 'price',
     params: [{ name: 'min_price', type: 'float', default: 5000, description: 'Minimum price' }],
   },
   {
     key: 'max_price',
     label: 'Max Price',
     description: 'Stock price <= threshold',
-    category: 'Price',
+    category: 'price',
     params: [{ name: 'max_price', type: 'float', default: 100000, description: 'Maximum price' }],
   },
   {
     key: 'price_range',
     label: 'Price Range',
     description: 'Stock price within range',
-    category: 'Price',
+    category: 'price',
     params: [
       { name: 'min_price', type: 'float', default: 0, description: 'Min price' },
       { name: 'max_price', type: 'float', default: 999999, description: 'Max price' },
@@ -54,7 +54,7 @@ export const CONDITION_REGISTRY: ConditionMeta[] = [
     key: 'price_change',
     label: 'Price Change %',
     description: 'Price change over N days',
-    category: 'Price',
+    category: 'price',
     params: [
       { name: 'min_change_pct', type: 'float', default: null, description: 'Min change %' },
       { name: 'max_change_pct', type: 'float', default: null, description: 'Max change %' },
@@ -66,14 +66,14 @@ export const CONDITION_REGISTRY: ConditionMeta[] = [
     key: 'min_volume',
     label: 'Min Volume',
     description: 'Volume >= threshold',
-    category: 'Volume',
+    category: 'volume',
     params: [{ name: 'min_volume', type: 'int', default: 100000, description: 'Minimum volume' }],
   },
   {
     key: 'volume_above_avg',
     label: 'Volume Above Avg',
     description: 'Volume above moving average',
-    category: 'Volume',
+    category: 'volume',
     params: [
       { name: 'multiplier', type: 'float', default: 1.5, description: 'Avg multiplier' },
       { name: 'period', type: 'int', default: 20, description: 'Average period' },
@@ -83,7 +83,7 @@ export const CONDITION_REGISTRY: ConditionMeta[] = [
     key: 'volume_spike',
     label: 'Volume Spike',
     description: 'Sudden volume increase',
-    category: 'Volume',
+    category: 'volume',
     params: [
       { name: 'multiplier', type: 'float', default: 2.0, description: 'Spike multiplier' },
       { name: 'period', type: 'int', default: 20, description: 'Average period' },
@@ -94,7 +94,7 @@ export const CONDITION_REGISTRY: ConditionMeta[] = [
     key: 'ma_touch',
     label: 'MA Touch',
     description: 'Price near moving average',
-    category: 'Moving Average',
+    category: 'movingAverage',
     params: [
       { name: 'period', type: 'int', default: 20, description: 'MA period' },
       { name: 'threshold', type: 'float', default: 0.02, description: 'Touch threshold (ratio)' },
@@ -104,7 +104,7 @@ export const CONDITION_REGISTRY: ConditionMeta[] = [
     key: 'above_ma',
     label: 'Above MA',
     description: 'Price above moving average',
-    category: 'Moving Average',
+    category: 'movingAverage',
     params: [
       { name: 'period', type: 'int', default: 20, description: 'MA period' },
       { name: 'min_distance_pct', type: 'float', default: 0, description: 'Min distance %' },
@@ -114,7 +114,7 @@ export const CONDITION_REGISTRY: ConditionMeta[] = [
     key: 'below_ma',
     label: 'Below MA',
     description: 'Price below moving average',
-    category: 'Moving Average',
+    category: 'movingAverage',
     params: [
       { name: 'period', type: 'int', default: 20, description: 'MA period' },
       { name: 'max_distance_pct', type: 'float', default: 0, description: 'Max distance %' },
@@ -124,7 +124,7 @@ export const CONDITION_REGISTRY: ConditionMeta[] = [
     key: 'ma_cross_up',
     label: 'MA Cross Up',
     description: 'Golden cross',
-    category: 'Moving Average',
+    category: 'movingAverage',
     params: [
       { name: 'short_period', type: 'int', default: 20, description: 'Short MA period' },
       { name: 'long_period', type: 'int', default: 60, description: 'Long MA period' },
@@ -135,7 +135,7 @@ export const CONDITION_REGISTRY: ConditionMeta[] = [
     key: 'ma_cross_down',
     label: 'MA Cross Down',
     description: 'Death cross',
-    category: 'Moving Average',
+    category: 'movingAverage',
     params: [
       { name: 'short_period', type: 'int', default: 20, description: 'Short MA period' },
       { name: 'long_period', type: 'int', default: 60, description: 'Long MA period' },
@@ -147,7 +147,7 @@ export const CONDITION_REGISTRY: ConditionMeta[] = [
     key: 'rsi_oversold',
     label: 'RSI Oversold',
     description: 'RSI below threshold',
-    category: 'RSI',
+    category: 'rsi',
     params: [
       { name: 'threshold', type: 'float', default: 30, description: 'RSI threshold' },
       { name: 'period', type: 'int', default: 14, description: 'RSI period' },
@@ -157,7 +157,7 @@ export const CONDITION_REGISTRY: ConditionMeta[] = [
     key: 'rsi_overbought',
     label: 'RSI Overbought',
     description: 'RSI above threshold',
-    category: 'RSI',
+    category: 'rsi',
     params: [
       { name: 'threshold', type: 'float', default: 70, description: 'RSI threshold' },
       { name: 'period', type: 'int', default: 14, description: 'RSI period' },
@@ -167,7 +167,7 @@ export const CONDITION_REGISTRY: ConditionMeta[] = [
     key: 'rsi_range',
     label: 'RSI Range',
     description: 'RSI within range',
-    category: 'RSI',
+    category: 'rsi',
     params: [
       { name: 'lower', type: 'float', default: 30, description: 'Lower bound' },
       { name: 'upper', type: 'float', default: 70, description: 'Upper bound' },
@@ -179,7 +179,7 @@ export const CONDITION_REGISTRY: ConditionMeta[] = [
     key: 'bollinger_width',
     label: 'Bollinger Width',
     description: 'BB width contraction',
-    category: 'Accumulation',
+    category: 'accumulation',
     params: [
       { name: 'max_width_pct', type: 'float', default: 10.0, description: 'Max BB width %' },
       { name: 'period', type: 'int', default: 20, description: 'BB period' },
@@ -190,7 +190,7 @@ export const CONDITION_REGISTRY: ConditionMeta[] = [
     key: 'volume_below_avg',
     label: 'Volume Below Avg',
     description: 'Quiet volume zone',
-    category: 'Accumulation',
+    category: 'accumulation',
     params: [
       { name: 'multiplier', type: 'float', default: 0.8, description: 'Max ratio to avg' },
       { name: 'period', type: 'int', default: 20, description: 'Average period' },
@@ -200,7 +200,7 @@ export const CONDITION_REGISTRY: ConditionMeta[] = [
     key: 'price_flat',
     label: 'Price Flat',
     description: 'Price consolidation',
-    category: 'Accumulation',
+    category: 'accumulation',
     params: [
       { name: 'max_range_pct', type: 'float', default: 5.0, description: 'Max range %' },
       { name: 'period', type: 'int', default: 20, description: 'Period' },
@@ -210,7 +210,7 @@ export const CONDITION_REGISTRY: ConditionMeta[] = [
     key: 'obv_trend',
     label: 'OBV Trend',
     description: 'On-Balance Volume trend',
-    category: 'Accumulation',
+    category: 'accumulation',
     params: [
       { name: 'direction', type: 'str', default: 'up', description: 'Trend direction (up/down)' },
       { name: 'lookback', type: 'int', default: 20, description: 'Lookback period' },
@@ -220,7 +220,7 @@ export const CONDITION_REGISTRY: ConditionMeta[] = [
     key: 'stochastic_level',
     label: 'Stochastic Level',
     description: 'Stochastic oscillator level',
-    category: 'Accumulation',
+    category: 'accumulation',
     params: [
       { name: 'threshold', type: 'float', default: 20.0, description: 'Level threshold' },
       { name: 'condition', type: 'str', default: 'below', description: 'below or above' },
@@ -232,7 +232,7 @@ export const CONDITION_REGISTRY: ConditionMeta[] = [
     key: 'vpci_trend',
     label: 'VPCI Trend',
     description: 'VPCI trend direction',
-    category: 'Accumulation',
+    category: 'accumulation',
     params: [
       { name: 'direction', type: 'str', default: 'up', description: 'Trend direction (up/down)' },
       { name: 'short_period', type: 'int', default: 5, description: 'Short period' },
@@ -244,7 +244,7 @@ export const CONDITION_REGISTRY: ConditionMeta[] = [
     key: 'obv_divergence',
     label: 'OBV Divergence',
     description: 'Price flat + OBV rising',
-    category: 'Accumulation',
+    category: 'accumulation',
     params: [
       { name: 'price_max_range_pct', type: 'float', default: 5.0, description: 'Price range %' },
       { name: 'obv_min_change_pct', type: 'float', default: 5.0, description: 'OBV change %' },
@@ -255,7 +255,7 @@ export const CONDITION_REGISTRY: ConditionMeta[] = [
     key: 'stochastic_divergence',
     label: 'Stochastic Divergence',
     description: 'Bullish stochastic divergence',
-    category: 'Accumulation',
+    category: 'accumulation',
     params: [
       { name: 'k_period', type: 'int', default: 14, description: '%K period' },
       { name: 'd_period', type: 'int', default: 3, description: '%D period' },
@@ -267,7 +267,7 @@ export const CONDITION_REGISTRY: ConditionMeta[] = [
     key: 'vpci_divergence',
     label: 'VPCI Divergence',
     description: 'Price flat + VPCI rising',
-    category: 'Accumulation',
+    category: 'accumulation',
     params: [
       { name: 'price_max_range_pct', type: 'float', default: 5.0, description: 'Price range %' },
       { name: 'short_period', type: 'int', default: 5, description: 'Short period' },
@@ -280,7 +280,7 @@ export const CONDITION_REGISTRY: ConditionMeta[] = [
     key: 'bottom_breakout',
     label: 'Bottom Breakout',
     description: 'N-day low breakout',
-    category: 'Breakout',
+    category: 'breakout',
     params: [
       { name: 'lookback_days', type: 'int', default: 20, description: 'Lookback days' },
       { name: 'breakout_pct', type: 'float', default: 5.0, description: 'Breakout %' },
@@ -290,7 +290,7 @@ export const CONDITION_REGISTRY: ConditionMeta[] = [
     key: 'fresh_breakout',
     label: 'Fresh Breakout',
     description: 'First-time breakout',
-    category: 'Breakout',
+    category: 'breakout',
     params: [
       { name: 'lookback_days', type: 'int', default: 20, description: 'Lookback days' },
       { name: 'breakout_pct', type: 'float', default: 5.0, description: 'Breakout %' },
@@ -300,7 +300,7 @@ export const CONDITION_REGISTRY: ConditionMeta[] = [
     key: 'breakout_with_volume',
     label: 'Breakout + Volume',
     description: 'Breakout with volume confirmation',
-    category: 'Breakout',
+    category: 'breakout',
     params: [
       { name: 'lookback_days', type: 'int', default: 20, description: 'Lookback days' },
       { name: 'breakout_pct', type: 'float', default: 5.0, description: 'Breakout %' },
@@ -313,7 +313,7 @@ export const CONDITION_REGISTRY: ConditionMeta[] = [
     key: 'resistance_breakout',
     label: 'Resistance Breakout',
     description: 'Resistance level breakout',
-    category: 'Breakout',
+    category: 'breakout',
     params: [
       { name: 'lookback_days', type: 'int', default: 20, description: 'Lookback days' },
       { name: 'breakout_margin_pct', type: 'float', default: 0.0, description: 'Margin above resistance %' },


### PR DESCRIPTION
## Summary
- Apply next-intl translations to all strategy builder components (NodePalette, PropertiesPanel, Universe/Condition/Output nodes)
- Apply i18n to backtest components (BacktestPanel, MetricsCards, TradesTable)
- Normalize conditionRegistry categories from display names to camelCase keys for translation lookup
- Add ~200 translation keys for EN/KO covering 26 screening conditions, strategy UI, and backtest metrics

## Changes
| Area | Files | Details |
|------|-------|---------|
| Messages | `en.json`, `ko.json` | +217 lines each (strategy, backtest, conditions sections) |
| Strategy | `page.tsx`, `NodePalette`, `PropertiesPanel` | `useTranslations()` with `tCond` for conditions |
| Nodes | `UniverseNode`, `ConditionNode`, `OutputNode` | Badge labels, descriptions translated |
| Backtest | `BacktestPanel`, `MetricsCards`, `TradesTable` | Period labels, metric names, trade columns |
| Registry | `conditionRegistry.ts` | Categories normalized to camelCase keys |

## Test plan
- [x] `npm run build` passes without errors
- [ ] Verify EN strategy page renders correctly at `/en/strategy`
- [ ] Verify KO strategy page renders correctly at `/ko/strategy`
- [ ] Verify backtest panel labels switch between EN/KO
- [ ] Verify condition names and params display correctly in both languages

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)