### PR TITLE
Fix analysis popup locale and chart rendering

### DIFF
--- a/web/src/components/charts/CandleChart.tsx
+++ b/web/src/components/charts/CandleChart.tsx
@@ -86,9 +86,11 @@ export default function CandleChart({
       },
     };
 
+    const initialWidth = containerRef.current.clientWidth || containerRef.current.offsetWidth || 300;
+
     const chart = createChart(containerRef.current, {
       ...chartOptions,
-      width: containerRef.current.clientWidth,
+      width: initialWidth,
       height: height,
     });
 
@@ -126,19 +128,20 @@ export default function CandleChart({
       volumeSeriesRef.current = volumeSeries;
     }
 
-    // Handle resize
-    const handleResize = () => {
-      if (containerRef.current && chartRef.current) {
-        chartRef.current.applyOptions({
-          width: containerRef.current.clientWidth,
-        });
+    // Handle resize with ResizeObserver (works in popups where initial width may be 0)
+    const resizeObserver = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const newWidth = entry.contentRect.width;
+        if (newWidth > 0 && chartRef.current) {
+          chartRef.current.applyOptions({ width: newWidth });
+        }
       }
-    };
+    });
 
-    window.addEventListener('resize', handleResize);
+    resizeObserver.observe(containerRef.current);
 
     return () => {
-      window.removeEventListener('resize', handleResize);
+      resizeObserver.disconnect();
       chart.remove();
       chartRef.current = null;
       candleSeriesRef.current = null;

--- a/web/src/components/layout/LocaleSwitcher.tsx
+++ b/web/src/components/layout/LocaleSwitcher.tsx
@@ -8,14 +8,18 @@ import type { Locale } from '@/i18n/routing';
 const localeLabels: Record<Locale, string> = {
   en: 'EN',
   ko: 'KO',
+  zh: 'ZH',
 };
+
+const localeOrder: Locale[] = ['en', 'ko', 'zh'];
 
 export default function LocaleSwitcher() {
   const locale = useLocale() as Locale;
   const router = useRouter();
   const pathname = usePathname();
 
-  const nextLocale: Locale = locale === 'en' ? 'ko' : 'en';
+  const currentIndex = localeOrder.indexOf(locale);
+  const nextLocale = localeOrder[(currentIndex + 1) % localeOrder.length];
 
   const handleSwitch = () => {
     router.replace(pathname, { locale: nextLocale });
@@ -26,7 +30,7 @@ export default function LocaleSwitcher() {
       type="button"
       onClick={handleSwitch}
       className="flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-sm font-medium text-[var(--foreground-muted)] hover:bg-[var(--border)] hover:text-[var(--foreground)] transition-colors"
-      aria-label={`Switch to ${nextLocale === 'en' ? 'English' : '한국어'}`}
+      aria-label={`Switch to ${nextLocale}`}
     >
       <Globe className="h-4 w-4" />
       <span>{localeLabels[locale]}</span>

--- a/web/src/i18n/routing.ts
+++ b/web/src/i18n/routing.ts
@@ -3,6 +3,7 @@ import { defineRouting } from 'next-intl/routing';
 export const routing = defineRouting({
   locales: ['en', 'ko', 'zh'],
   defaultLocale: 'en',
+  localeDetection: false,
 });
 
 export type Locale = (typeof routing.locales)[number];


### PR DESCRIPTION
## Summary
- **#103**: Popup window ignores current locale and renders in English
- **#113**: Chart doesn't render in popup mode (container width=0)
- **Bonus**: LocaleSwitcher missing zh locale support from #106

## Changes
- **`routing.ts`**: Add `localeDetection: false` to prevent NEXT_LOCALE cookie from overriding URL path locale in popups
- **`CandleChart.tsx`**: Replace `window.addEventListener('resize')` with `ResizeObserver` — correctly handles popup windows where container width starts at 0
- **`LocaleSwitcher.tsx`**: Add zh label, cycle through en → ko → zh instead of toggling en ↔ ko

## Test plan
- [ ] Open `/ko/strategy`, run a strategy, click a result row → popup should show Korean UI
- [ ] Popup chart should render correctly (not blank)
- [ ] Click locale switcher: EN → KO → ZH → EN cycle
- [ ] Direct URL `/zh/analysis/AAPL?popup=true` should render in Chinese

Closes #103
Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)