### PR TITLE
Change strategy canvas layout from vertical to horizontal (LR)

### DIFF
--- a/web/src/app/[locale]/strategy/page.tsx
+++ b/web/src/app/[locale]/strategy/page.tsx
@@ -61,13 +61,13 @@ const initialNodes: Node[] = [
   {
     id: 'universe_1',
     type: 'universeNode',
-    position: { x: 250, y: 50 },
+    position: { x: 50, y: 200 },
     data: { node_type: 'universe', universe: 'KOSPI' } satisfies StrategyNodeData,
   },
   {
     id: 'output_1',
     type: 'outputNode',
-    position: { x: 250, y: 400 },
+    position: { x: 800, y: 200 },
     data: { node_type: 'output' } satisfies StrategyNodeData,
   },
 ];

--- a/web/src/components/strategy/nodes/ConditionNode.tsx
+++ b/web/src/components/strategy/nodes/ConditionNode.tsx
@@ -42,8 +42,8 @@ function ConditionNode({ data, selected }: NodeProps) {
       {!isInsideGroup && (
         <Handle
           type="target"
-          position={Position.Top}
-          className="!w-3.5 !h-3.5 !bg-[#1313ec] !border-2 !border-white dark:!border-[#1e1e1f] !-top-[7px] hover:!scale-125 !transition-transform"
+          position={Position.Left}
+          className="!w-3.5 !h-3.5 !bg-[#1313ec] !border-2 !border-white dark:!border-[#1e1e1f] !-left-[7px] hover:!scale-125 !transition-transform"
         />
       )}
       <div className="flex items-center gap-2 mb-2">
@@ -65,8 +65,8 @@ function ConditionNode({ data, selected }: NodeProps) {
       {!isInsideGroup && (
         <Handle
           type="source"
-          position={Position.Bottom}
-          className="!w-3.5 !h-3.5 !bg-[#1313ec] !border-2 !border-white dark:!border-[#1e1e1f] !-bottom-[7px] hover:!scale-125 !transition-transform"
+          position={Position.Right}
+          className="!w-3.5 !h-3.5 !bg-[#1313ec] !border-2 !border-white dark:!border-[#1e1e1f] !-right-[7px] hover:!scale-125 !transition-transform"
         />
       )}
     </div>

--- a/web/src/components/strategy/nodes/GroupNode.tsx
+++ b/web/src/components/strategy/nodes/GroupNode.tsx
@@ -61,8 +61,8 @@ function GroupNode({ id, data, selected }: NodeProps) {
     >
       <Handle
         type="target"
-        position={Position.Top}
-        className="!w-3.5 !h-3.5 !bg-[#1313ec] !border-2 !border-white dark:!border-[#1e1e1f] !-top-[7px] hover:!scale-125 !transition-transform"
+        position={Position.Left}
+        className="!w-3.5 !h-3.5 !bg-[#1313ec] !border-2 !border-white dark:!border-[#1e1e1f] !-left-[7px] hover:!scale-125 !transition-transform"
       />
 
       {/* Badge */}
@@ -86,8 +86,8 @@ function GroupNode({ id, data, selected }: NodeProps) {
 
       <Handle
         type="source"
-        position={Position.Bottom}
-        className="!w-3.5 !h-3.5 !bg-[#1313ec] !border-2 !border-white dark:!border-[#1e1e1f] !-bottom-[7px] hover:!scale-125 !transition-transform"
+        position={Position.Right}
+        className="!w-3.5 !h-3.5 !bg-[#1313ec] !border-2 !border-white dark:!border-[#1e1e1f] !-right-[7px] hover:!scale-125 !transition-transform"
       />
     </div>
   );

--- a/web/src/components/strategy/nodes/LogicNode.tsx
+++ b/web/src/components/strategy/nodes/LogicNode.tsx
@@ -27,8 +27,8 @@ function LogicNode({ data, selected }: NodeProps) {
     >
       <Handle
         type="target"
-        position={Position.Top}
-        className="!w-3.5 !h-3.5 !bg-[#1313ec] !border-2 !border-white dark:!border-[#1e1e1f] !-top-[7px] hover:!scale-125 !transition-transform"
+        position={Position.Left}
+        className="!w-3.5 !h-3.5 !bg-[#1313ec] !border-2 !border-white dark:!border-[#1e1e1f] !-left-[7px] hover:!scale-125 !transition-transform"
       />
       <div className={`inline-flex items-center gap-1.5 px-3 py-1 rounded-full ${style.bg}`}>
         <GitMerge className={`h-3.5 w-3.5 ${style.text}`} />
@@ -36,8 +36,8 @@ function LogicNode({ data, selected }: NodeProps) {
       </div>
       <Handle
         type="source"
-        position={Position.Bottom}
-        className="!w-3.5 !h-3.5 !bg-[#1313ec] !border-2 !border-white dark:!border-[#1e1e1f] !-bottom-[7px] hover:!scale-125 !transition-transform"
+        position={Position.Right}
+        className="!w-3.5 !h-3.5 !bg-[#1313ec] !border-2 !border-white dark:!border-[#1e1e1f] !-right-[7px] hover:!scale-125 !transition-transform"
       />
     </div>
   );

--- a/web/src/components/strategy/nodes/OutputNode.tsx
+++ b/web/src/components/strategy/nodes/OutputNode.tsx
@@ -22,8 +22,8 @@ function OutputNode({ data, selected }: NodeProps) {
     >
       <Handle
         type="target"
-        position={Position.Top}
-        className="!w-3.5 !h-3.5 !bg-[#1313ec] !border-2 !border-white dark:!border-[#1e1e1f] !-top-[7px] hover:!scale-125 !transition-transform"
+        position={Position.Left}
+        className="!w-3.5 !h-3.5 !bg-[#1313ec] !border-2 !border-white dark:!border-[#1e1e1f] !-left-[7px] hover:!scale-125 !transition-transform"
       />
       <div className="flex items-center justify-center gap-2 mb-1">
         <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-orange-50 dark:bg-orange-500/10 text-orange-600 dark:text-orange-400 text-[10px] font-semibold uppercase tracking-wider">

--- a/web/src/components/strategy/nodes/UniverseNode.tsx
+++ b/web/src/components/strategy/nodes/UniverseNode.tsx
@@ -33,8 +33,8 @@ function UniverseNode({ data, selected }: NodeProps) {
       </div>
       <Handle
         type="source"
-        position={Position.Bottom}
-        className="!w-3.5 !h-3.5 !bg-[#1313ec] !border-2 !border-white dark:!border-[#1e1e1f] !-bottom-[7px] hover:!scale-125 !transition-transform"
+        position={Position.Right}
+        className="!w-3.5 !h-3.5 !bg-[#1313ec] !border-2 !border-white dark:!border-[#1e1e1f] !-right-[7px] hover:!scale-125 !transition-transform"
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- Change node handle positions from Top/Bottom to Left/Right for horizontal flow
- Update initial node placement: Universe on the left, Output on the right
- Group-internal child stacking remains vertical (unchanged)

Closes #43

## Test plan
- [ ] Open strategy page — Universe node appears on the left, Output on the right
- [ ] Drag a condition node — edges connect left→right between nodes
- [ ] Drop condition into AND/OR group — children stack vertically inside group
- [ ] Edges render horizontally with smoothstep animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)