### PR TITLE
Add ROIC screening condition (#78)

### DIFF
--- a/models/condition.py
+++ b/models/condition.py
@@ -77,6 +77,7 @@ class ConditionType(Enum):
     # Fundamental (Composite Scores)
     PIOTROSKI_FSCORE = "piotroski_fscore" # Piotroski F-Score
     ALTMAN_ZSCORE = "altman_zscore"       # Altman Z-Score
+    ROIC = "roic"                         # Return on Invested Capital
 
 
 # 각 조건 타입별 기본 파라미터
@@ -116,6 +117,7 @@ DEFAULT_PARAMS: Dict[ConditionType, Dict[str, Any]] = {
     # Fundamental (Composite)
     ConditionType.PIOTROSKI_FSCORE: {"min_score": 7, "max_score": None},
     ConditionType.ALTMAN_ZSCORE: {"min_zscore": 2.5, "max_zscore": None},
+    ConditionType.ROIC: {"min_roic": 15.0, "max_roic": None},
 }
 
 

--- a/screener/conditions/__init__.py
+++ b/screener/conditions/__init__.py
@@ -27,7 +27,7 @@ Usage:
         DividendYieldCondition, EarningsYieldCondition, EbitEvCondition,
         FcfYieldCondition, PegRatioCondition, DebtToEquityCondition,
         CurrentRatioCondition, RoeCondition, PiotroskiFScoreCondition,
-        AltmanZScoreCondition, clear_info_cache,
+        AltmanZScoreCondition, RoicCondition, clear_info_cache,
     )
 """
 
@@ -102,6 +102,7 @@ from .fundamental import (
     RoeCondition,
     PiotroskiFScoreCondition,
     AltmanZScoreCondition,
+    RoicCondition,
     clear_info_cache,
 )
 
@@ -143,7 +144,7 @@ __all__ = [
     'PERatioCondition', 'PBRatioCondition', 'PSRatioCondition', 'PCFRatioCondition',
     'DividendYieldCondition', 'EarningsYieldCondition', 'EbitEvCondition', 'FcfYieldCondition',
     'PegRatioCondition', 'DebtToEquityCondition', 'CurrentRatioCondition', 'RoeCondition',
-    'PiotroskiFScoreCondition', 'AltmanZScoreCondition', 'clear_info_cache',
+    'PiotroskiFScoreCondition', 'AltmanZScoreCondition', 'RoicCondition', 'clear_info_cache',
 
     # Registry
     'get_condition_class_map', 'get_condition_metadata',

--- a/screener/conditions/fundamental.py
+++ b/screener/conditions/fundamental.py
@@ -13,7 +13,7 @@ Usage:
         DividendYieldCondition, EarningsYieldCondition, EbitEvCondition,
         FcfYieldCondition, PegRatioCondition, DebtToEquityCondition,
         CurrentRatioCondition, RoeCondition, PiotroskiFScoreCondition,
-        AltmanZScoreCondition, clear_info_cache,
+        AltmanZScoreCondition, RoicCondition, clear_info_cache,
     )
 """
 
@@ -1354,3 +1354,94 @@ class AltmanZScoreCondition(BaseCondition):
 
     def __repr__(self) -> str:
         return f"AltmanZScoreCondition(min_zscore={self.min_zscore}, max_zscore={self.max_zscore})"
+
+
+# ===================================================================
+# 15. RoicCondition
+# ===================================================================
+
+@register_condition(
+    key="roic",
+    label="ROIC",
+    description="Return on Invested Capital filter",
+    category="Fundamental",
+    params=[
+        {"name": "min_roic", "type": "float", "default": 15.0, "description": "Min ROIC %"},
+        {"name": "max_roic", "type": "float", "default": None, "description": "Max ROIC %"},
+    ],
+)
+class RoicCondition(BaseCondition):
+    """Return on Invested Capital screening condition.
+
+    ROIC = NOPAT / Invested Capital * 100
+
+    Where:
+        NOPAT = Operating Income * (1 - Tax Rate)
+        Invested Capital = Total Debt + Total Stockholder Equity
+
+    Excludes tickers with non-positive invested capital.
+    """
+
+    def __init__(
+        self,
+        min_roic: Optional[float] = 15.0,
+        max_roic: Optional[float] = None,
+    ):
+        """
+        Args:
+            min_roic: Minimum ROIC in % (inclusive).
+            max_roic: Maximum ROIC in % (inclusive).
+        """
+        self.min_roic = min_roic
+        self.max_roic = max_roic
+
+    @property
+    def name(self) -> str:
+        return f"roic_min{self.min_roic}"
+
+    @property
+    def required_days(self) -> int:
+        return 1
+
+    def evaluate(self, ticker: str, data: pd.DataFrame) -> ConditionResult:
+        info = _get_info(ticker)
+
+        operating_income = info.get("operatingIncome") or info.get("ebitda", 0)
+        if not operating_income:
+            return ConditionResult(
+                matched=False,
+                condition_name=self.name,
+                details={"error": "No operating income data"},
+            )
+
+        tax_rate = info.get("effectiveTaxRate") or 0.21
+        nopat = operating_income * (1 - tax_rate)
+
+        total_debt = info.get("totalDebt", 0)
+        total_equity = info.get("totalStockholderEquity", 0)
+        invested_capital = total_debt + total_equity
+
+        if invested_capital <= 0:
+            return ConditionResult(
+                matched=False,
+                condition_name=self.name,
+                details={"error": "Non-positive invested capital"},
+            )
+
+        roic_pct = (nopat / invested_capital) * 100
+        matched = _in_range(roic_pct, self.min_roic, self.max_roic)
+
+        return ConditionResult(
+            matched=matched,
+            condition_name=self.name,
+            details={
+                "roic_pct": float(roic_pct),
+                "nopat": float(nopat),
+                "invested_capital": float(invested_capital),
+                "min_roic": self.min_roic,
+                "max_roic": self.max_roic,
+            },
+        )
+
+    def __repr__(self) -> str:
+        return f"RoicCondition(min_roic={self.min_roic}%, max_roic={self.max_roic}%)"

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -511,6 +511,11 @@
       "label": "Altman Z-Score",
       "desc": "Altman Z-Score bankruptcy risk filter",
       "params": { "min_zscore": "Min Z-Score", "max_zscore": "Max Z-Score" }
+    },
+    "roic": {
+      "label": "ROIC",
+      "description": "Return on Invested Capital filter",
+      "params": { "min_roic": "Min ROIC %", "max_roic": "Max ROIC %" }
     }
   },
   "markets": {

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -511,6 +511,11 @@
       "label": "알트만 Z-스코어",
       "desc": "알트만 Z-스코어 부도 위험 필터",
       "params": { "min_zscore": "최소 Z-스코어", "max_zscore": "최대 Z-스코어" }
+    },
+    "roic": {
+      "label": "투하자본수익률(ROIC)",
+      "description": "투하자본수익률 필터",
+      "params": { "min_roic": "최소 ROIC %", "max_roic": "최대 ROIC %" }
     }
   },
   "markets": {


### PR DESCRIPTION
## Summary
- Add `RoicCondition` class with `@register_condition` decorator in `screener/conditions/fundamental.py`
- ROIC = NOPAT / Invested Capital (uses yfinance `operatingIncome`, `totalDebt`, `totalStockholderEquity`)
- Add i18n translations (en/ko), ConditionType enum entry, and `__init__.py` export

## Test plan
- [ ] `python -c "from screener.conditions import RoicCondition; print('OK')"`
- [ ] Verify ROIC appears in strategy builder condition palette
- [ ] Test with a ticker: ROIC filter with min_roic=15

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)