### PR TITLE
Add invalid drop alerts and nested group support

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -195,7 +195,8 @@
     "notGroup": "NOT Group",
     "dropConditionHere": "Drop conditions here",
     "emptyGroup": "Drag conditions into this group",
-    "groupInstruction": "Drag condition nodes into this group container, then connect the group to Output.",
+    "cannotDropInGroup": "Universe and Output nodes cannot be placed inside a group.",
+    "groupInstruction": "Drag condition or logic group nodes into this group container, then connect the group to Output.",
     "finalOutput": "Final Output",
 
     "nodeProperties": "Node Properties",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -195,7 +195,8 @@
     "notGroup": "NOT 그룹",
     "dropConditionHere": "조건을 여기에 드롭하세요",
     "emptyGroup": "조건을 이 그룹에 드래그하세요",
-    "groupInstruction": "조건 노드를 이 그룹 컨테이너에 드래그한 후, 그룹을 출력에 연결하세요.",
+    "cannotDropInGroup": "유니버스와 출력 노드는 그룹 안에 넣을 수 없습니다.",
+    "groupInstruction": "조건 또는 논리 그룹 노드를 이 그룹 컨테이너에 드래그한 후, 그룹을 출력에 연결하세요.",
     "finalOutput": "최종 출력",
 
     "nodeProperties": "노드 속성",

--- a/web/src/app/[locale]/strategy/page.tsx
+++ b/web/src/app/[locale]/strategy/page.tsx
@@ -29,6 +29,7 @@ import OutputNode from '@/components/strategy/nodes/OutputNode';
 import NodePalette from '@/components/strategy/NodePalette';
 import PropertiesPanel from '@/components/strategy/PropertiesPanel';
 import BacktestPanel from '@/components/backtest/BacktestPanel';
+import { Toast, useToast } from '@/components/ui/Toast';
 import type { StrategyNodeData } from '@/lib/strategy/graphSerializer';
 import { serializeGraph } from '@/lib/strategy/graphSerializer';
 import { validateGraph } from '@/lib/strategy/graphValidator';
@@ -89,6 +90,7 @@ export default function StrategyPage() {
   const [reactFlowInstance, setReactFlowInstance] = useState<ReactFlowInstance | null>(null);
 
   const runStrategy = useRunStrategy();
+  const { toast, showToast, hideToast } = useToast();
 
   const onConnect = useCallback(
     (connection: Connection) => {
@@ -180,18 +182,28 @@ export default function StrategyPage() {
 
       const newNodeId = getNodeId();
 
-      // If dropping a condition, check if it lands inside a group
-      if (nodeType === 'conditionNode') {
-        const targetGroup = findGroupAtPosition(position);
-        if (targetGroup) {
-          // Count existing children in this group
+      // Check if dropping inside a group
+      const targetGroup = findGroupAtPosition(position);
+      if (targetGroup) {
+        // Block invalid drops: universe and output cannot go in groups
+        if (nodeType === 'universeNode' || nodeType === 'outputNode') {
+          showToast(t('cannotDropInGroup'), 'warning');
+          // Still place on canvas as standalone (fall through)
+        } else if (nodeType === 'conditionNode' || nodeType === 'groupNode') {
+          // Valid drop: condition or nested group into a group
           const childrenInGroup = nodes.filter(
             (n) => n.parentId === targetGroup.id
           );
           const childIndex = childrenInGroup.length;
+          const childHeight = nodeType === 'groupNode' ? GROUP_MIN_HEIGHT : CHILD_HEIGHT;
           const relativePosition = {
             x: GROUP_PADDING_X,
-            y: GROUP_PADDING_TOP + childIndex * (CHILD_HEIGHT + CHILD_SPACING),
+            y: GROUP_PADDING_TOP + childrenInGroup.reduce((acc, child) => {
+              const h = child.type === 'groupNode'
+                ? ((child.style?.height as number) || GROUP_MIN_HEIGHT)
+                : CHILD_HEIGHT;
+              return acc + h + CHILD_SPACING;
+            }, 0),
           };
 
           const newNode: Node = {
@@ -201,6 +213,9 @@ export default function StrategyPage() {
             parentId: targetGroup.id,
             extent: 'parent' as const,
             data: data as unknown as Record<string, unknown>,
+            ...(nodeType === 'groupNode'
+              ? { style: { width: GROUP_MIN_WIDTH - GROUP_PADDING_X * 2, height: GROUP_MIN_HEIGHT } }
+              : {}),
           };
 
           setNodes((nds) => [...nds, newNode]);
@@ -208,7 +223,7 @@ export default function StrategyPage() {
         }
       }
 
-      // Normal drop (not inside a group)
+      // Normal drop (not inside a group, or invalid type for group)
       const newNode: Node = {
         id: newNodeId,
         type: nodeType,
@@ -223,25 +238,32 @@ export default function StrategyPage() {
 
       setNodes((nds) => [...nds, newNode]);
     },
-    [reactFlowInstance, setNodes, findGroupAtPosition, nodes]
+    [reactFlowInstance, setNodes, findGroupAtPosition, nodes, showToast, t]
   );
 
-  // Auto-resize group nodes when children change
+  // Auto-resize group nodes when children change (supports nested groups)
   useEffect(() => {
     setNodes((nds) => {
-      const groupNodes = nds.filter((n) => n.type === 'groupNode');
       let changed = false;
       const updatedNodes = nds.map((n) => {
         if (n.type !== 'groupNode') return n;
         const children = nds.filter((c) => c.parentId === n.id);
-        const childCount = children.length;
+        // Calculate total height based on actual child sizes
+        const totalChildrenHeight = children.reduce((acc, child) => {
+          const h = child.type === 'groupNode'
+            ? ((child.style?.height as number) || GROUP_MIN_HEIGHT)
+            : CHILD_HEIGHT;
+          return acc + h + CHILD_SPACING;
+        }, 0);
         const neededHeight = Math.max(
           GROUP_MIN_HEIGHT,
-          GROUP_PADDING_TOP +
-            childCount * (CHILD_HEIGHT + CHILD_SPACING) +
-            GROUP_PADDING_BOTTOM
+          GROUP_PADDING_TOP + totalChildrenHeight + GROUP_PADDING_BOTTOM
         );
-        const neededWidth = GROUP_MIN_WIDTH;
+        // Nested groups are narrower; top-level groups use full width
+        const isNested = !!n.parentId;
+        const neededWidth = isNested
+          ? GROUP_MIN_WIDTH - GROUP_PADDING_X * 2
+          : GROUP_MIN_WIDTH;
         const currentWidth = (n.style?.width as number) || GROUP_MIN_WIDTH;
         const currentHeight = (n.style?.height as number) || GROUP_MIN_HEIGHT;
         if (
@@ -258,7 +280,7 @@ export default function StrategyPage() {
       });
       return changed ? updatedNodes : nds;
     });
-  }, [nodes.length, setNodes]);
+  }, [nodes, setNodes]);
 
   // Handle removing condition from group when dragged outside
   const handleNodesChange = useCallback(
@@ -574,6 +596,15 @@ export default function StrategyPage() {
         isOpen={showBacktest}
         onClose={() => setShowBacktest(false)}
       />
+
+      {/* Toast notifications */}
+      {toast && (
+        <Toast
+          message={toast.message}
+          type={toast.type as 'error' | 'warning' | 'info'}
+          onClose={hideToast}
+        />
+      )}
     </div>
   );
 }

--- a/web/src/components/ui/Toast.tsx
+++ b/web/src/components/ui/Toast.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { X } from 'lucide-react';
+
+export type ToastType = 'error' | 'warning' | 'info';
+
+interface ToastProps {
+  message: string;
+  type: ToastType;
+  onClose: () => void;
+}
+
+const toastStyles: Record<ToastType, string> = {
+  error: 'bg-red-500',
+  warning: 'bg-amber-500',
+  info: 'bg-[#1313ec]',
+};
+
+export function Toast({ message, type, onClose }: ToastProps) {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const enterTimer = window.setTimeout(() => setIsVisible(true), 10);
+    const dismissTimer = window.setTimeout(onClose, 3000);
+
+    return () => {
+      window.clearTimeout(enterTimer);
+      window.clearTimeout(dismissTimer);
+    };
+  }, [onClose]);
+
+  return (
+    <div className="fixed bottom-6 left-1/2 z-50 -translate-x-1/2">
+      <div
+        className={`${toastStyles[type]} flex min-w-[280px] items-center gap-3 rounded-lg px-4 py-3 text-white shadow-lg transition-all duration-300 ease-out ${
+          isVisible ? 'translate-y-0 opacity-100' : 'translate-y-4 opacity-0'
+        }`}
+        role="status"
+        aria-live="polite"
+      >
+        <span className="flex-1 text-sm">{message}</span>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close toast"
+          className="rounded p-1 text-white/90 transition hover:bg-white/20 hover:text-white"
+        >
+          <X size={16} />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+interface ToastState {
+  message: string;
+  type: string;
+}
+
+export function useToast() {
+  const [toast, setToast] = useState<ToastState | null>(null);
+
+  const showToast = useCallback((message: string, type: ToastType) => {
+    setToast({ message, type });
+  }, []);
+
+  const hideToast = useCallback(() => {
+    setToast(null);
+  }, []);
+
+  return { toast, showToast, hideToast };
+}

--- a/web/src/lib/strategy/graphSerializer.ts
+++ b/web/src/lib/strategy/graphSerializer.ts
@@ -113,10 +113,10 @@ export function deserializeGraph(
 
     // Set group node dimensions
     if (nodeType === 'groupNode') {
-      const childCount = n.data.child_node_ids?.length || 0;
+      const isNested = !!childToParent[n.id];
       base.style = {
-        width: 280,
-        height: Math.max(200, 40 + childCount * 88 + 20),
+        width: isNested ? 280 - 32 : 280,
+        height: 200,
       };
     }
 

--- a/web/src/lib/strategy/graphValidator.ts
+++ b/web/src/lib/strategy/graphValidator.ts
@@ -57,7 +57,7 @@ export function validateGraph(
   // Group node validation
   for (const node of nodes) {
     if (node.data.node_type === 'logic') {
-      // Count children (nodes with parentId pointing to this group)
+      // Count children (conditions or nested groups with parentId pointing to this group)
       const children = nodes.filter((n) => n.parentId === node.id);
       const hasChildNodeIds = children.length > 0;
       // Also check edge-based children (backward compatibility)
@@ -81,6 +81,36 @@ export function validateGraph(
         );
       }
     }
+  }
+
+  // Check maximum group nesting depth (max 3 levels)
+  const nodeById = new Map(nodes.map((n) => [n.id, n] as const));
+
+  function getGroupDepth(groupId: string): number {
+    let depth = 1;
+    let current = nodeById.get(groupId);
+
+    while (current?.parentId) {
+      const parent = nodeById.get(current.parentId);
+      if (!parent || parent.data.node_type !== 'logic') {
+        break;
+      }
+
+      depth += 1;
+      if (depth > 3) {
+        return depth;
+      }
+      current = parent;
+    }
+
+    return depth;
+  }
+
+  const hasTooDeepNesting = nodes.some(
+    (node) => node.data.node_type === 'logic' && getGroupDepth(node.id) > 3
+  );
+  if (hasTooDeepNesting) {
+    errors.push('Group nesting is too deep (max 3 levels).');
   }
 
   // Check output node has incoming connections


### PR DESCRIPTION
## Summary
- **#41**: Show toast warning when Universe/Output nodes are dropped into AND/OR/NOT groups
- **#42**: Support nested logic groups (e.g., OR group inside AND group) for complex screening strategies

## Changes
- New `Toast` component with auto-dismiss (3s) and `useToast` hook
- `onDrop` handler now accepts both condition and group nodes inside groups
- Auto-resize accounts for variable child heights (nested groups are taller than conditions)
- `graphValidator` adds max nesting depth check (3 levels)
- `graphSerializer` handles nested group dimensions on deserialization
- i18n keys added for `cannotDropInGroup` (en/ko)

## Test plan
- [ ] Drag Universe into an AND group → toast warning, node placed outside
- [ ] Drag Output into an AND group → toast warning, node placed outside
- [ ] Drag condition into AND group → adds as child
- [ ] Drag OR group into AND group → adds as nested child
- [ ] Parent group auto-resizes to fit nested group
- [ ] Drag nested group out of parent → detaches correctly
- [ ] Build passes (`npm run build`)

Fixes #41, Fixes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)