### PR TITLE
Remove hardcoded 2025 date fallback in pykrx data fetcher

### DIFF
--- a/screener/stock_screener.py
+++ b/screener/stock_screener.py
@@ -228,16 +228,10 @@ class StockScreener:
             # 티커에서 종목코드 추출 (005930.KS -> 005930)
             code = ticker.split('.')[0]
 
-            # 최근 거래일 찾기 (오늘 날짜가 미래일 수 있으므로)
-            # 가장 최근 유효한 날짜를 찾기 위해 과거 날짜부터 시도
+            # 최근 거래일 찾기
             from datetime import date
             today = date.today()
-
-            # 시스템 날짜가 미래인 경우 2025년 1월로 설정
-            if today.year > 2025:
-                end_date = date(2025, 1, 24)  # 유효한 거래일
-            else:
-                end_date = today
+            end_date = today
 
             start_date = end_date - timedelta(days=days * 2)
 


### PR DESCRIPTION
## Summary
- Remove the `today.year > 2025` guard in `screener/stock_screener.py` that forced pykrx to use `date(2025, 1, 24)` as end_date
- pykrx handles 2026 dates correctly (verified: Samsung 274 rows, KOSPI 950 stocks)

## Test plan
- [x] Verified `StockScreener.get_universe('KOSPI')` returns 950 stocks (was 98)
- [x] Verified `_fetch_data_pykrx` returns recent data for Samsung (005930.KS)
- [x] Codex code review: LGTM

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)