### PR TITLE
Add saved strategies to screening presets API

### DIFF
--- a/api/schemas/screening.py
+++ b/api/schemas/screening.py
@@ -111,6 +111,7 @@ class PresetInfo(BaseModel):
         name: Preset identifier
         description: Human-readable description
         conditions: List of condition names in the preset
+        source: Origin of the preset ('static' for built-in, 'custom' for saved strategies)
     """
 
     name: str = Field(..., description="Preset identifier")
@@ -119,6 +120,7 @@ class PresetInfo(BaseModel):
         default_factory=list,
         description="List of condition names"
     )
+    source: str = Field(default="static", description="'static' or 'custom'")
 
 
 class UniverseInfo(BaseModel):

--- a/api/services/screening_service.py
+++ b/api/services/screening_service.py
@@ -63,21 +63,21 @@ class ScreeningService:
         """
         Get list of available screening presets.
 
+        Returns static presets and saved QuantCanvas strategies.
+
         Returns:
             List of PresetInfo with preset details
         """
         presets = []
 
+        # Static presets
         for name in list_presets():
             preset_func = PRESET_REGISTRY.get(name)
             description = ""
             conditions = []
 
             if preset_func:
-                # Get docstring as description
                 description = (preset_func.__doc__ or "").strip()
-
-                # Get condition names by calling the preset
                 try:
                     condition_instances = preset_func()
                     conditions = [c.name for c in condition_instances]
@@ -87,8 +87,41 @@ class ScreeningService:
             presets.append(PresetInfo(
                 name=name,
                 description=description,
-                conditions=conditions
+                conditions=conditions,
+                source="static",
             ))
+
+        # Saved QuantCanvas strategies
+        try:
+            from api.services.strategy_save_service import get_strategy_save_service
+            from api.services.strategy_service import build_conditions_from_graph
+            from api.schemas.strategy import StrategyGraph
+
+            saved = get_strategy_save_service().list_strategies()
+            for strategy in saved:
+                try:
+                    graph = strategy.graph
+                    if isinstance(graph, dict):
+                        graph = StrategyGraph(**graph)
+                    cond_list, _ = build_conditions_from_graph(graph)
+                    if not cond_list:
+                        continue
+                    conditions = [type(c).__name__ for c in cond_list]
+                except Exception as e:
+                    logger.warning(
+                        "Skipping unparseable saved strategy %s: %s",
+                        strategy.id, e,
+                    )
+                    continue
+
+                presets.append(PresetInfo(
+                    name=f"custom:{strategy.id}",
+                    description=strategy.name,
+                    conditions=conditions,
+                    source="custom",
+                ))
+        except Exception as e:
+            logger.warning("Failed to load saved strategies for presets: %s", e)
 
         return presets
 
@@ -176,6 +209,31 @@ class ScreeningService:
         else:
             raise ValueError(f"Unknown universe: {universe}")
 
+    def _resolve_conditions(self, preset: str, params: Optional[Dict[str, Any]] = None) -> list:
+        """Resolve conditions from a static preset or custom strategy."""
+        if preset.startswith("custom:"):
+            strategy_id = preset[len("custom:"):]
+            from api.services.strategy_save_service import get_strategy_save_service
+            from api.services.strategy_service import build_conditions_from_graph
+            from api.schemas.strategy import StrategyGraph
+
+            strategy = get_strategy_save_service().get_strategy(strategy_id)
+            if strategy is None:
+                raise ValueError(f"Saved strategy not found: {strategy_id}")
+            graph = strategy.graph
+            if isinstance(graph, dict):
+                graph = StrategyGraph(**graph)
+            cond_list, _ = build_conditions_from_graph(graph)
+            if not cond_list:
+                raise ValueError(f"No conditions in saved strategy: {strategy_id}")
+            return cond_list
+
+        preset_params = params or {}
+        try:
+            return get_preset(preset, **preset_params)
+        except ValueError as e:
+            raise ValueError(f"Invalid preset: {e}")
+
     def run_screening(
         self,
         preset: str,
@@ -186,19 +244,14 @@ class ScreeningService:
         Run stock screening with the given preset and universe.
 
         Args:
-            preset: Preset name
+            preset: Preset name (static name or 'custom:{strategy_id}')
             universe: Universe name
             params: Optional parameters to override preset defaults
 
         Returns:
             Dict with results, total_count, and matched_count
         """
-        # Get conditions from preset
-        preset_params = params or {}
-        try:
-            conditions = get_preset(preset, **preset_params)
-        except ValueError as e:
-            raise ValueError(f"Invalid preset: {e}")
+        conditions = self._resolve_conditions(preset, params)
 
         # Create screener
         screener = StockScreener(
@@ -262,12 +315,7 @@ class ScreeningService:
         Returns:
             ScreeningResultItem with the evaluation result
         """
-        # Get conditions from preset
-        preset_params = params or {}
-        try:
-            conditions = get_preset(preset, **preset_params)
-        except ValueError as e:
-            raise ValueError(f"Invalid preset: {e}")
+        conditions = self._resolve_conditions(preset, params)
 
         # Create screener
         screener = StockScreener(


### PR DESCRIPTION
## Summary
- `GET /api/screening/presets` now returns saved QuantCanvas strategies alongside static presets
- New `source` field on `PresetInfo`: `static` for built-in, `custom` for saved strategies
- Custom presets use `custom:{strategy_id}` naming and are executable via `/api/screening/run`
- Invalid/empty strategies are excluded from the list
- DB errors don't break static preset loading (graceful fallback)

## Changed Files
| File | Change |
|------|--------|
| `api/schemas/screening.py` | Add `source` field to `PresetInfo` |
| `api/services/screening_service.py` | Load saved strategies, `_resolve_conditions()` for custom execution |

## Test plan
- [x] Static presets still return correctly (14 presets)
- [x] Saved strategies appear with `source: "custom"` after creation
- [x] Unparseable/empty strategies excluded from list
- [x] Codex review passed (2 rounds)

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)