### PR TITLE
Fix duplicate node key error with UUID-based IDs

### DIFF
--- a/web/src/app/[locale]/strategy/page.tsx
+++ b/web/src/app/[locale]/strategy/page.tsx
@@ -52,9 +52,8 @@ const CHILD_HEIGHT = 80;
 const GROUP_MIN_WIDTH = 280;
 const GROUP_MIN_HEIGHT = 200;
 
-let nodeId = 0;
 function getNodeId() {
-  return `node_${++nodeId}`;
+  return `node_${crypto.randomUUID().slice(0, 8)}`;
 }
 
 const initialNodes: Node[] = [
@@ -385,7 +384,6 @@ export default function StrategyPage() {
     setSelectedNodeId(null);
     setResults(null);
     setErrors([]);
-    nodeId = 0;
   }, [setNodes, setEdges]);
 
   const currentSelectedNode = useMemo(() => {


### PR DESCRIPTION
## Summary

- Replace module-level `nodeId` counter with `crypto.randomUUID()` to generate unique node IDs
- Remove counter reset in `handleClear()` (no longer needed)

## Root Cause

`nodeId` was a module-level `let` variable that generated sequential IDs (`node_1`, `node_2`, ...). On HMR or `handleClear()`, the counter reset to 0, creating duplicate keys that caused React warnings in MiniMap.

## Changes

- `getNodeId()` now returns `node_${crypto.randomUUID().slice(0, 8)}` for guaranteed uniqueness
- Removed `let nodeId = 0` and `nodeId = 0` reset in `handleClear`

## Test Plan

- [x] Next.js build passes
- [x] No more "Encountered two children with the same key" warning after clear and re-add

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)