### PR TITLE
Fix strategy i18n: nodeLimit params and condition label translations

### DIFF
--- a/web/src/app/[locale]/strategy/page.tsx
+++ b/web/src/app/[locale]/strategy/page.tsx
@@ -1150,7 +1150,7 @@ function StrategyPageInner() {
         <div className="flex items-center gap-4">
           {/* Node limit with progress bar */}
           <div className="flex items-center gap-2">
-            <span>{t('nodeLimit')}: {nodeCount}/20</span>
+            <span>{t('nodeLimit', { count: nodeCount, max: 20 })}</span>
             <div className="w-16 h-1 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
               <div
                 className="h-full bg-[#1313ec] rounded-full transition-all"

--- a/web/src/components/strategy/edges/LabeledEdge.tsx
+++ b/web/src/components/strategy/edges/LabeledEdge.tsx
@@ -112,8 +112,15 @@ function StockListPopup({
   onClose: () => void;
 }) {
   const t = useTranslations('strategy');
+  const tc = useTranslations('conditions');
   const locale = useLocale();
   const popupRef = useRef<HTMLDivElement>(null);
+
+  // Translate condition labels via i18n, keep others as-is
+  const displayLabel =
+    result.node_type === 'condition' && tc.has(`${result.label}.label`)
+      ? tc(`${result.label}.label`)
+      : result.label;
 
   // Close on click outside
   useEffect(() => {
@@ -144,7 +151,7 @@ function StockListPopup({
       <div className="px-3 py-2 border-b border-[#e1e3e5] dark:border-[#2e2e30] flex items-center justify-between">
         <div>
           <div className="text-[11px] font-semibold text-[#1313ec] dark:text-blue-400 uppercase tracking-wider">
-            {result.label}
+            {displayLabel}
           </div>
           <div className="text-lg font-bold text-gray-900 dark:text-gray-100">
             {result.stock_count.toLocaleString()}

--- a/web/src/components/strategy/nodes/NodeEditPopup.tsx
+++ b/web/src/components/strategy/nodes/NodeEditPopup.tsx
@@ -275,6 +275,13 @@ export function IntermediateResultSection({
   result: import('@/lib/api').NodeIntermediateResult;
 }) {
   const t = useTranslations('strategy');
+  const tc = useTranslations('conditions');
+
+  // Translate condition labels via i18n, keep others as-is
+  const displayLabel =
+    result.node_type === 'condition' && tc.has(`${result.label}.label`)
+      ? tc(`${result.label}.label`)
+      : result.label;
 
   return (
     <div className="pt-3 border-t border-[#e1e3e5] dark:border-[#2e2e30]">
@@ -282,7 +289,7 @@ export function IntermediateResultSection({
 
       <div className="rounded-lg bg-blue-50 dark:bg-blue-500/10 border border-blue-100 dark:border-blue-500/20 p-3 mb-3">
         <div className="text-[11px] font-semibold text-[#1313ec] dark:text-blue-400 uppercase tracking-wider">
-          {t('intermediateResultsFor', { label: result.label })}
+          {t('intermediateResultsFor', { label: displayLabel })}
         </div>
         <div className="mt-1 text-2xl font-bold text-gray-900 dark:text-gray-100">
           {result.stock_count.toLocaleString()}


### PR DESCRIPTION
## Summary

- Fix `nodeLimit` displaying raw ICU template (`strategy.nodeLimit: 4/20`) by passing `{count, max}` params to `t()`
- Add i18n condition label lookup in `IntermediateResultSection` (NodeEditPopup) — raw keys like `avg_trading_value` now show translated labels
- Add i18n condition label lookup in `StockListPopup` (LabeledEdge) — same fix for edge popup headers
- Both use `tc.has()` fallback pattern for non-condition node types

## Test plan

- [ ] Strategy page footer shows "노드 제한: 4/20" (not `strategy.nodeLimit: 4/20`)
- [ ] Click condition node → intermediate results popup shows Korean label
- [ ] Click edge eye icon → stock list header shows Korean condition label
- [ ] `npx tsc --noEmit` → 0 errors
- [ ] `npm run lint` → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)