### PR TITLE
Fix: resolve group nodes without explicit edges in strategy graph

### DIFF
--- a/api/services/strategy_service.py
+++ b/api/services/strategy_service.py
@@ -520,12 +520,32 @@ def build_conditions_from_graph(graph: StrategyGraph) -> tuple[List[BaseConditio
                 raise ValueError(f"Unknown logic operator: {operator}")
 
         if node.data.node_type == "output":
-            # Resolve all incoming nodes to the output
+            # Resolve all incoming nodes to the output via edges
             sub_conditions = []
+            resolved_ids = set()
             for src_id in incoming.get(node_id, []):
+                resolved_ids.add(src_id)
                 cond = _resolve_node(src_id)
                 if cond is not None:
                     sub_conditions.append(cond)
+
+            # Also resolve top-level logic/condition nodes not connected
+            # via edges (e.g., group nodes using child_node_ids containment)
+            child_ids_set: set[str] = set()
+            for n in graph.nodes:
+                if n.data.child_node_ids:
+                    child_ids_set.update(n.data.child_node_ids)
+
+            for n in graph.nodes:
+                if (
+                    n.data.node_type in ("logic", "condition")
+                    and n.id not in child_ids_set  # not a child of a group
+                    and n.id not in resolved_ids  # not already resolved via edge
+                ):
+                    cond = _resolve_node(n.id)
+                    if cond is not None:
+                        sub_conditions.append(cond)
+
             return sub_conditions  # type: ignore
 
         return None


### PR DESCRIPTION
## Summary

- Fix `build_conditions_from_graph()` to resolve top-level logic/condition nodes that use `child_node_ids` containment but aren't connected to the output via edges
- When conditions are dropped into AND/OR/NOT groups, they use `parentId` containment without explicit edges to the output. The output resolution now handles this case.

## Root Cause

The frontend uses ReactFlow `parentId` relationships to represent conditions inside groups, and `serializeGraph()` correctly translates these into `child_node_ids`. However, the backend only walked backward from the output node via edges, missing unconnected group nodes.

## Test Plan

- [x] Verified with curl: AND group with `child_node_ids` but no edge to output now returns `AndCondition`
- [x] Backward compatible: edge-based condition flow still works (direct condition → output)
- [x] Next.js build passes

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)