### PR TITLE
Add SSE progress events for strategy execution (#159)

### DIFF
--- a/api/routers/strategy.py
+++ b/api/routers/strategy.py
@@ -8,6 +8,7 @@ import json
 import logging
 import queue
 import threading
+import time
 
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import StreamingResponse
@@ -220,69 +221,109 @@ async def run_strategy(request: StrategyExecuteRequest) -> StrategyExecuteRespon
 )
 async def run_strategy_stream(request: StrategyExecuteRequest):
     """Execute a visual strategy graph with streaming progress events."""
-    progress_queue: queue.Queue = queue.Queue()
+    progress_queue: queue.Queue = queue.Queue(maxsize=100)
+    cancel_event = threading.Event()
+
+    def _progress_cb(processed: int, total: int, matched: int) -> None:
+        if cancel_event.is_set():
+            return
+        # Throttle: emit at most ~50 progress events
+        interval = max(1, -(-total // 50))  # ceil division
+        if processed % interval != 0 and processed != total:
+            return
+        try:
+            progress_queue.put_nowait(
+                StrategyProgressEvent(
+                    processed_tickers=processed,
+                    total_tickers=total,
+                    matched_count=matched,
+                    progress_pct=round(processed / total * 100, 1) if total else 0,
+                    status="running",
+                )
+            )
+        except queue.Full:
+            pass
 
     def _run():
         try:
             result = execute_strategy_with_progress(
                 graph=request.graph,
                 universe_override=request.universe_override,
-                progress_callback=lambda p, t, m: progress_queue.put(
+                progress_callback=_progress_cb,
+            )
+            if cancel_event.is_set():
+                return
+            screened = result.get("screened_count", result["total_count"])
+            try:
+                progress_queue.put(
                     StrategyProgressEvent(
-                        processed_tickers=p,
-                        total_tickers=t,
-                        matched_count=m,
-                        progress_pct=round(p / t * 100, 1) if t else 0,
-                        status="running",
-                    )
-                ),
-            )
-            progress_queue.put(
-                StrategyProgressEvent(
-                    processed_tickers=result["total_count"],
-                    total_tickers=result["total_count"],
-                    matched_count=result["matched_count"],
-                    progress_pct=100.0,
-                    status="done",
+                        processed_tickers=screened,
+                        total_tickers=screened,
+                        matched_count=result["matched_count"],
+                        progress_pct=100.0,
+                        status="done",
+                    ),
+                    timeout=5,
                 )
-            )
-            progress_queue.put(result)
+            except queue.Full:
+                return
+            if cancel_event.is_set():
+                return
+            try:
+                progress_queue.put(result, timeout=5)
+            except queue.Full:
+                pass
         except Exception as e:
             logger.exception("Strategy streaming execution failed")
-            progress_queue.put(
-                StrategyProgressEvent(
-                    status="error",
-                    message=str(e),
+            if cancel_event.is_set():
+                return
+            try:
+                progress_queue.put(
+                    StrategyProgressEvent(
+                        status="error",
+                        message="Strategy execution failed. Check server logs for details.",
+                    ),
+                    timeout=5,
                 )
-            )
+            except queue.Full:
+                pass
 
     thread = threading.Thread(target=_run, daemon=True)
     thread.start()
 
     def event_stream():
-        while True:
-            try:
-                item = progress_queue.get(timeout=120)
-            except queue.Empty:
-                yield f"event: error\ndata: {json.dumps({'status': 'error', 'message': 'timeout'})}\n\n"
-                break
-
-            if isinstance(item, StrategyProgressEvent):
-                yield f"event: progress\ndata: {item.model_dump_json()}\n\n"
-                if item.status in ("done", "error"):
-                    if item.status == "done":
-                        # Final result follows
-                        try:
-                            final = progress_queue.get(timeout=10)
-                            resp = StrategyExecuteResponse(**final)
-                            yield f"event: result\ndata: {resp.model_dump_json()}\n\n"
-                        except queue.Empty:
-                            pass
+        start = time.monotonic()
+        max_duration = 600  # 10 minutes absolute limit
+        try:
+            while True:
+                if time.monotonic() - start > max_duration:
+                    yield f"event: error\ndata: {json.dumps({'status': 'error', 'message': 'Maximum duration exceeded'})}\n\n"
                     break
-            elif isinstance(item, dict):
-                resp = StrategyExecuteResponse(**item)
-                yield f"event: result\ndata: {resp.model_dump_json()}\n\n"
-                break
+                try:
+                    item = progress_queue.get(timeout=5)
+                except queue.Empty:
+                    # Heartbeat to keep connection alive
+                    yield ": heartbeat\n\n"
+                    continue
+
+                if isinstance(item, StrategyProgressEvent):
+                    yield f"event: progress\ndata: {item.model_dump_json()}\n\n"
+                    if item.status in ("done", "error"):
+                        if item.status == "done":
+                            # Final result follows
+                            try:
+                                final = progress_queue.get(timeout=10)
+                                resp = StrategyExecuteResponse(**final)
+                                yield f"event: result\ndata: {resp.model_dump_json()}\n\n"
+                            except queue.Empty:
+                                pass
+                        break
+                elif isinstance(item, dict):
+                    resp = StrategyExecuteResponse(**item)
+                    yield f"event: result\ndata: {resp.model_dump_json()}\n\n"
+                    break
+        finally:
+            cancel_event.set()
 
     return StreamingResponse(
         event_stream(),

--- a/api/schemas/strategy.py
+++ b/api/schemas/strategy.py
@@ -4,7 +4,7 @@ Strategy Builder Schemas.
 Pydantic models for the visual strategy builder graph serialization and execution.
 """
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 from pydantic import BaseModel, Field
 
 
@@ -170,7 +170,7 @@ class StrategyProgressEvent(BaseModel):
     total_tickers: int = 0
     matched_count: int = 0
     progress_pct: float = 0.0
-    status: str = Field(description="'running', 'done', 'error'")
+    status: Literal["running", "done", "error"] = Field(description="Event status")
     message: Optional[str] = None
 
 

--- a/api/services/strategy_service.py
+++ b/api/services/strategy_service.py
@@ -8,7 +8,7 @@ Converts graph representations into screener conditions and executes them.
 import logging
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, Callable, Dict, List, Optional, Type
 
 import numpy as np
 
@@ -709,7 +709,7 @@ def _compute_node_survivors(
 def execute_strategy_with_progress(
     graph: StrategyGraph,
     universe_override: Optional[str] = None,
-    progress_callback: Optional[callable] = None,
+    progress_callback: Optional[Callable[[int, int, int], None]] = None,
 ) -> Dict[str, Any]:
     """Execute a visual strategy graph with an optional progress callback.
 
@@ -725,7 +725,7 @@ def execute_strategy_with_progress(
 def execute_strategy(
     graph: StrategyGraph,
     universe_override: Optional[str] = None,
-    progress_callback: Optional[callable] = None,
+    progress_callback: Optional[Callable[[int, int, int], None]] = None,
 ) -> Dict[str, Any]:
     """
     Execute a visual strategy graph.
@@ -888,6 +888,7 @@ def execute_strategy(
     return {
         "results": final_items,
         "total_count": total_count,
+        "screened_count": len(tickers),
         "matched_count": len(final_items),
         "universe": universe,
         "conditions_used": conditions_used,

--- a/screener/stock_screener.py
+++ b/screener/stock_screener.py
@@ -24,7 +24,7 @@ Usage:
     results = screener.run(universe="KOSPI")
 """
 
-from typing import List, Dict, Any, Optional
+from typing import Callable, List, Dict, Any, Optional
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 import time
@@ -362,7 +362,7 @@ class StockScreener:
         tickers: Optional[List[str]] = None,
         show_progress: bool = True,
         return_all: bool = False,
-        progress_callback: Optional[callable] = None,
+        progress_callback: Optional[Callable[[int, int, int], None]] = None,
     ) -> List[ScreeningResult]:
         """
         스크리닝 실행
@@ -427,7 +427,10 @@ class StockScreener:
                     print(f"  진행: {i}/{len(target_tickers)}")
 
                 if progress_callback is not None:
-                    progress_callback(i, len(target_tickers), matched_count)
+                    try:
+                        progress_callback(i, len(target_tickers), matched_count)
+                    except Exception:
+                        pass
 
         if show_progress:
             print(f"\n{'='*60}")


### PR DESCRIPTION
## Summary
- Add `POST /api/strategy/run/stream` SSE endpoint for real-time strategy execution progress
- Add `progress_callback` parameter to `StockScreener.run()` and `execute_strategy()`
- Add `StrategyProgressEvent` schema with `Literal` status type

## Key Design Decisions
- **Threading + Queue pattern**: Sync screener runs in a background thread, progress events are streamed via SSE
- **Bounded queue** (`maxsize=100`) + `put_nowait` with throttling (~50 events max) to prevent memory issues
- **Cancel event**: `threading.Event` set in generator's `finally` block to stop producing events on client disconnect
- **Heartbeat**: 5-second timeout with `: heartbeat` SSE comments to keep connection alive
- **`screened_count`**: Separate field for post-filter ticker count to avoid mismatch with `total_count`
- **Generic error messages**: Internal exception details logged server-side only

## SSE Event Types
- `progress` — periodic progress updates (throttled to ~50 events)
- `result` — final strategy execution results
- `error` — error events with safe messages
- `: heartbeat` — SSE comments to maintain connection

## Test plan
- [ ] Start Docker PostgreSQL and backend server
- [ ] Send POST to `/api/strategy/run/stream` with a valid strategy graph
- [ ] Verify progress events stream with increasing `processed_tickers`
- [ ] Verify final `done` + `result` events contain complete results
- [ ] Verify client disconnect stops producing events (cancel_event)
- [ ] Verify heartbeat comments appear during idle periods

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)