### PR TITLE
Replace hardcoded English strings in analysis popup with i18n

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -301,7 +301,14 @@
     "averagePrice": "Average Price",
     "periodReturn": "Period Return",
     "currentPriceAt": "Current price is at",
-    "ofRange": "of the range"
+    "ofRange": "of the range",
+    "loadingData": "Loading {ticker} data...",
+    "loadFailed": "Failed to Load Data",
+    "retry": "Retry",
+    "loadingConditions": "Loading conditions...",
+    "aiDescription": "AI-powered analysis with valuation score, risk assessment, and entry recommendation.",
+    "low": "Low",
+    "high": "High"
   },
   "backtest": {
     "title": "Backtest Strategy",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -301,7 +301,14 @@
     "averagePrice": "평균 가격",
     "periodReturn": "기간 수익률",
     "currentPriceAt": "현재 가격 위치",
-    "ofRange": "범위 중"
+    "ofRange": "범위 중",
+    "loadingData": "{ticker} 데이터 로딩 중...",
+    "loadFailed": "데이터 로드 실패",
+    "retry": "다시 시도",
+    "loadingConditions": "조건 로딩 중...",
+    "aiDescription": "밸류에이션 점수, 리스크 평가, 진입 추천을 포함한 AI 기반 분석입니다.",
+    "low": "최저",
+    "high": "최고"
   },
   "backtest": {
     "title": "전략 백테스트",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -292,7 +292,14 @@
     "averagePrice": "平均价格",
     "periodReturn": "区间收益",
     "currentPriceAt": "当前价格位于",
-    "ofRange": "区间的"
+    "ofRange": "区间的",
+    "loadingData": "正在加载 {ticker} 数据...",
+    "loadFailed": "数据加载失败",
+    "retry": "重试",
+    "loadingConditions": "正在加载条件...",
+    "aiDescription": "基于 AI 的分析，包含估值评分、风险评估和入场建议。",
+    "low": "最低",
+    "high": "最高"
   },
   "backtest": {
     "title": "策略回测",

--- a/web/src/app/[locale]/analysis/[ticker]/page.tsx
+++ b/web/src/app/[locale]/analysis/[ticker]/page.tsx
@@ -276,7 +276,7 @@ export default function TickerAnalysisPage() {
             <div className="flex flex-col items-center gap-3">
               <div className="animate-spin rounded-full h-10 w-10 border-3 border-[var(--color-primary)] border-t-transparent" />
               <span className="text-[var(--foreground-muted)]">
-                Loading {ticker.toUpperCase()} data...
+                {t('loadingData', { ticker: ticker.toUpperCase() })}
               </span>
             </div>
           </div>
@@ -289,7 +289,7 @@ export default function TickerAnalysisPage() {
           <div className="flex flex-col items-center">
             <BarChart3 className="h-12 w-12 text-red-500 mb-4" />
             <h3 className="text-lg font-medium text-[var(--foreground)]">
-              Failed to Load Data
+              {t('loadFailed')}
             </h3>
             <p className="mt-1 text-sm text-red-600 dark:text-red-400">
               {error}
@@ -301,7 +301,7 @@ export default function TickerAnalysisPage() {
               onClick={() => fetchData(selectedPeriod)}
             >
               <RefreshCw className="h-4 w-4 mr-2" />
-              Retry
+              {t('retry')}
             </Button>
           </div>
         </Card>
@@ -476,7 +476,7 @@ export default function TickerAnalysisPage() {
               {screeningLoading && (
                 <div className="flex items-center gap-3 py-4">
                   <div className="animate-spin rounded-full h-5 w-5 border-2 border-[var(--color-primary)] border-t-transparent" />
-                  <span className="text-[var(--foreground-muted)]">Loading conditions...</span>
+                  <span className="text-[var(--foreground-muted)]">{t('loadingConditions')}</span>
                 </div>
               )}
 
@@ -562,7 +562,7 @@ export default function TickerAnalysisPage() {
                 <div className="flex flex-col items-center gap-4 py-6">
                   <Brain className="h-10 w-10 text-[var(--foreground-muted)]" />
                   <p className="text-sm text-[var(--foreground-muted)] text-center">
-                    AI-powered analysis with valuation score, risk assessment, and entry recommendation.
+                    {t('aiDescription')}
                   </p>
                   <Button
                     variant="primary"
@@ -795,8 +795,8 @@ export default function TickerAnalysisPage() {
                   return (
                     <>
                       <div className="flex justify-between text-sm text-[var(--foreground-muted)]">
-                        <span>Low: ${periodLow.toFixed(2)}</span>
-                        <span>High: ${periodHigh.toFixed(2)}</span>
+                        <span>{t('low')}: ${periodLow.toFixed(2)}</span>
+                        <span>{t('high')}: ${periodHigh.toFixed(2)}</span>
                       </div>
                       <div className="relative h-3 rounded-full bg-gradient-to-r from-red-400 via-yellow-400 to-green-400">
                         <div


### PR DESCRIPTION
## Summary
- Add 7 missing i18n keys to `stockDetail` namespace in en/ko/zh locale files
- Replace all hardcoded English strings in `web/src/app/[locale]/analysis/[ticker]/page.tsx`

| String | Key |
|--------|-----|
| `Loading {ticker} data...` | `loadingData` |
| `Failed to Load Data` | `loadFailed` |
| `Retry` | `retry` |
| `Loading conditions...` | `loadingConditions` |
| `AI-powered analysis with...` | `aiDescription` |
| `Low:` | `low` |
| `High:` | `high` |

## Test plan
- [ ] Open analysis popup in KO locale → verify loading/error/AI text is Korean
- [ ] Open analysis popup in ZH locale → verify Chinese translations
- [ ] Open analysis popup in EN locale → verify English still works
- [ ] Check trading range section shows translated Low/High labels

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)