### PR TITLE
Enhanced stock detail page with strategy context, AI insight, and clickable results

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -558,7 +558,7 @@
     },
     "roic": {
       "label": "ROIC",
-      "description": "Return on Invested Capital filter",
+      "desc": "Return on Invested Capital filter",
       "params": { "min_roic": "Min ROIC %", "max_roic": "Max ROIC %" }
     }
   },

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -558,7 +558,7 @@
     },
     "roic": {
       "label": "투하자본수익률(ROIC)",
-      "description": "투하자본수익률 필터",
+      "desc": "투하자본수익률 필터",
       "params": { "min_roic": "최소 ROIC %", "max_roic": "최대 ROIC %" }
     }
   },

--- a/web/src/app/[locale]/strategy/page.tsx
+++ b/web/src/app/[locale]/strategy/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useCallback, useRef, useMemo, useEffect } from 'react';
-import { useTranslations } from 'next-intl';
+import { useTranslations, useLocale } from 'next-intl';
 import {
   ReactFlow,
   addEdge,
@@ -112,6 +112,7 @@ function loadCanvasFromSession(): CanvasSnapshot | null {
 
 function StrategyPageInner() {
   const t = useTranslations('strategy');
+  const locale = useLocale();
   const { getDefaultParams } = useConditions();
 
   // Restore from sessionStorage if available (locale-switch persistence)
@@ -837,9 +838,20 @@ function StrategyPageInner() {
               {results.map((r) => (
                 <tr
                   key={r.ticker}
-                  className="border-b border-[#e1e3e5] dark:border-[#2e2e30] hover:bg-gray-50 dark:hover:bg-white/5 transition-colors"
+                  className="border-b border-[#e1e3e5] dark:border-[#2e2e30] hover:bg-gray-50 dark:hover:bg-white/5 transition-colors cursor-pointer"
+                  onClick={() => {
+                    const width = 1000;
+                    const height = 700;
+                    const left = (screen.width - width) / 2;
+                    const top = (screen.height - height) / 2;
+                    window.open(
+                      `/${locale}/analysis/${r.ticker}`,
+                      `analysis_${r.ticker}`,
+                      `width=${width},height=${height},left=${left},top=${top},scrollbars=yes,resizable=yes`
+                    );
+                  }}
                 >
-                  <td className="px-4 py-1.5 font-mono text-[#1313ec] font-medium">
+                  <td className="px-4 py-1.5 font-mono text-[#1313ec] font-medium underline decoration-[#1313ec]/30 hover:decoration-[#1313ec]">
                     {r.ticker}
                   </td>
                   <td className="px-4 py-1.5 text-gray-700 dark:text-gray-200">


### PR DESCRIPTION
## Summary

- **Stock detail page**: Added Financial Overview (EPS), Strategy Context with preset selector, AI Insight (button-triggered), and Sector Distribution sections
- **Backend**: Added `eps` field to `TickerFundamental` schema, sourced from yfinance `trailingEps`
- **QuantCanvas results**: Clicking a screening result row opens the stock analysis page in a popup window
- **i18n**: Added 33 translation keys for `stockDetail` namespace (en/ko), fixed `roic.desc` key typo
- **Config**: Added `.env.example` files, CORS_ORIGINS support for custom frontend ports

Closes #93

## Test plan

- [ ] Navigate to `/[locale]/analysis/[ticker]` and verify all 4 new sections render
- [ ] Change preset selector in Strategy Context and verify conditions update
- [ ] Run a strategy in QuantCanvas and click a result row to verify popup opens
- [ ] Verify i18n works for both `en` and `ko` locales
- [ ] Known issue: popup locale may show English regardless of current locale (#103)

🤖 Generated with [Claude Code](https://claude.com/claude-code)