### PR TITLE
Add internal edges between conditions inside groups (#77)

### DIFF
--- a/web/src/app/[locale]/strategy/page.tsx
+++ b/web/src/app/[locale]/strategy/page.tsx
@@ -275,6 +275,26 @@ function StrategyPageInner() {
           };
 
           setNodes((nds) => [...nds, newNode]);
+
+          // Auto-create internal "Then" edge from previous child
+          if (childrenInGroup.length > 0) {
+            const prevChild = childrenInGroup[childrenInGroup.length - 1];
+            const isLast = true; // new node is always last
+            setEdges((eds) => [
+              ...eds,
+              {
+                id: `internal_${prevChild.id}_${newNodeId}`,
+                source: prevChild.id,
+                sourceHandle: 'bottom',
+                target: newNodeId,
+                targetHandle: 'top',
+                type: 'labeled',
+                animated: false,
+                data: { label: 'Then' },
+                style: { stroke: '#1313ec', strokeWidth: 1.5, opacity: 0.4, strokeDasharray: '4 4' },
+              },
+            ]);
+          }
           return;
         }
       }

--- a/web/src/components/strategy/edges/LabeledEdge.tsx
+++ b/web/src/components/strategy/edges/LabeledEdge.tsx
@@ -18,6 +18,7 @@ function LabeledEdge({
   targetPosition,
   style,
   markerEnd,
+  data,
 }: EdgeProps) {
   const [edgePath, labelX, labelY] = getSmoothStepPath({
     sourceX,
@@ -27,6 +28,8 @@ function LabeledEdge({
     targetY,
     targetPosition,
   });
+
+  const label = (data as Record<string, unknown>)?.label as string | undefined;
 
   return (
     <>
@@ -39,7 +42,7 @@ function LabeledEdge({
           }}
         >
           <span className="bg-white dark:bg-[#1e1e1f] text-[10px] font-medium text-gray-400 dark:text-gray-500 px-2 py-0.5 rounded-full border border-[#e1e3e5] dark:border-[#2e2e30] shadow-sm">
-            Then
+            {label ?? 'Then'}
           </span>
         </div>
       </EdgeLabelRenderer>

--- a/web/src/components/strategy/nodes/ConditionNode.tsx
+++ b/web/src/components/strategy/nodes/ConditionNode.tsx
@@ -50,6 +50,14 @@ function ConditionNode({ data, selected }: NodeProps) {
           className="!w-3.5 !h-3.5 !bg-[#1313ec] !border-2 !border-white dark:!border-[#1e1e1f] !-left-[7px] hover:!scale-125 !transition-transform"
         />
       )}
+      {isInsideGroup && (
+        <Handle
+          type="target"
+          id="top"
+          position={Position.Top}
+          className="!w-2.5 !h-2.5 !bg-[#1313ec]/60 !border-2 !border-white dark:!border-[#1e1e1f] !-top-[5px] hover:!scale-125 !transition-transform"
+        />
+      )}
 
       {/* Header bar */}
       <div className="flex items-center justify-between px-3 py-1.5 rounded-t-[10px] bg-blue-50 dark:bg-blue-500/10 border-b border-blue-100 dark:border-blue-500/20">
@@ -83,6 +91,14 @@ function ConditionNode({ data, selected }: NodeProps) {
           type="source"
           position={Position.Right}
           className="!w-3.5 !h-3.5 !bg-[#1313ec] !border-2 !border-white dark:!border-[#1e1e1f] !-right-[7px] hover:!scale-125 !transition-transform"
+        />
+      )}
+      {isInsideGroup && (
+        <Handle
+          type="source"
+          id="bottom"
+          position={Position.Bottom}
+          className="!w-2.5 !h-2.5 !bg-[#1313ec]/60 !border-2 !border-white dark:!border-[#1e1e1f] !-bottom-[5px] hover:!scale-125 !transition-transform"
         />
       )}
     </div>


### PR DESCRIPTION
## Summary

- **ConditionNode**: Show Top (target) / Bottom (source) handles when inside a group for vertical internal connections between sibling conditions
- **LabeledEdge**: Support dynamic label text via `data.label` (defaults to "Then")
- **page.tsx onDrop**: Auto-create a dashed "Then" edge from the previous child when dropping a new condition into an AND/OR/NOT group

## How it works

When a 2nd+ condition is dropped into a group:
1. The previous child's `bottom` handle connects to the new child's `top` handle
2. A dashed "Then" labeled edge is created between them
3. Visual flow: `Condition 1 --Then--> Condition 2 --Then--> Condition 3`

## Test plan

- [ ] Drop 1 condition into AND group — no internal edge (only 1 child)
- [ ] Drop 2nd condition into AND group — "Then" edge appears between them
- [ ] Drop 3rd condition — "Then" edge from 2nd to 3rd
- [ ] Internal edges are dashed with lower opacity (distinct from external edges)
- [ ] Conditions outside groups still use Left/Right handles
- [ ] Conditions inside groups show smaller Top/Bottom handles

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)