### PR TITLE
Add missing /reports page and fix gitignore (#140)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,9 +150,9 @@ logs/
 results/
 !results/.gitkeep
 
-# Reports (daily screening reports)
-reports/
-!reports/.gitkeep
+# Reports (daily screening reports — root only)
+/reports/
+!/reports/.gitkeep
 
 # Config (keep templates, ignore local configs)
 config/*.json

--- a/web/src/app/[locale]/reports/page.tsx
+++ b/web/src/app/[locale]/reports/page.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { FileText } from 'lucide-react';
+import { ReportList } from '@/components/analysis';
+
+/**
+ * Dedicated page for analysis reports.
+ */
+export default function ReportsPage() {
+  const t = useTranslations('reports');
+
+  return (
+    <div className="space-y-6">
+      {/* Page Header */}
+      <div className="flex items-center gap-3">
+        <FileText className="h-7 w-7 text-[var(--color-primary)]" />
+        <div>
+          <h1 className="text-2xl font-bold text-[var(--foreground)]">
+            {t('title')}
+          </h1>
+          <p className="mt-1 text-[var(--foreground-muted)]">
+            {t('subtitle')}
+          </p>
+        </div>
+      </div>
+
+      {/* Reports List */}
+      <ReportList initialLimit={20} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- The reports page.tsx was created in PR #167 but was gitignored by the root `reports/` pattern
- Fix: change `.gitignore` from `reports/` to `/reports/` so only the root reports dir is ignored
- Add `web/src/app/[locale]/reports/page.tsx` that was missed in the squash merge

## Test plan
- [ ] `/reports` page loads and shows ReportList
- [ ] Root `reports/` directory files are still gitignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)