### PR TITLE
Hide global navigation in stock detail popup

### DIFF
--- a/web/src/app/[locale]/analysis/[ticker]/page.tsx
+++ b/web/src/app/[locale]/analysis/[ticker]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState, useCallback } from 'react';
-import { useParams } from 'next/navigation';
+import { useParams, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import {
@@ -57,6 +57,8 @@ const periodOptions: { value: PeriodOption; label: string }[] = [
  */
 export default function TickerAnalysisPage() {
   const params = useParams();
+  const searchParams = useSearchParams();
+  const isPopup = searchParams.get('popup') === 'true';
   const ticker = params.ticker as string;
   const t = useTranslations('stockDetail');
 
@@ -210,14 +212,16 @@ export default function TickerAnalysisPage() {
 
   return (
     <div className="space-y-6">
-      {/* Back navigation */}
-      <Link
-        href="/analysis"
-        className="inline-flex items-center gap-2 text-[var(--foreground-muted)] hover:text-[var(--foreground)] transition-colors"
-      >
-        <ArrowLeft className="h-4 w-4" />
-        {t('backToAnalysis')}
-      </Link>
+      {/* Back navigation - hidden in popup mode */}
+      {!isPopup && (
+        <Link
+          href="/analysis"
+          className="inline-flex items-center gap-2 text-[var(--foreground-muted)] hover:text-[var(--foreground)] transition-colors"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          {t('backToAnalysis')}
+        </Link>
+      )}
 
       {/* Header */}
       <div className="flex flex-wrap items-start justify-between gap-4">

--- a/web/src/app/[locale]/strategy/page.tsx
+++ b/web/src/app/[locale]/strategy/page.tsx
@@ -993,7 +993,7 @@ function StrategyPageInner() {
                         const left = (screen.width - width) / 2;
                         const top = (screen.height - height) / 2;
                         window.open(
-                          `/${locale}/analysis/${r.ticker}`,
+                          `/${locale}/analysis/${r.ticker}?popup=true`,
                           `analysis_${r.ticker}`,
                           `width=${width},height=${height},left=${left},top=${top},scrollbars=yes,resizable=yes`
                         );

--- a/web/src/components/layout/MainLayout.tsx
+++ b/web/src/components/layout/MainLayout.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, ReactNode } from 'react';
+import { useSearchParams } from 'next/navigation';
 import Header from './Header';
 import Sidebar from './Sidebar';
 import Footer from './Footer';
@@ -12,12 +13,19 @@ interface MainLayoutProps {
 /**
  * Main layout wrapper that combines Header, Sidebar, and Footer
  * Handles mobile sidebar state
+ * When popup=true query param is present, renders content only (no navigation)
  */
 export default function MainLayout({ children }: MainLayoutProps) {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const searchParams = useSearchParams();
+  const isPopup = searchParams.get('popup') === 'true';
 
   const toggleSidebar = () => setIsSidebarOpen(!isSidebarOpen);
   const closeSidebar = () => setIsSidebarOpen(false);
+
+  if (isPopup) {
+    return <main className="min-h-screen p-4">{children}</main>;
+  }
 
   return (
     <div className="min-h-screen bg-[var(--background)]">


### PR DESCRIPTION
## Summary
- Add `?popup=true` query param to `window.open()` URL in strategy page
- MainLayout detects `popup=true` and skips Header/Sidebar/Footer rendering
- Stock detail page hides "Back to Analysis" link in popup mode

## Test plan
- [ ] Strategy results → click ticker → popup shows analysis only (no nav chrome)
- [ ] Direct visit to `/analysis/AAPL` → full layout with Header/Sidebar/Footer
- [ ] "Back to Analysis" link hidden in popup, visible in normal page

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)