### PR TITLE
Split analysis page: move reports to /reports (#140)

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -30,6 +30,7 @@
     "strategy": "Strategy",
     "portfolio": "Portfolio",
     "analysis": "Analysis",
+    "reports": "Reports",
     "settings": "Settings",
     "openSidebar": "Open sidebar",
     "closeSidebar": "Close sidebar",
@@ -265,7 +266,12 @@
     "selectTickerDesc": "Search for a stock above or click one of the popular tickers",
     "technicalIndicators": "Technical Indicators",
     "recentReports": "Recent Analysis Reports",
-    "runScreeningForReports": "Run a screening to generate reports"
+    "runScreeningForReports": "Run a screening to generate reports",
+    "retry": "Retry"
+  },
+  "reports": {
+    "title": "Analysis Reports",
+    "subtitle": "View past analysis reports and AI-powered stock insights"
   },
   "stockDetail": {
     "financialOverview": "Financial Overview",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -30,6 +30,7 @@
     "strategy": "전략",
     "portfolio": "포트폴리오",
     "analysis": "분석",
+    "reports": "리포트",
     "settings": "설정",
     "openSidebar": "사이드바 열기",
     "closeSidebar": "사이드바 닫기",
@@ -265,7 +266,12 @@
     "selectTickerDesc": "위에서 종목을 검색하거나 인기 종목을 클릭하세요",
     "technicalIndicators": "기술적 지표",
     "recentReports": "최근 분석 리포트",
-    "runScreeningForReports": "스크리닝을 실행하여 리포트를 생성하세요"
+    "runScreeningForReports": "스크리닝을 실행하여 리포트를 생성하세요",
+    "retry": "재시도"
+  },
+  "reports": {
+    "title": "분석 리포트",
+    "subtitle": "과거 분석 리포트와 AI 종목 인사이트 보기"
   },
   "stockDetail": {
     "financialOverview": "재무 개요",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -30,6 +30,7 @@
     "strategy": "策略",
     "portfolio": "投资组合",
     "analysis": "分析",
+    "reports": "报告",
     "settings": "设置",
     "openSidebar": "打开侧边栏",
     "closeSidebar": "关闭侧边栏",
@@ -259,7 +260,12 @@
     "selectTickerDesc": "在上方搜索股票，或点击热门代码之一",
     "technicalIndicators": "技术指标",
     "recentReports": "最近分析报告",
-    "runScreeningForReports": "运行筛选以生成报告"
+    "runScreeningForReports": "运行筛选以生成报告",
+    "retry": "重试"
+  },
+  "reports": {
+    "title": "分析报告",
+    "subtitle": "查看历史分析报告和AI股票洞察"
   },
   "stockDetail": {
     "financialOverview": "财务概览",

--- a/web/src/app/[locale]/analysis/page.tsx
+++ b/web/src/app/[locale]/analysis/page.tsx
@@ -3,16 +3,17 @@
 import { useState, useCallback, useEffect } from 'react';
 import { Search, BarChart3, X, ArrowRight } from 'lucide-react';
 import Link from 'next/link';
+import { useTranslations } from 'next-intl';
 import { Card, Button } from '@/components/ui';
 import { CandleChart, IndicatorPanel } from '@/components/charts';
-import { ReportList } from '@/components/analysis';
 import { getTickerAnalysis, searchTickers } from '@/lib/api';
 import type { TickerAnalysis } from '@/lib/types';
 
 /**
- * Main analysis page with ticker search, charts, and reports
+ * Main analysis page with ticker search, charts, and indicators.
  */
 export default function AnalysisPage() {
+  const t = useTranslations('analysis');
 
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState<
@@ -81,10 +82,10 @@ export default function AnalysisPage() {
       {/* Page Header */}
       <div>
         <h1 className="text-2xl font-bold text-[var(--foreground)]">
-          Charts & Analysis
+          {t('title')}
         </h1>
         <p className="mt-1 text-[var(--foreground-muted)]">
-          Technical analysis with interactive charts and indicators
+          {t('subtitle')}
         </p>
       </div>
 
@@ -99,7 +100,7 @@ export default function AnalysisPage() {
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
                 onFocus={() => searchResults.length > 0 && setShowResults(true)}
-                placeholder="Search ticker or company name..."
+                placeholder={t('searchPlaceholder')}
                 className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] py-2.5 pl-10 pr-4 text-[var(--foreground)] placeholder:text-[var(--foreground-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)] focus:border-transparent"
               />
               {isSearching && (
@@ -152,7 +153,7 @@ export default function AnalysisPage() {
         {/* Quick ticker buttons */}
         <div className="mt-4 flex flex-wrap gap-2">
           <span className="text-sm text-[var(--foreground-muted)] mr-2">
-            Popular:
+            {t('popular')}:
           </span>
           {['AAPL', 'MSFT', 'GOOGL', 'AMZN', 'NVDA', 'TSLA'].map((ticker) => (
             <button
@@ -206,7 +207,7 @@ export default function AnalysisPage() {
                 href={`/analysis/${selectedTicker}`}
                 className="flex items-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--background-secondary)] px-4 py-2 text-sm font-medium text-[var(--foreground)] hover:bg-[var(--background)] transition-colors"
               >
-                Full Analysis
+                {t('fullAnalysis')}
                 <ArrowRight className="h-4 w-4" />
               </Link>
             )}
@@ -218,7 +219,7 @@ export default function AnalysisPage() {
               <div className="flex flex-col items-center gap-3">
                 <div className="animate-spin rounded-full h-8 w-8 border-2 border-[var(--color-primary)] border-t-transparent" />
                 <span className="text-[var(--foreground-muted)]">
-                  Loading chart data...
+                  {t('loadingChart')}
                 </span>
               </div>
             </div>
@@ -234,7 +235,7 @@ export default function AnalysisPage() {
                 className="mt-4"
                 onClick={() => selectedTicker && handleSelectTicker(selectedTicker)}
               >
-                Retry
+                {t('retry')}
               </Button>
             </div>
           )}
@@ -251,7 +252,7 @@ export default function AnalysisPage() {
               {/* Indicators */}
               <div>
                 <h3 className="text-lg font-semibold text-[var(--foreground)] mb-3">
-                  Technical Indicators
+                  {t('technicalIndicators')}
                 </h3>
                 <IndicatorPanel technicalData={tickerData.technical} />
               </div>
@@ -265,21 +266,13 @@ export default function AnalysisPage() {
         <Card padding="lg" className="text-center">
           <BarChart3 className="h-12 w-12 text-[var(--foreground-muted)] mx-auto mb-4" />
           <h3 className="text-lg font-medium text-[var(--foreground)]">
-            Select a Ticker to View Chart
+            {t('selectTicker')}
           </h3>
           <p className="mt-1 text-sm text-[var(--foreground-muted)]">
-            Search for a stock above or click one of the popular tickers
+            {t('selectTickerDesc')}
           </p>
         </Card>
       )}
-
-      {/* Reports Section */}
-      <div>
-        <h2 className="text-xl font-semibold text-[var(--foreground)] mb-4">
-          Recent Analysis Reports
-        </h2>
-        <ReportList initialLimit={10} />
-      </div>
     </div>
   );
 }

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -8,6 +8,7 @@ import {
   Search,
   PieChart,
   BarChart3,
+  FileText,
   Workflow,
   Settings,
   ChevronLeft,
@@ -16,7 +17,7 @@ import {
 import type { LucideIcon } from 'lucide-react';
 
 interface NavItem {
-  href: '/' | '/screening' | '/strategy' | '/portfolio' | '/analysis' | '/settings';
+  href: '/' | '/screening' | '/strategy' | '/portfolio' | '/analysis' | '/reports' | '/settings';
   labelKey: string;
   icon: LucideIcon;
 }
@@ -27,6 +28,7 @@ const navItems: NavItem[] = [
   { href: '/strategy', labelKey: 'strategy', icon: Workflow },
   { href: '/portfolio', labelKey: 'portfolio', icon: PieChart },
   { href: '/analysis', labelKey: 'analysis', icon: BarChart3 },
+  { href: '/reports', labelKey: 'reports', icon: FileText },
   { href: '/settings', labelKey: 'settings', icon: Settings },
 ];
 


### PR DESCRIPTION
## Summary
- Removed `ReportList` section from `/analysis` page — now focused on stock search + chart + indicators only
- Created new `/reports` page with `ReportList` as main content (initialLimit=20)
- Added "Reports" nav item (FileText icon) to sidebar between Analysis and Settings
- Replaced all hardcoded English strings in analysis page with i18n translation keys
- Added i18n keys: `nav.reports`, `reports.title`, `reports.subtitle`, `analysis.retry` (en/ko/zh)

Closes #140

## Test plan
- [ ] `/analysis` page shows only search bar, popular tickers, chart, indicators — no reports section
- [ ] `/reports` page shows analysis reports list with proper header
- [ ] Sidebar shows "Reports" item between Analysis and Settings
- [ ] Reports nav item highlights when on `/reports` page
- [ ] All text on analysis page is translated (switch locale to ko/zh to verify)
- [ ] Dark mode works on both pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)