### PR TITLE
Fix drag-and-drop conditions into AND/OR group nodes (#87)

### DIFF
--- a/web/src/app/[locale]/strategy/page.tsx
+++ b/web/src/app/[locale]/strategy/page.tsx
@@ -394,15 +394,26 @@ function StrategyPageInner() {
                   return acc + h + CHILD_SPACING;
                 }, 0);
 
-                return nds.map((n) => {
-                  if (n.id !== change.id) return n;
-                  return {
-                    ...n,
-                    position: { x: GROUP_PADDING_X, y: relY },
-                    parentId: group.id,
-                    extent: 'parent' as const,
-                  };
-                });
+                // Update the node with parent relationship
+                const updatedChild: Node = {
+                  ...node,
+                  position: { x: GROUP_PADDING_X, y: relY },
+                  parentId: group.id,
+                  extent: 'parent' as const,
+                };
+
+                // ReactFlow requires parent nodes to appear before their
+                // children in the nodes array.  Rebuild the array so that
+                // the parent (group) always precedes the newly-adopted child.
+                const rest = nds.filter(
+                  (n) => n.id !== change.id
+                );
+                const parentIdx = rest.findIndex(
+                  (n) => n.id === group.id
+                );
+                // Insert the child right after its parent
+                rest.splice(parentIdx + 1, 0, updatedChild);
+                return rest;
               }
             }
             return nds;


### PR DESCRIPTION
## Summary
- Fix node ordering bug in `handleNodesChange` drag-in logic
- ReactFlow requires parent nodes before children in the array; `Array.map()` preserved wrong order
- Replace with array rebuild that inserts child immediately after parent node
- Conditions created before a group can now be dragged into it correctly

## Root Cause
ReactFlow's `adoptUserNodes` iterates in array order. When a child node appeared before its parent (due to `nds.map()` preserving creation order), the parent-child relationship was silently skipped.

## Test plan
- [ ] Drag a condition (created first) into a group (created later)
- [ ] Drag a condition (created later) into a group (created first)
- [ ] Verify node stays visually inside the group after drop
- [ ] Drag a child out of a group and back in

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)