### PR TITLE
Fix condition node i18n label display (#86)

### DIFF
--- a/web/src/components/strategy/nodes/ConditionNode.tsx
+++ b/web/src/components/strategy/nodes/ConditionNode.tsx
@@ -10,13 +10,24 @@ import { useConditions } from '@/contexts/ConditionsContext';
 
 function ConditionNode({ data, selected }: NodeProps) {
   const t = useTranslations('strategy');
+  const tCond = useTranslations('conditions');
   const { getConditionMeta } = useConditions();
   const nodeData = data as unknown as StrategyNodeData;
   const meta = nodeData.condition_type
     ? getConditionMeta(nodeData.condition_type)
     : null;
 
-  const label = meta?.label || nodeData.label || t('condition');
+  const condKey = nodeData.condition_type || '';
+  let label: string;
+  if (condKey) {
+    try {
+      label = tCond(`${condKey}.label`);
+    } catch {
+      label = meta?.label || nodeData.label || t('condition');
+    }
+  } else {
+    label = nodeData.label || t('condition');
+  }
 
   const nodeId = useNodeId();
   const { getNode } = useReactFlow();


### PR DESCRIPTION
## Summary
- Fix `ConditionNode.tsx` to use `tCond('${condKey}.label')` for i18n translation instead of raw English `meta?.label`
- Korean locale now shows translated condition names on canvas nodes
- Fallback to English label if translation key is missing

## Test plan
- [ ] Switch to Korean locale, verify condition nodes show Korean labels
- [ ] Switch to English locale, verify English labels still work
- [ ] Add a condition without translation key, verify fallback works

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)