### PR TITLE
Add sector/industry data lookup and strategy node support (#136)

### DIFF
--- a/api/routers/strategy.py
+++ b/api/routers/strategy.py
@@ -12,6 +12,8 @@ from api.schemas.strategy import (
     ConditionsListResponse,
     SavedStrategiesListResponse,
     SavedStrategyResponse,
+    SectorInfo,
+    SectorListResponse,
     StrategyExecuteRequest,
     StrategyExecuteResponse,
     StrategySaveRequest,
@@ -22,6 +24,7 @@ from api.services.strategy_service import (
     execute_strategy,
     get_available_conditions,
 )
+from screener.sector_fetcher import get_sector_fetcher
 
 logger = logging.getLogger(__name__)
 
@@ -150,6 +153,37 @@ async def delete_saved_strategy(strategy_id: str) -> None:
             status_code=500,
             detail=f"Failed to delete strategy: {str(e)}",
         )
+
+
+@router.get(
+    "/sectors",
+    response_model=SectorListResponse,
+    summary="Get available sectors",
+    description="Return all available sectors for a given market with stock counts.",
+)
+async def list_sectors(market: str = "KOSPI") -> SectorListResponse:
+    """Return available sectors for the node palette."""
+    market_upper = market.upper()
+    if market_upper not in ("KOSPI", "KOSDAQ"):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Sector listing is only supported for KOSPI and KOSDAQ, got: {market}",
+        )
+    try:
+        fetcher = get_sector_fetcher()
+        sector_counts = fetcher.get_sector_counts(market_upper)
+        sectors = [
+            SectorInfo(name=name, stock_count=count)
+            for name, count in sorted(sector_counts.items())
+        ]
+        return SectorListResponse(
+            market=market_upper,
+            sectors=sectors,
+            total_sectors=len(sectors),
+        )
+    except Exception as e:
+        logger.exception("Failed to fetch sectors for %s", market)
+        raise HTTPException(status_code=500, detail="Failed to fetch sector data")
 
 
 @router.post(

--- a/api/schemas/strategy.py
+++ b/api/schemas/strategy.py
@@ -13,7 +13,7 @@ class StrategyNodeData(BaseModel):
 
     node_type: str = Field(
         ...,
-        description="Type of node: 'universe', 'condition', 'logic', 'output'",
+        description="Type of node: 'universe', 'sector', 'condition', 'logic', 'output'",
     )
     condition_type: Optional[str] = Field(
         None, description="Condition class key (e.g., 'rsi_oversold')"
@@ -26,6 +26,9 @@ class StrategyNodeData(BaseModel):
     )
     universe: Optional[str] = Field(
         None, description="Universe name (e.g., 'KOSPI', 'SP500')"
+    )
+    sector: Optional[str] = Field(
+        None, description="Sector name for sector node filtering (e.g., '전기전자')"
     )
     child_node_ids: Optional[List[str]] = Field(
         None, description="Child node IDs for group/logic nodes"
@@ -158,3 +161,18 @@ class SavedStrategiesListResponse(BaseModel):
 
     strategies: List[SavedStrategyResponse]
     total_count: int
+
+
+class SectorInfo(BaseModel):
+    """Information about a market sector."""
+
+    name: str = Field(description="Sector name (e.g., '전기전자')")
+    stock_count: int = Field(description="Number of stocks in this sector")
+
+
+class SectorListResponse(BaseModel):
+    """Response listing available sectors for a market."""
+
+    market: str
+    sectors: List[SectorInfo]
+    total_sectors: int

--- a/api/services/strategy_service.py
+++ b/api/services/strategy_service.py
@@ -23,6 +23,7 @@ from api.schemas.strategy import (
 from screener.conditions import BaseCondition, AndCondition, OrCondition, NotCondition
 from screener.conditions.registry import get_condition_class_map, get_condition_metadata
 from screener import StockScreener
+from screener.sector_fetcher import get_sector_fetcher
 from api.services.screening_service import ScreeningService
 
 logger = logging.getLogger(__name__)
@@ -324,6 +325,9 @@ def build_conditions_from_graph(graph: StrategyGraph) -> tuple[List[BaseConditio
         if node.data.node_type == "universe":
             return None
 
+        if node.data.node_type == "sector":
+            return None  # Sector filters tickers, not conditions
+
         if node.data.node_type == "condition":
             if not node.data.condition_type:
                 raise ValueError(f"Condition node {node_id} has no condition_type")
@@ -467,6 +471,15 @@ def build_flat_conditions_from_graph(
             }
             return []
 
+        if node.data.node_type == "sector":
+            node_meta[node_id] = {
+                "node_type": "sector",
+                "label": node.data.sector or "Sector",
+                "leaf_indices": [],
+                "operator": None,
+            }
+            return []
+
         if node.data.node_type == "condition":
             if not node.data.condition_type:
                 raise ValueError(f"Condition node {node_id} has no condition_type")
@@ -581,6 +594,12 @@ def _compute_node_survivors(
     all_indices = set(range(len(all_results)))
 
     if node.data.node_type == "universe":
+        cache[node_id] = all_indices
+        return all_indices
+
+    if node.data.node_type == "sector":
+        # Tickers are already pre-filtered by sector in execute_strategy,
+        # so all results pass the sector node.
         cache[node_id] = all_indices
         return all_indices
 
@@ -701,6 +720,32 @@ def execute_strategy(
     Returns:
         Dict with results, counts, universe, conditions used, and node_results
     """
+    # Validate sector nodes early (only 1 allowed, must be connected)
+    sector_nodes = [n for n in graph.nodes if n.data.node_type == "sector"]
+    if len(sector_nodes) > 1:
+        raise ValueError("Only one sector node is allowed per strategy graph")
+    if sector_nodes:
+        sector_name_raw = (sector_nodes[0].data.sector or "").strip()
+        if not sector_name_raw:
+            raise ValueError("Sector node must have a sector name")
+        # Only apply if sector node is reachable from the output node
+        _incoming = {n.id: [] for n in graph.nodes}
+        for edge in graph.edges:
+            if edge.target in _incoming:
+                _incoming[edge.target].append(edge.source)
+        _output = [n for n in graph.nodes if n.data.node_type == "output"]
+        reachable: set[str] = set()
+        if _output:
+            stack = [_output[0].id]
+            while stack:
+                nid = stack.pop()
+                if nid in reachable:
+                    continue
+                reachable.add(nid)
+                stack.extend(_incoming.get(nid, []))
+        if sector_nodes[0].id not in reachable:
+            sector_nodes = []  # Disconnected sector node — ignore
+
     leaf_conditions, graph_universe, node_meta = build_flat_conditions_from_graph(graph)
 
     if not leaf_conditions:
@@ -712,6 +757,17 @@ def execute_strategy(
     screening_service = ScreeningService()
     tickers = screening_service._get_universe_tickers(universe)
     total_count = len(tickers)
+
+    # Apply sector filtering (already validated above)
+    if sector_nodes:
+        sector_name = (sector_nodes[0].data.sector or "").strip()
+        fetcher = get_sector_fetcher()
+        sector_tickers = set(fetcher.get_sector_tickers(universe, sector_name))
+        tickers = [t for t in tickers if t in sector_tickers]
+        logger.info(
+            "Sector filter '%s': %d -> %d tickers",
+            sector_name, total_count, len(tickers),
+        )
 
     # Create screener with flat leaf conditions and run with return_all=True
     screener = StockScreener(

--- a/screener/sector_fetcher.py
+++ b/screener/sector_fetcher.py
@@ -1,0 +1,189 @@
+"""
+한국 주식 시장 업종 분류 수집 모듈
+- pykrx를 이용해 코스피/코스닥 업종 정보를 조회
+"""
+
+import logging
+from datetime import datetime, timedelta
+from typing import Dict, List, Optional, Tuple
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+class SectorFetcher:
+    """한국 시장 업종 분류 수집기"""
+
+    CACHE_TTL = timedelta(days=1)
+    SUPPORTED_MARKETS = {"KOSPI": ".KS", "KOSDAQ": ".KQ"}
+
+    def __init__(self):
+        # {market: (fetched_at, dataframe)}
+        self._cache: Dict[str, Tuple[datetime, pd.DataFrame]] = {}
+
+    def get_sectors(self, market: str = "KOSPI") -> List[str]:
+        """
+        시장의 업종명 목록을 정렬하여 반환
+
+        Args:
+            market: KOSPI 또는 KOSDAQ
+
+        Returns:
+            정렬된 업종명 리스트
+        """
+        normalized_market = self._normalize_market(market)
+        df = self._get_market_classifications(normalized_market)
+        if df.empty:
+            return []
+
+        sectors = sorted(df["업종명"].dropna().astype(str).unique().tolist())
+        return sectors
+
+    def get_sector_tickers(self, market: str, sector_name: str) -> List[str]:
+        """
+        특정 업종에 속한 티커 목록 반환
+
+        Args:
+            market: KOSPI 또는 KOSDAQ
+            sector_name: 업종명
+
+        Returns:
+            접미사(.KS/.KQ)가 포함된 티커 목록
+        """
+        normalized_market = self._normalize_market(market)
+        df = self._get_market_classifications(normalized_market)
+        if df.empty or not sector_name:
+            return []
+
+        suffix = self.SUPPORTED_MARKETS[normalized_market]
+        filtered = df[df["업종명"] == sector_name]
+        tickers = sorted([f"{code}{suffix}" for code in filtered.index.tolist()])
+        return tickers
+
+    def get_sector_counts(self, market: str = "KOSPI") -> Dict[str, int]:
+        """
+        시장의 업종별 종목 수를 한 번에 계산하여 반환
+
+        Args:
+            market: KOSPI 또는 KOSDAQ
+
+        Returns:
+            {업종명: 종목수} 딕셔너리
+        """
+        normalized_market = self._normalize_market(market)
+        df = self._get_market_classifications(normalized_market)
+        if df.empty:
+            return {}
+
+        counts = df.groupby("업종명").size()
+        return {str(name): int(count) for name, count in counts.items()}
+
+    def get_all_sector_classifications(self, market: str = "KOSPI") -> Dict[str, str]:
+        """
+        시장 전체 종목의 업종 매핑 반환
+
+        Args:
+            market: KOSPI 또는 KOSDAQ
+
+        Returns:
+            {티커(.KS/.KQ 포함): 업종명} 딕셔너리
+        """
+        normalized_market = self._normalize_market(market)
+        df = self._get_market_classifications(normalized_market)
+        if df.empty:
+            return {}
+
+        suffix = self.SUPPORTED_MARKETS[normalized_market]
+        result: Dict[str, str] = {}
+        for code, row in df.iterrows():
+            sector_name = row.get("업종명")
+            if pd.notna(sector_name):
+                result[f"{code}{suffix}"] = str(sector_name)
+
+        return result
+
+    def _get_market_classifications(self, market: str) -> pd.DataFrame:
+        """캐시 확인 후 업종 데이터 반환"""
+        cached = self._cache.get(market)
+        if cached is not None:
+            cached_at, cached_df = cached
+            if datetime.now() - cached_at < self.CACHE_TTL:
+                logger.info(f"{market} 업종 데이터 캐시 사용")
+                return cached_df.copy()
+
+            logger.info(f"{market} 업종 데이터 캐시 만료")
+
+        df = self._fetch_from_pykrx(market)
+        if not df.empty:
+            self._cache[market] = (datetime.now(), df.copy())
+            logger.info(f"{market} 업종 데이터 {len(df)}건 캐시 저장")
+        return df
+
+    def _fetch_from_pykrx(self, market: str) -> pd.DataFrame:
+        """
+        pykrx에서 업종 분류 데이터 조회
+        - 오늘부터 최대 11일 전까지 역순 조회 (휴장일 대응)
+        """
+        try:
+            from pykrx import stock
+        except ImportError:
+            logger.warning("pykrx가 설치되지 않음")
+            return pd.DataFrame()
+
+        for days_ago in range(0, 12):
+            target_date = datetime.now() - timedelta(days=days_ago)
+            date_str = target_date.strftime("%Y%m%d")
+
+            try:
+                df = stock.get_market_sector_classifications(date_str, market=market)
+                if df is None or df.empty:
+                    continue
+
+                normalized_df = df.copy()
+                normalized_df.index = normalized_df.index.astype(str).str.zfill(6)
+                logger.info(f"{market} 업종 데이터 조회 성공: {date_str}, {len(normalized_df)}건")
+                return normalized_df
+            except Exception as e:
+                logger.warning(f"{market} 업종 조회 실패 ({date_str}): {e}")
+
+        logger.error(f"{market} 업종 데이터를 최근 11일 내에서 찾지 못함")
+        return pd.DataFrame()
+
+    def _normalize_market(self, market: str) -> str:
+        """지원 시장명 검증 및 정규화"""
+        normalized_market = (market or "").upper().strip()
+        if normalized_market not in self.SUPPORTED_MARKETS:
+            raise ValueError(f"지원하지 않는 시장입니다: {market}. KOSPI/KOSDAQ만 지원합니다.")
+        return normalized_market
+
+
+_sector_fetcher: Optional[SectorFetcher] = None
+
+
+def get_sector_fetcher() -> SectorFetcher:
+    """SectorFetcher 싱글턴 반환"""
+    global _sector_fetcher
+    if _sector_fetcher is None:
+        _sector_fetcher = SectorFetcher()
+    return _sector_fetcher
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+
+    fetcher = get_sector_fetcher()
+
+    for market_name in ["KOSPI", "KOSDAQ"]:
+        try:
+            sectors = fetcher.get_sectors(market_name)
+            print(f"\n[{market_name}] 업종 수: {len(sectors)}")
+            print(f"상위 10개 업종: {sectors[:10]}")
+
+            if sectors:
+                first_sector = sectors[0]
+                tickers = fetcher.get_sector_tickers(market_name, first_sector)
+                print(f"'{first_sector}' 종목 수: {len(tickers)}")
+                print(f"샘플 10개: {tickers[:10]}")
+        except Exception as e:
+            logger.error(f"{market_name} 테스트 실패: {e}")


### PR DESCRIPTION
## Summary
- Add `screener/sector_fetcher.py`: pykrx-based sector classification fetcher with 1-day in-memory cache for KOSPI (26 sectors) and KOSDAQ (24 sectors)
- Add `GET /api/strategy/sectors?market=KOSPI` endpoint returning sector names with stock counts
- Extend strategy graph schema with `sector` node_type and `sector` field in `StrategyNodeData`
- Integrate sector filtering in strategy execution: Universe → Sector → Conditions → Output flow

## Key design decisions
- Sector node acts as a pre-filter on universe tickers, not as a condition
- Only 1 sector node per graph (validated at execution time)
- Disconnected sector nodes (not reachable from output) are ignored
- Korean markets only (KOSPI/KOSDAQ) via pykrx; US sector support is deferred

## Test plan
- [x] Verify KOSPI returns 26 sectors, KOSDAQ returns 24 sectors
- [x] Verify `get_sector_counts()` returns correct stock counts per sector
- [x] Verify multi-sector node validation raises ValueError
- [x] Verify empty/whitespace sector name validation raises ValueError
- [x] Verify disconnected sector node is ignored (total=950 for KOSPI)
- [x] Verify all module imports work correctly
- [ ] Frontend: Add Sector node to canvas (follow-up: #137)

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)