### PR TITLE
Apply preset-based defaults and recommended sorting for conditions

### DIFF
--- a/api/routers/strategy.py
+++ b/api/routers/strategy.py
@@ -37,6 +37,7 @@ router = APIRouter(prefix="/api/strategy", tags=["Strategy"])
 async def list_conditions() -> ConditionsListResponse:
     """Return available condition types for the node palette."""
     conditions = get_available_conditions()
+    conditions.sort(key=lambda c: (not c.recommended, c.order, c.key))
     categories = sorted(set(c.category for c in conditions))
     return ConditionsListResponse(conditions=conditions, categories=categories)
 

--- a/api/schemas/strategy.py
+++ b/api/schemas/strategy.py
@@ -112,6 +112,8 @@ class ConditionInfo(BaseModel):
     description: str = ""
     category: str
     params: List[ConditionParamInfo] = Field(default_factory=list)
+    recommended: bool = False
+    order: int = 0
 
 
 class ConditionsListResponse(BaseModel):

--- a/api/services/strategy_service.py
+++ b/api/services/strategy_service.py
@@ -57,6 +57,8 @@ def get_available_conditions() -> List[ConditionInfo]:
                 description=meta.get("description", ""),
                 category=meta["category"],
                 params=params,
+                recommended=meta.get("recommended", False),
+                order=meta.get("order", 0),
             )
         )
     return conditions

--- a/screener/conditions/accumulation.py
+++ b/screener/conditions/accumulation.py
@@ -46,10 +46,12 @@ from discovery.indicators import (
     description="BB width contraction",
     category="accumulation",
     params=[
-        {"name": "max_width_pct", "type": "float", "default": 10.0, "description": "Max BB width %"},
+        {"name": "max_width_pct", "type": "float", "default": 15.0, "description": "Max BB width %"},
         {"name": "period", "type": "int", "default": 20, "description": "BB period"},
         {"name": "std_dev", "type": "float", "default": 2.0, "description": "Std deviation"},
     ],
+    recommended=True,
+    order=80,
 )
 class BollingerWidthCondition(BaseCondition):
     """
@@ -116,9 +118,11 @@ class BollingerWidthCondition(BaseCondition):
     description="Quiet volume zone",
     category="accumulation",
     params=[
-        {"name": "multiplier", "type": "float", "default": 0.8, "description": "Max ratio to avg"},
+        {"name": "multiplier", "type": "float", "default": 1.0, "description": "Max ratio to avg"},
         {"name": "period", "type": "int", "default": 20, "description": "Average period"},
     ],
+    recommended=True,
+    order=90,
 )
 class VolumeBelowAvgCondition(BaseCondition):
     """
@@ -187,9 +191,11 @@ class VolumeBelowAvgCondition(BaseCondition):
     description="Price consolidation (low volatility)",
     category="accumulation",
     params=[
-        {"name": "max_range_pct", "type": "float", "default": 5.0, "description": "Max range %"},
+        {"name": "max_range_pct", "type": "float", "default": 10.0, "description": "Max range %"},
         {"name": "period", "type": "int", "default": 20, "description": "Period"},
     ],
+    recommended=True,
+    order=100,
 )
 class PriceFlatCondition(BaseCondition):
     """

--- a/screener/conditions/ma.py
+++ b/screener/conditions/ma.py
@@ -18,9 +18,11 @@ from .registry import register_condition
     description="Price near moving average",
     category="movingAverage",
     params=[
-        {"name": "period", "type": "int", "default": 20, "description": "MA period"},
+        {"name": "period", "type": "int", "default": 120, "description": "MA period"},
         {"name": "threshold", "type": "float", "default": 0.02, "description": "Touch threshold (ratio)"},
     ],
+    recommended=True,
+    order=10,
 )
 class MATouchCondition(BaseCondition):
     """이동평균선 터치 조건"""
@@ -91,6 +93,8 @@ class MATouchCondition(BaseCondition):
         {"name": "period", "type": "int", "default": 20, "description": "MA period"},
         {"name": "min_distance_pct", "type": "float", "default": 0, "description": "Min distance %"},
     ],
+    recommended=True,
+    order=30,
 )
 class AboveMACondition(BaseCondition):
     """이동평균선 위 조건"""
@@ -226,10 +230,12 @@ class BelowMACondition(BaseCondition):
     description="Golden cross (short MA crosses above long MA)",
     category="movingAverage",
     params=[
-        {"name": "short_period", "type": "int", "default": 20, "description": "Short MA period"},
-        {"name": "long_period", "type": "int", "default": 60, "description": "Long MA period"},
+        {"name": "short_period", "type": "int", "default": 5, "description": "Short MA period"},
+        {"name": "long_period", "type": "int", "default": 20, "description": "Long MA period"},
         {"name": "lookback_days", "type": "int", "default": 5, "description": "Lookback days"},
     ],
+    recommended=True,
+    order=20,
 )
 class MACrossUpCondition(BaseCondition):
     """골든크로스 조건 (단기 MA가 장기 MA 상향 돌파)"""

--- a/screener/conditions/registry.py
+++ b/screener/conditions/registry.py
@@ -29,6 +29,8 @@ def register_condition(
     description: str = "",
     category: str = "",
     params: List[Dict[str, Any]] | None = None,
+    recommended: bool = False,
+    order: int = 0,
 ):
     """Decorator to register a condition class with its metadata."""
 
@@ -39,6 +41,8 @@ def register_condition(
             "description": description,
             "category": category,
             "params": params or [],
+            "recommended": recommended,
+            "order": order,
         }
         return cls
 

--- a/screener/conditions/rsi.py
+++ b/screener/conditions/rsi.py
@@ -30,9 +30,11 @@ def calculate_rsi(close: pd.Series, period: int = 14) -> pd.Series:
     description="RSI below threshold",
     category="rsi",
     params=[
-        {"name": "threshold", "type": "float", "default": 30, "description": "RSI threshold"},
+        {"name": "threshold", "type": "float", "default": 35, "description": "RSI threshold"},
         {"name": "period", "type": "int", "default": 14, "description": "RSI period"},
     ],
+    recommended=True,
+    order=40,
 )
 class RSIOversoldCondition(BaseCondition):
     """RSI 과매도 조건"""
@@ -158,10 +160,12 @@ class RSIOverboughtCondition(BaseCondition):
     description="RSI within range",
     category="rsi",
     params=[
-        {"name": "lower", "type": "float", "default": 30, "description": "Lower bound"},
+        {"name": "lower", "type": "float", "default": 50, "description": "Lower bound"},
         {"name": "upper", "type": "float", "default": 70, "description": "Upper bound"},
         {"name": "period", "type": "int", "default": 14, "description": "RSI period"},
     ],
+    recommended=True,
+    order=50,
 )
 class RSIRangeCondition(BaseCondition):
     """RSI 범위 조건"""

--- a/screener/conditions/volume.py
+++ b/screener/conditions/volume.py
@@ -67,9 +67,11 @@ class MinVolumeCondition(BaseCondition):
     description="Volume above moving average",
     category="volume",
     params=[
-        {"name": "multiplier", "type": "float", "default": 1.5, "description": "Avg multiplier"},
+        {"name": "multiplier", "type": "float", "default": 1.0, "description": "Avg multiplier"},
         {"name": "period", "type": "int", "default": 20, "description": "Average period"},
     ],
+    recommended=True,
+    order=70,
 )
 class VolumeAboveAvgCondition(BaseCondition):
     """평균 거래량 대비 조건"""
@@ -134,9 +136,11 @@ class VolumeAboveAvgCondition(BaseCondition):
     description="Sudden volume increase",
     category="volume",
     params=[
-        {"name": "multiplier", "type": "float", "default": 2.0, "description": "Spike multiplier"},
+        {"name": "multiplier", "type": "float", "default": 1.5, "description": "Spike multiplier"},
         {"name": "period", "type": "int", "default": 20, "description": "Average period"},
     ],
+    recommended=True,
+    order=60,
 )
 class VolumeSpikeCondition(BaseCondition):
     """거래량 급증 조건"""

--- a/tests/test_condition_registry_metadata.py
+++ b/tests/test_condition_registry_metadata.py
@@ -1,0 +1,190 @@
+"""
+Tests for Condition Registry Metadata (Issue #112)
+
+Verifies that:
+1. Recommended conditions have correct default param values in registry metadata.
+2. All conditions include 'recommended' and 'order' fields in metadata.
+3. The API service function get_available_conditions() exposes the new fields.
+"""
+
+import pytest
+
+# Import condition modules so they register themselves via @register_condition
+import screener.conditions.ma  # noqa: F401
+import screener.conditions.rsi  # noqa: F401
+import screener.conditions.volume  # noqa: F401
+import screener.conditions.accumulation  # noqa: F401
+
+from screener.conditions.registry import get_condition_metadata
+from api.services.strategy_service import get_available_conditions
+
+
+# Expected data for the 10 recommended conditions.
+# Each tuple: (key, param_name, expected_default, order)
+# For 'above_ma' there is no param default override to check,
+# so we only verify recommended=True and order.
+RECOMMENDED_DEFAULTS = [
+    ("ma_touch", "period", 120, 10),
+    ("ma_cross_up", "short_period", 5, 20),
+    ("ma_cross_up", "long_period", 20, 20),
+    ("rsi_oversold", "threshold", 35, 40),
+    ("rsi_range", "lower", 50, 50),
+    ("volume_spike", "multiplier", 1.5, 60),
+    ("volume_above_avg", "multiplier", 1.0, 70),
+    ("bollinger_width", "max_width_pct", 15.0, 80),
+    ("volume_below_avg", "multiplier", 1.0, 90),
+    ("price_flat", "max_range_pct", 10.0, 100),
+]
+
+RECOMMENDED_KEYS = [
+    "ma_touch",
+    "ma_cross_up",
+    "above_ma",
+    "rsi_oversold",
+    "rsi_range",
+    "volume_spike",
+    "volume_above_avg",
+    "bollinger_width",
+    "volume_below_avg",
+    "price_flat",
+]
+
+RECOMMENDED_ORDERS = {
+    "ma_touch": 10,
+    "ma_cross_up": 20,
+    "above_ma": 30,
+    "rsi_oversold": 40,
+    "rsi_range": 50,
+    "volume_spike": 60,
+    "volume_above_avg": 70,
+    "bollinger_width": 80,
+    "volume_below_avg": 90,
+    "price_flat": 100,
+}
+
+
+class TestRecommendedConditionsDefaults:
+    """Test that the 10 recommended conditions have correct param defaults
+    from the registry metadata (not the class __init__ defaults)."""
+
+    def test_recommended_conditions_defaults(self):
+        metadata = get_condition_metadata()
+
+        for key, param_name, expected_default, expected_order in RECOMMENDED_DEFAULTS:
+            assert key in metadata, f"Condition '{key}' not found in registry metadata"
+
+            meta = metadata[key]
+
+            # Verify recommended flag
+            assert meta["recommended"] is True, (
+                f"Condition '{key}' should be recommended=True"
+            )
+
+            # Verify order
+            assert meta["order"] == expected_order, (
+                f"Condition '{key}' order: expected {expected_order}, got {meta['order']}"
+            )
+
+            # Find the param by name and check its default
+            param_found = False
+            for param in meta["params"]:
+                if param["name"] == param_name:
+                    param_found = True
+                    assert param["default"] == expected_default, (
+                        f"Condition '{key}' param '{param_name}': "
+                        f"expected default={expected_default}, got {param['default']}"
+                    )
+                    break
+
+            assert param_found, (
+                f"Condition '{key}' missing param '{param_name}' in metadata"
+            )
+
+        # Also verify 'above_ma' is recommended with correct order,
+        # even though we have no specific param default override to check
+        assert "above_ma" in metadata
+        assert metadata["above_ma"]["recommended"] is True
+        assert metadata["above_ma"]["order"] == 30
+
+
+class TestMetadataHasRecommendedAndOrder:
+    """Verify that 'recommended' and 'order' keys exist in the metadata dict
+    for ALL registered conditions, not just recommended ones."""
+
+    def test_metadata_has_recommended_and_order(self):
+        metadata = get_condition_metadata()
+
+        assert len(metadata) > 0, "Registry metadata is empty; condition modules not loaded"
+
+        for key, meta in metadata.items():
+            assert "recommended" in meta, (
+                f"Condition '{key}' metadata missing 'recommended' field"
+            )
+            assert "order" in meta, (
+                f"Condition '{key}' metadata missing 'order' field"
+            )
+            assert isinstance(meta["recommended"], bool), (
+                f"Condition '{key}' 'recommended' should be bool, got {type(meta['recommended'])}"
+            )
+            assert isinstance(meta["order"], int), (
+                f"Condition '{key}' 'order' should be int, got {type(meta['order'])}"
+            )
+
+        # Verify that exactly the expected keys are marked as recommended
+        recommended_keys_actual = sorted(
+            k for k, m in metadata.items() if m["recommended"]
+        )
+        recommended_keys_expected = sorted(RECOMMENDED_KEYS)
+        assert recommended_keys_actual == recommended_keys_expected, (
+            f"Recommended keys mismatch.\n"
+            f"  Expected: {recommended_keys_expected}\n"
+            f"  Actual:   {recommended_keys_actual}"
+        )
+
+
+class TestGetAvailableConditionsIncludesNewFields:
+    """The API service function get_available_conditions() should include
+    'recommended' and 'order' in each ConditionInfo output."""
+
+    def test_get_available_conditions_includes_new_fields(self):
+        conditions = get_available_conditions()
+
+        assert len(conditions) > 0, "get_available_conditions() returned empty list"
+
+        for cond in conditions:
+            # ConditionInfo should have recommended and order attributes
+            assert hasattr(cond, "recommended"), (
+                f"ConditionInfo '{cond.key}' missing 'recommended' attribute"
+            )
+            assert hasattr(cond, "order"), (
+                f"ConditionInfo '{cond.key}' missing 'order' attribute"
+            )
+            assert isinstance(cond.recommended, bool), (
+                f"ConditionInfo '{cond.key}' recommended should be bool"
+            )
+            assert isinstance(cond.order, int), (
+                f"ConditionInfo '{cond.key}' order should be int"
+            )
+
+        # Build a lookup for quick assertions
+        cond_map = {c.key: c for c in conditions}
+
+        # Verify recommended conditions are correct in the API output
+        for key in RECOMMENDED_KEYS:
+            assert key in cond_map, (
+                f"Recommended condition '{key}' not in get_available_conditions() output"
+            )
+            assert cond_map[key].recommended is True, (
+                f"ConditionInfo '{key}' should have recommended=True"
+            )
+            assert cond_map[key].order == RECOMMENDED_ORDERS[key], (
+                f"ConditionInfo '{key}' order: "
+                f"expected {RECOMMENDED_ORDERS[key]}, got {cond_map[key].order}"
+            )
+
+        # Verify non-recommended conditions have recommended=False
+        for cond in conditions:
+            if cond.key not in RECOMMENDED_KEYS:
+                assert cond.recommended is False, (
+                    f"ConditionInfo '{cond.key}' should have recommended=False"
+                )

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -346,6 +346,7 @@
     "totalTrades": "Total ({count} trades)"
   },
   "conditions": {
+    "recommended": "REC",
     "categories": {
       "price": "Price",
       "volume": "Volume",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -346,6 +346,7 @@
     "totalTrades": "합계 ({count}건)"
   },
   "conditions": {
+    "recommended": "\ucd94\ucc9c",
     "categories": {
       "price": "가격",
       "volume": "거래량",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -337,6 +337,7 @@
     "totalTrades": "总计（{count} 笔交易）"
   },
   "conditions": {
+    "recommended": "\u63a8\u8350",
     "categories": {
       "price": "价格",
       "volume": "成交量",

--- a/web/src/components/strategy/NodePalette.tsx
+++ b/web/src/components/strategy/NodePalette.tsx
@@ -31,6 +31,7 @@ function DraggableItem({
   icon: Icon,
   color,
   conditionKey,
+  recommendedLabel,
 }: {
   type: string;
   label: string;
@@ -38,6 +39,7 @@ function DraggableItem({
   icon: React.ComponentType<{ className?: string }>;
   color: string;
   conditionKey?: string;
+  recommendedLabel?: string;
 }) {
   const onDragStart = (event: React.DragEvent) => {
     event.dataTransfer.setData('application/reactflow-type', type);
@@ -56,7 +58,14 @@ function DraggableItem({
       <GripVertical className="h-3 w-3 text-gray-300 dark:text-gray-600 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0" />
       <Icon className={`h-4 w-4 ${color} flex-shrink-0`} />
       <div className="min-w-0">
-        <div className="text-sm text-gray-700 dark:text-gray-200 font-medium truncate">{label}</div>
+        <div className="text-sm text-gray-700 dark:text-gray-200 font-medium truncate">
+          {label}
+          {recommendedLabel && (
+            <span className="ml-1.5 inline-flex items-center px-1 py-0 text-[9px] font-bold rounded bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400 align-middle">
+              {recommendedLabel}
+            </span>
+          )}
+        </div>
         {description && (
           <div className="text-[11px] text-gray-400 dark:text-gray-500 truncate">
             {description}
@@ -195,6 +204,7 @@ export default function NodePalette({ nodeCount }: NodePaletteProps) {
                         icon={Filter}
                         color="text-[#1313ec] dark:text-blue-400"
                         conditionKey={cond.key}
+                        recommendedLabel={cond.recommended ? tCond('recommended') : undefined}
                       />
                     ))}
                 </div>

--- a/web/src/contexts/ConditionsContext.tsx
+++ b/web/src/contexts/ConditionsContext.tsx
@@ -66,6 +66,13 @@ export function ConditionsProvider({ children }: { children: React.ReactNode }) 
           }
           grouped[c.category].push(c);
         }
+        for (const cat of Object.keys(grouped)) {
+          grouped[cat].sort((a, b) => {
+            if (a.recommended !== b.recommended) return a.recommended ? -1 : 1;
+            if (a.order !== b.order) return a.order - b.order;
+            return a.key.localeCompare(b.key);
+          });
+        }
         return grouped;
       },
       getDefaultParams: (key: string) => {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -222,6 +222,8 @@ export interface StrategyConditionInfo {
     default: unknown;
     description: string;
   }>;
+  recommended: boolean;
+  order: number;
 }
 
 export interface StrategyConditionsResponse {

--- a/web/src/lib/strategy/conditionRegistry.ts
+++ b/web/src/lib/strategy/conditionRegistry.ts
@@ -18,4 +18,6 @@ export interface ConditionMeta {
   description: string;
   category: string;
   params: ConditionParam[];
+  recommended: boolean;
+  order: number;
 }


### PR DESCRIPTION
## Summary
- Align 10 key condition defaults with real-world screening presets (`screener/presets.py`)
- Add `recommended` flag and `order` field to condition metadata for UI sorting and badge display
- Show REC/추천/推荐 badge on recommended conditions in NodePalette

## Changes

### Backend (screener + api)
- `@register_condition` decorator extended with `recommended: bool` and `order: int`
- 10 conditions updated: MA Touch (period 120), MA Cross Up (5/20), RSI Oversold (35), RSI Range (lower 50), Volume Spike (1.5), Volume Above Avg (1.0), Bollinger Width (15%), Volume Below Avg (1.0), Price Flat (10%)
- `ConditionInfo` schema, service, and router updated to propagate and sort by recommended-first

### Frontend (web)
- `StrategyConditionInfo` and `ConditionMeta` types extended
- `ConditionsContext` sorts within categories: recommended > order > key
- `NodePalette` shows amber REC badge on recommended conditions
- i18n: en/ko/zh `"recommended"` key added

### Tests
- `tests/test_condition_registry_metadata.py`: 3 tests verifying defaults, metadata fields, API propagation

## Test plan
- [x] `pytest tests/test_condition_registry_metadata.py -v` — 3/3 passed
- [x] `npx tsc --noEmit` — no new errors
- [x] API: `GET /api/strategy/conditions` returns 10 recommended conditions with correct defaults
- [x] UI: NodePalette shows REC badge, MA Touch defaults to period=120

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)