### PR TITLE
Polish node visual styling to match Stitch design (#123)

### DIFF
--- a/web/src/components/strategy/nodes/ConditionNode.tsx
+++ b/web/src/components/strategy/nodes/ConditionNode.tsx
@@ -46,14 +46,12 @@ function ConditionNode({ data, selected }: NodeProps) {
   // Check if condition has params configured
   const hasParams = nodeData.params && Object.keys(nodeData.params).length > 0;
 
-  // Build a concise value summary (e.g., "RSI < 30" or "Period: 20")
-  const valueSummary = nodeData.params
+  // Collect param entries for tag-style display
+  const paramEntries = nodeData.params
     ? Object.entries(nodeData.params)
         .filter(([, v]) => v !== null && v !== undefined)
-        .slice(0, 2)
-        .map(([k, v]) => `${String(k).replace(/_/g, ' ')}: ${v}`)
-        .join(' · ')
-    : '';
+        .slice(0, 3)
+    : [];
 
   const handleParamChange = useCallback(
     (name: string, value: unknown) => {
@@ -112,9 +110,9 @@ function ConditionNode({ data, selected }: NodeProps) {
 
   return (
     <div
-      className={`rounded-xl bg-white dark:bg-[#1e1e1f] border min-w-[220px] transition-shadow ${
+      className={`rounded-lg bg-white dark:bg-[#1e1e1f] border min-w-[220px] transition-shadow ${
         selected
-          ? 'border-[#1313ec] shadow-[0_0_0_1px_#1313ec] ring-1 ring-[#1313ec]/20'
+          ? 'border-2 border-[#1313ec] shadow-xl'
           : 'border-[#e1e3e5] dark:border-[#2e2e30] shadow-sm hover:shadow-md'
       }`}
     >
@@ -135,10 +133,10 @@ function ConditionNode({ data, selected }: NodeProps) {
       )}
 
       {/* Header bar */}
-      <div className="flex items-center justify-between px-3 py-1.5 rounded-t-[10px] bg-blue-50 dark:bg-blue-500/10 border-b border-blue-100 dark:border-blue-500/20">
+      <div className="flex items-center justify-between px-3 py-2 rounded-t-[7px] bg-blue-50 dark:bg-blue-500/10 border-b border-[#e1e3e5] dark:border-[#2e2e30]">
         <div className="flex items-center gap-1.5">
-          <Filter className="h-3 w-3 text-[#1313ec] dark:text-blue-400" />
-          <span className="text-[10px] font-semibold text-[#1313ec] dark:text-blue-400 uppercase tracking-wider">
+          <Filter className="h-3.5 w-3.5 text-[#1313ec] dark:text-blue-400" />
+          <span className="text-[11px] font-bold text-[#1313ec] dark:text-blue-400 uppercase tracking-wider">
             {t('screeningBadge')}
           </span>
         </div>
@@ -151,12 +149,21 @@ function ConditionNode({ data, selected }: NodeProps) {
 
       {/* Content */}
       <div className="px-3 py-2.5">
-        <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+        <div className="text-[13px] font-bold text-gray-900 dark:text-gray-100">
           {label}
         </div>
-        {valueSummary && (
-          <div className="mt-1.5 text-[11px] text-gray-500 dark:text-gray-400 font-mono bg-gray-50 dark:bg-gray-800/50 px-2 py-1 rounded-md">
-            {valueSummary}
+        {paramEntries.length > 0 && (
+          <div className="mt-2 flex items-center gap-1.5 flex-wrap">
+            {paramEntries.map(([k, v]) => (
+              <span key={k} className="inline-flex items-center gap-1">
+                <span className="px-1.5 py-0.5 bg-slate-100 dark:bg-slate-800 rounded text-[10px] text-slate-500">
+                  {String(k).replace(/_/g, ' ')}
+                </span>
+                <span className="px-1.5 py-0.5 bg-blue-50 dark:bg-blue-900/20 text-[#1313ec] dark:text-blue-400 rounded text-[10px] font-bold">
+                  {String(v)}
+                </span>
+              </span>
+            ))}
           </div>
         )}
       </div>

--- a/web/src/components/strategy/nodes/GroupNode.tsx
+++ b/web/src/components/strategy/nodes/GroupNode.tsx
@@ -90,7 +90,7 @@ function GroupNode({ id, data, selected }: NodeProps) {
     <div
       className={`relative rounded-2xl border ${style.border} ${style.bg} transition-shadow ${
         selected
-          ? 'shadow-[0_0_0_2px_rgba(19,19,236,0.3)] ring-2 ring-[#1313ec]/10'
+          ? 'shadow-xl ring-2 ring-[#1313ec]/20'
           : 'shadow-sm hover:shadow-md'
       }`}
       style={{ width: '100%', height: '100%', minWidth: 380, minHeight: 220 }}

--- a/web/src/components/strategy/nodes/OutputNode.tsx
+++ b/web/src/components/strategy/nodes/OutputNode.tsx
@@ -21,9 +21,9 @@ function OutputNode({ data, selected }: NodeProps) {
 
   return (
     <div
-      className={`rounded-lg bg-white dark:bg-[#1e1e1f] border px-4 py-3 min-w-[180px] text-center transition-shadow ${
+      className={`rounded-lg bg-white dark:bg-[#1e1e1f] border min-w-[180px] transition-shadow ${
         selected
-          ? 'border-[#1313ec] shadow-[0_0_0_1px_#1313ec] ring-1 ring-[#1313ec]/20'
+          ? 'border-2 border-[#1313ec] shadow-xl'
           : 'border-[#e1e3e5] dark:border-[#2e2e30] shadow-sm hover:shadow-md'
       }`}
     >
@@ -32,24 +32,28 @@ function OutputNode({ data, selected }: NodeProps) {
         position={Position.Left}
         className="!w-3.5 !h-3.5 !bg-[#1313ec] !border-2 !border-white dark:!border-[#1e1e1f] !-left-[7px] hover:!scale-125 !transition-transform"
       />
-      <div className="flex items-center justify-center gap-2 mb-1">
-        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-orange-50 dark:bg-orange-500/10 text-orange-600 dark:text-orange-400 text-[10px] font-semibold uppercase tracking-wider">
-          <Flag className="h-3 w-3" />
+      {/* Header bar */}
+      <div className="px-3 py-2 border-b border-[#e1e3e5] dark:border-[#2e2e30] bg-[#1313ec]/5 rounded-t-[7px] flex items-center gap-2">
+        <Flag className="h-3.5 w-3.5 text-[#1313ec] dark:text-blue-400" />
+        <span className="text-[11px] font-bold text-[#1313ec] dark:text-blue-400 uppercase tracking-wider">
           {t('outputBadge')}
         </span>
       </div>
-      <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">
-        {t('finalSelection')}
+      {/* Content */}
+      <div className="p-3">
+        <div className="text-[13px] font-bold text-gray-900 dark:text-gray-100">
+          {t('finalSelection')}
+        </div>
+        {resultCount !== undefined && resultCount !== null ? (
+          <div className="mt-1.5 text-xs text-slate-500 dark:text-slate-400">
+            {t('estimatedItems', { count: resultCount })}
+          </div>
+        ) : (
+          <div className="mt-1 text-xs text-slate-400 dark:text-slate-500">
+            {t('connectAndRun')}
+          </div>
+        )}
       </div>
-      {resultCount !== undefined && resultCount !== null ? (
-        <div className="mt-1.5 text-xs text-gray-500 dark:text-gray-400">
-          {t('estimatedItems', { count: resultCount })}
-        </div>
-      ) : (
-        <div className="mt-1 text-xs text-gray-400 dark:text-gray-500">
-          {t('connectAndRun')}
-        </div>
-      )}
 
       {/* Inline info popup (read-only) */}
       <NodeEditPopup selected={!!selected} onDelete={handleDelete}>

--- a/web/src/components/strategy/nodes/UniverseNode.tsx
+++ b/web/src/components/strategy/nodes/UniverseNode.tsx
@@ -29,23 +29,27 @@ function UniverseNode({ data, selected }: NodeProps) {
 
   return (
     <div
-      className={`rounded-lg bg-white dark:bg-[#1e1e1f] border px-4 py-3 min-w-[200px] transition-shadow ${
+      className={`rounded-lg bg-white dark:bg-[#1e1e1f] border min-w-[200px] transition-shadow ${
         selected
-          ? 'border-[#1313ec] shadow-[0_0_0_1px_#1313ec] ring-1 ring-[#1313ec]/20'
+          ? 'border-2 border-[#1313ec] shadow-xl'
           : 'border-[#e1e3e5] dark:border-[#2e2e30] shadow-sm hover:shadow-md'
       }`}
     >
-      <div className="flex items-center gap-2 mb-2">
-        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-emerald-50 dark:bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 text-[10px] font-semibold uppercase tracking-wider">
-          <Globe className="h-3 w-3" />
+      {/* Header bar */}
+      <div className="px-3 py-2 border-b border-[#e1e3e5] dark:border-[#2e2e30] bg-slate-50 dark:bg-slate-800/50 rounded-t-[7px] flex items-center gap-2">
+        <Globe className="h-3.5 w-3.5 text-[#1313ec] dark:text-blue-400" />
+        <span className="text-[11px] font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider">
           {t('inputBadge')}
         </span>
       </div>
-      <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">
-        {t('marketSelection')}
-      </div>
-      <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-        {t('composite', { universe: nodeData.universe || 'KOSPI' })}
+      {/* Content */}
+      <div className="p-3">
+        <div className="text-[13px] font-bold text-gray-900 dark:text-gray-100">
+          {t('marketSelection')}
+        </div>
+        <div className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+          {t('composite', { universe: nodeData.universe || 'KOSPI' })}
+        </div>
       </div>
       <Handle
         type="source"


### PR DESCRIPTION
## Summary
- **UniverseNode**: green pill badge → header bar pattern (slate bg + blue Globe icon + "INPUT")
- **ConditionNode**: `rounded-xl` → `rounded-lg`, mono param box → inline tag pills, simplified selected border
- **OutputNode**: orange pill badge → blue header bar (`bg-[#1313ec]/5` + Flag icon + "OUTPUT")
- **GroupNode**: simplified selected shadow for consistency

## Test plan
- [ ] 전략 빌더에서 각 노드 타입 (Input, Condition, Output, Group) 헤더 바 스타일 확인
- [ ] 노드 선택 시 `border-2 border-primary shadow-xl` 일관된 스타일 확인
- [ ] ConditionNode 파라미터 태그 pill 정상 표시 확인
- [ ] 다크모드 전환 시 정상 동작 확인

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)