### PR TITLE
Fix conditions not dropping into group nodes

### DIFF
--- a/web/src/app/[locale]/strategy/page.tsx
+++ b/web/src/app/[locale]/strategy/page.tsx
@@ -146,12 +146,11 @@ export default function StrategyPage() {
       const type = event.dataTransfer.getData('application/reactflow-type');
       const conditionKey = event.dataTransfer.getData('application/reactflow-condition');
 
-      if (!type || !reactFlowInstance || !reactFlowWrapper.current) return;
+      if (!type || !reactFlowInstance) return;
 
-      const bounds = reactFlowWrapper.current.getBoundingClientRect();
       const position = reactFlowInstance.screenToFlowPosition({
-        x: event.clientX - bounds.left,
-        y: event.clientY - bounds.top,
+        x: event.clientX,
+        y: event.clientY,
       });
 
       let data: StrategyNodeData;


### PR DESCRIPTION
## Summary
- Fix `screenToFlowPosition` double-offset bug that prevented conditions from being dropped into AND/OR/NOT group nodes
- Remove incorrect `bounds` subtraction — xyflow v12's `screenToFlowPosition` already handles container offset internally

## Root Cause
The `onDrop` handler subtracted `reactFlowWrapper.getBoundingClientRect()` before passing coordinates to `screenToFlowPosition`, causing the calculated flow position to be shifted. This made `findGroupAtPosition()` fail to detect the target group under the cursor.

## Test plan
- [ ] Drag an AND group onto the canvas
- [ ] Drag a condition (e.g., Min Price) into the AND group — should appear as a child
- [ ] Drag a condition onto empty canvas — should appear as standalone node
- [ ] Drag a condition out of a group — should detach from group

Fixes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)