### PR TITLE
Fix edge count display and enable group node connections (#146)

### DIFF
--- a/web/src/app/[locale]/strategy/page.tsx
+++ b/web/src/app/[locale]/strategy/page.tsx
@@ -200,31 +200,31 @@ function StrategyPageInner() {
       );
       if (sourceAlreadyConnected || targetAlreadyConnected) return false;
 
-      if (sourceType === 'universeNode') {
-        return targetType === 'conditionNode';
-      }
+      // Allowed target types per source type
+      const allowedTargets: Record<string, string[]> = {
+        universeNode: ['conditionNode', 'groupNode'],
+        conditionNode: ['conditionNode', 'groupNode', 'outputNode'],
+        groupNode: ['conditionNode', 'groupNode', 'outputNode'],
+      };
 
-      if (sourceType === 'conditionNode') {
-        if (targetType !== 'conditionNode' && targetType !== 'outputNode') return false;
+      const allowed = allowedTargets[sourceType!];
+      if (!allowed || !allowed.includes(targetType!)) return false;
 
-        // Prevent cycles: check if target can already reach source via existing edges
-        const visited = new Set<string>();
-        const queue = [target];
-        while (queue.length > 0) {
-          const current = queue.pop()!;
-          if (current === source) return false; // cycle detected
-          if (visited.has(current)) continue;
-          visited.add(current);
-          for (const edge of activeEdges) {
-            if (edge.source === current) {
-              queue.push(edge.target);
-            }
+      // Prevent cycles: check if target can already reach source via existing edges
+      const visited = new Set<string>();
+      const queue = [target];
+      while (queue.length > 0) {
+        const current = queue.pop()!;
+        if (current === source) return false; // cycle detected
+        if (visited.has(current)) continue;
+        visited.add(current);
+        for (const edge of activeEdges) {
+          if (edge.source === current) {
+            queue.push(edge.target);
           }
         }
-        return true;
       }
-
-      return false;
+      return true;
     },
     [nodes, edges]
   );

--- a/web/src/components/strategy/edges/LabeledEdge.tsx
+++ b/web/src/components/strategy/edges/LabeledEdge.tsx
@@ -5,7 +5,7 @@ import {
   BaseEdge,
   EdgeLabelRenderer,
   getSmoothStepPath,
-  useReactFlow,
+  useNodesData,
   type EdgeProps,
 } from '@xyflow/react';
 import { Eye } from 'lucide-react';
@@ -251,7 +251,6 @@ function LabeledEdge({
   data,
 }: EdgeProps) {
   const t = useTranslations('strategy');
-  const { getNode } = useReactFlow();
   const [showStockList, setShowStockList] = useState(false);
 
   const [edgePath, labelX, labelY] = getSmoothStepPath({
@@ -265,9 +264,9 @@ function LabeledEdge({
 
   const label = (data as Record<string, unknown>)?.label as string | undefined;
 
-  // Get source node's intermediate result for edge count badge
-  const sourceNode = getNode(source);
-  const sourceData = sourceNode?.data as unknown as StrategyNodeData | undefined;
+  // Reactively subscribe to source node data so edge re-renders when results arrive
+  const sourceNodeData = useNodesData(source);
+  const sourceData = sourceNodeData?.data as unknown as StrategyNodeData | undefined;
   const intermediateResult = sourceData?.intermediateResult;
   const stockCount = intermediateResult?.stock_count;
 


### PR DESCRIPTION
## Summary
- **Edge count bug**: Replace `getNode()` with reactive `useNodesData()` in LabeledEdge so stock counts appear immediately after Deploy (not only after clicking a node)
- **Group node connections**: Add `groupNode` to `isValidConnection` allowed targets — condition nodes can now connect to/from AND/OR/NOT nodes

## Test plan
- [ ] Deploy 후 엣지 카운트 즉시 표시 확인
- [ ] Condition → AND 노드 연결 가능 확인
- [ ] AND 노드 → Output 연결 가능 확인
- [ ] 순환 연결 방지 정상 동작 확인

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)