### PR TITLE
Add deep value accumulation presets

### DIFF
--- a/screener/presets.py
+++ b/screener/presets.py
@@ -21,6 +21,7 @@ from .conditions import (
     BaseCondition,
     # Price
     MinPriceCondition, MaxPriceCondition, PriceRangeCondition, PriceChangeCondition,
+    DrawdownFromHighCondition,
     # Volume
     MinVolumeCondition, VolumeAboveAvgCondition, VolumeSpikeCondition,
     # MA
@@ -249,6 +250,64 @@ def accumulation_full(
     ]
 
 
+# ============================================================
+# Deep Value Accumulation Presets (고점 대비 대폭 하락 + 매집)
+# ============================================================
+
+def deep_value_accumulation(
+    min_price: int = 5000,
+    lookback_days: int = 252,
+    min_drop_pct: float = 50.0,
+    bb_max_width: float = 15.0,
+    volume_multiplier: float = 0.8,
+    price_max_range: float = 10.0,
+) -> List[BaseCondition]:
+    """
+    Deep Value Accumulation - 고점 대비 50%+ 하락 후 매집 구간
+    - 최소 가격 5000원 이상
+    - 252일(1년) 고점 대비 50% 이상 하락
+    - 볼린저 밴드 수축 (폭 15% 이하)
+    - 거래량 평균 80% 이하
+    - 가격 횡보 (변동폭 10% 이하)
+    """
+    return [
+        MinPriceCondition(min_price),
+        DrawdownFromHighCondition(lookback_days=lookback_days, min_drop_pct=min_drop_pct),
+        BollingerWidthCondition(max_width_pct=bb_max_width),
+        VolumeBelowAvgCondition(multiplier=volume_multiplier),
+        PriceFlatCondition(max_range_pct=price_max_range),
+    ]
+
+
+def deep_value_accumulation_divergence(
+    min_price: int = 5000,
+    lookback_days: int = 252,
+    min_drop_pct: float = 50.0,
+    bb_max_width: float = 15.0,
+    volume_multiplier: float = 0.8,
+    price_max_range: float = 10.0,
+) -> List[BaseCondition]:
+    """
+    Deep Value Accumulation + Divergence - 대폭 하락 후 다이버전스 매집
+    - 최소 가격 5000원 이상
+    - 252일(1년) 고점 대비 50% 이상 하락
+    - 볼린저 밴드 수축 + 거래량 감소 + 가격 횡보
+    - OBV/Stochastic/VPCI 다이버전스 중 1개 이상
+    """
+    return [
+        MinPriceCondition(min_price),
+        DrawdownFromHighCondition(lookback_days=lookback_days, min_drop_pct=min_drop_pct),
+        BollingerWidthCondition(max_width_pct=bb_max_width),
+        VolumeBelowAvgCondition(multiplier=volume_multiplier),
+        PriceFlatCondition(max_range_pct=price_max_range),
+        OrCondition([
+            OBVDivergenceCondition(),
+            StochasticDivergenceCondition(),
+            VPCIDivergenceCondition(),
+        ]),
+    ]
+
+
 # 프리셋 목록 (CLI 등에서 사용)
 PRESET_REGISTRY = {
     "ma_touch_160": ma_touch_160,
@@ -266,6 +325,9 @@ PRESET_REGISTRY = {
     "accumulation_basic": accumulation_basic,
     "accumulation_obv": accumulation_obv,
     "accumulation_full": accumulation_full,
+    # Deep Value Accumulation (고점 대비 대폭 하락 + 매집)
+    "deep_value_accumulation": deep_value_accumulation,
+    "deep_value_accumulation_divergence": deep_value_accumulation_divergence,
 }
 
 

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -114,7 +114,15 @@
     "name": "Name",
     "price": "Price",
     "match": "Match",
-    "details": "Details"
+    "details": "Details",
+    "presetNames": {
+      "deep_value_accumulation": "Deep Value Accumulation",
+      "deep_value_accumulation_divergence": "Deep Value + Divergence"
+    },
+    "presetDescriptions": {
+      "deep_value_accumulation": "Stocks down 50%+ from highs with accumulation signals (BB squeeze, low volume, price consolidation)",
+      "deep_value_accumulation_divergence": "Deep value accumulation with OBV/Stochastic/VPCI divergence confirmation"
+    }
   },
   "portfolio": {
     "title": "Portfolio",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -114,7 +114,15 @@
     "name": "종목명",
     "price": "가격",
     "match": "매치",
-    "details": "상세"
+    "details": "상세",
+    "presetNames": {
+      "deep_value_accumulation": "딥 밸류 매집",
+      "deep_value_accumulation_divergence": "딥 밸류 + 다이버전스"
+    },
+    "presetDescriptions": {
+      "deep_value_accumulation": "고점 대비 50% 이상 하락 후 매집 신호 (BB 수축, 거래량 감소, 가격 횡보)",
+      "deep_value_accumulation_divergence": "딥 밸류 매집 + OBV/Stochastic/VPCI 다이버전스 확인"
+    }
   },
   "portfolio": {
     "title": "포트폴리오",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -114,7 +114,15 @@
     "name": "名称",
     "price": "价格",
     "match": "匹配",
-    "details": "详情"
+    "details": "详情",
+    "presetNames": {
+      "deep_value_accumulation": "深度价值吸筹",
+      "deep_value_accumulation_divergence": "深度价值 + 背离"
+    },
+    "presetDescriptions": {
+      "deep_value_accumulation": "从高点下跌50%以上并显示吸筹信号（布林带收窄、成交量萎缩、价格横盘）",
+      "deep_value_accumulation_divergence": "深度价值吸筹 + OBV/随机指标/VPCI背离确认"
+    }
   },
   "portfolio": {
     "title": "投资组合",


### PR DESCRIPTION
## Summary
- Add `deep_value_accumulation` preset: 50%+ drawdown from 252-day high + BB squeeze + low volume + price consolidation
- Add `deep_value_accumulation_divergence` preset: same + OBV/Stochastic/VPCI divergence confirmation
- Add i18n keys (en/ko/zh) for preset names and descriptions

## Test plan
- [x] `get_preset('deep_value_accumulation')` returns 5 conditions (MinPrice, DrawdownFromHigh, BB, VolBelow, PriceFlat)
- [x] `get_preset('deep_value_accumulation_divergence')` returns 6 conditions (above + OrCondition with 3 divergences)
- [x] `list_presets()` includes both new presets
- [x] JSON validation passes for all 3 locale files
- [ ] `GET /api/screening/presets` returns new presets
- [ ] `POST /api/screening/run` with `preset=deep_value_accumulation` executes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)