### PR TITLE
Add edge labels, node limit counter, and Export JSON

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -215,7 +215,9 @@
     "notInvertFirst": "NOT (invert first input)",
     "outputInstruction": "Connect condition nodes to this output, then click \"Deploy Strategy\" to execute the screening.",
     "removeNode": "Remove Node",
-    "applyChanges": "Apply Changes"
+    "applyChanges": "Apply Changes",
+    "exportJson": "Export JSON",
+    "nodeLimit": "Node limit: {count}/{max}"
   },
   "analysis": {
     "title": "Charts & Analysis",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -215,7 +215,9 @@
     "notInvertFirst": "NOT (첫 번째 입력 반전)",
     "outputInstruction": "조건 노드를 이 출력에 연결한 후 \"전략 배포\"를 클릭하여 스크리닝을 실행하세요.",
     "removeNode": "노드 삭제",
-    "applyChanges": "변경 적용"
+    "applyChanges": "변경 적용",
+    "exportJson": "JSON 내보내기",
+    "nodeLimit": "노드 제한: {count}/{max}"
   },
   "analysis": {
     "title": "차트 & 분석",

--- a/web/src/app/[locale]/strategy/page.tsx
+++ b/web/src/app/[locale]/strategy/page.tsx
@@ -21,11 +21,12 @@ import {
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
 
-import { Loader2, Zap, RotateCcw, Save, TestTube } from 'lucide-react';
+import { Loader2, Zap, RotateCcw, Save, TestTube, Download } from 'lucide-react';
 import UniverseNode from '@/components/strategy/nodes/UniverseNode';
 import ConditionNode from '@/components/strategy/nodes/ConditionNode';
 import GroupNode from '@/components/strategy/nodes/GroupNode';
 import OutputNode from '@/components/strategy/nodes/OutputNode';
+import LabeledEdge from '@/components/strategy/edges/LabeledEdge';
 import NodePalette from '@/components/strategy/NodePalette';
 import PropertiesPanel from '@/components/strategy/PropertiesPanel';
 import BacktestPanel from '@/components/backtest/BacktestPanel';
@@ -42,6 +43,10 @@ const nodeTypes: NodeTypes = {
   conditionNode: ConditionNode,
   groupNode: GroupNode,
   outputNode: OutputNode,
+};
+
+const edgeTypes = {
+  labeled: LabeledEdge,
 };
 
 const GROUP_PADDING_TOP = 56;
@@ -386,6 +391,18 @@ export default function StrategyPage() {
     setErrors([]);
   }, [setNodes, setEdges]);
 
+  const handleExportJson = useCallback(() => {
+    const typedNodes = nodes as unknown as Node<StrategyNodeData>[];
+    const graph = serializeGraph(typedNodes, edges);
+    const blob = new Blob([JSON.stringify(graph, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'strategy.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  }, [nodes, edges]);
+
   const currentSelectedNode = useMemo(() => {
     if (!selectedNodeId) return null;
     const found = nodes.find((n) => n.id === selectedNodeId);
@@ -474,7 +491,7 @@ export default function StrategyPage() {
       {/* Main content */}
       <div className="flex flex-1 overflow-hidden">
         {/* Left palette */}
-        <NodePalette />
+        <NodePalette nodeCount={nodeCount} />
 
         {/* Canvas */}
         <div className="flex-1" ref={reactFlowWrapper}>
@@ -490,12 +507,13 @@ export default function StrategyPage() {
             onDragOver={onDragOver}
             onDrop={onDrop}
             nodeTypes={nodeTypes}
+            edgeTypes={edgeTypes}
             fitView
             fitViewOptions={{ maxZoom: 0.75, padding: 0.3 }}
             connectionMode={ConnectionMode.Loose}
             className="!bg-[#f6f6f7] dark:!bg-[#141414]"
             defaultEdgeOptions={{
-              type: 'smoothstep',
+              type: 'labeled',
               animated: true,
               style: { stroke: '#1313ec', strokeWidth: 2, opacity: 0.6 },
             }}
@@ -540,6 +558,14 @@ export default function StrategyPage() {
         <div className="flex items-center gap-4">
           <span>{t('kospiData')}</span>
           <span>{results ? t('lastRunJustNow') : t('lastRunNever')}</span>
+          <button
+            type="button"
+            onClick={handleExportJson}
+            className="flex items-center gap-1 px-2 py-0.5 rounded text-[11px] font-medium text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+          >
+            <Download className="h-3 w-3" />
+            {t('exportJson')}
+          </button>
         </div>
       </div>
 

--- a/web/src/components/strategy/NodePalette.tsx
+++ b/web/src/components/strategy/NodePalette.tsx
@@ -69,7 +69,11 @@ function DraggableItem({
   );
 }
 
-export default function NodePalette() {
+interface NodePaletteProps {
+  nodeCount?: number;
+}
+
+export default function NodePalette({ nodeCount }: NodePaletteProps) {
   const t = useTranslations('strategy');
   const tCond = useTranslations('conditions');
   const [expandedCategories, setExpandedCategories] = useState<Set<string>>(
@@ -218,6 +222,10 @@ export default function NodePalette() {
             </div>
           </div>
         )}
+      </div>
+
+      <div className="px-3 py-2 border-t border-[#e1e3e5] dark:border-[#2e2e30] text-[11px] text-gray-400 dark:text-gray-500">
+        {t('nodeLimit', { count: nodeCount ?? 0, max: 20 })}
       </div>
     </div>
   );

--- a/web/src/components/strategy/edges/LabeledEdge.tsx
+++ b/web/src/components/strategy/edges/LabeledEdge.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { memo } from 'react';
+import {
+  BaseEdge,
+  EdgeLabelRenderer,
+  getSmoothStepPath,
+  type EdgeProps,
+} from '@xyflow/react';
+
+function LabeledEdge({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  style,
+  markerEnd,
+}: EdgeProps) {
+  const [edgePath, labelX, labelY] = getSmoothStepPath({
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+  });
+
+  return (
+    <>
+      <BaseEdge path={edgePath} markerEnd={markerEnd} style={style} />
+      <EdgeLabelRenderer>
+        <div
+          className="nodrag nopan pointer-events-none absolute"
+          style={{
+            transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
+          }}
+        >
+          <span className="bg-white dark:bg-[#1e1e1f] text-[10px] font-medium text-gray-400 dark:text-gray-500 px-2 py-0.5 rounded-full border border-[#e1e3e5] dark:border-[#2e2e30] shadow-sm">
+            Then
+          </span>
+        </div>
+      </EdgeLabelRenderer>
+    </>
+  );
+}
+
+export default memo(LabeledEdge);


### PR DESCRIPTION
## Summary

Three UI improvements from the Stitch design:

1. **Edge connector labels** (#52): Custom `LabeledEdge` component showing "Then" label on connectors between nodes
2. **Node limit counter** (#53): NodePalette footer shows "Node limit: N/20"
3. **Export JSON button** (#54): Footer status bar button to download current strategy graph as JSON

## Changes

- `web/src/components/strategy/edges/LabeledEdge.tsx` (new) - Custom edge with label
- `web/src/components/strategy/NodePalette.tsx` - Add `nodeCount` prop + footer counter
- `web/src/app/[locale]/strategy/page.tsx` - Register edge type, pass nodeCount, add export handler
- `web/messages/en.json`, `web/messages/ko.json` - i18n keys

## Test Plan

- [x] Next.js build passes
- [x] i18n keys added (en/ko)
- [ ] Verify "Then" labels appear on edges
- [ ] Verify node limit counter updates
- [ ] Verify Export JSON downloads valid file

Closes #52, #53, #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)