### PR TITLE
Add portfolio CSV import/export (#192)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,8 +139,9 @@ cython_debug/
 
 # Project-specific
 # Data files
-data/
+data/*
 !data/.gitkeep
+!data/templates/
 
 # Log files
 logs/

--- a/api/routers/portfolio.py
+++ b/api/routers/portfolio.py
@@ -4,12 +4,16 @@ Portfolio router.
 Provides endpoints for portfolio management operations.
 """
 
+import io
 import logging
+from pathlib import Path
 from typing import List, Optional
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Form, HTTPException, Query, UploadFile
+from fastapi.responses import StreamingResponse
 
 from api.schemas.portfolio import (
+    CsvImportResponse,
     HoldingCreate,
     HoldingUpdate,
     HoldingResponse,
@@ -19,6 +23,9 @@ from api.schemas.portfolio import (
     SellSignalsResponse,
 )
 from api.services.portfolio_service import get_portfolio_service
+
+TEMPLATE_DIR = Path(__file__).parent.parent.parent / "data" / "templates"
+MAX_UPLOAD_SIZE = 1_048_576  # 1 MB
 
 logger = logging.getLogger(__name__)
 
@@ -128,6 +135,116 @@ async def add_holding(data: HoldingCreate) -> HoldingResponse:
             status_code=500,
             detail=f"Failed to add holding: {str(e)}"
         )
+
+
+@router.post(
+    "/holdings/import",
+    response_model=CsvImportResponse,
+    summary="Import Holdings from CSV",
+    description="Bulk import holdings from a CSV file.",
+)
+async def import_holdings(
+    file: UploadFile,
+    mode: str = Form("merge"),
+) -> CsvImportResponse:
+    """
+    Import holdings from a CSV file.
+
+    Args:
+        file: CSV file with ticker, quantity, avg_price columns
+        mode: "merge" to upsert or "replace" to clear first
+
+    Returns:
+        CsvImportResponse with import counts and errors
+    """
+    if mode not in ("merge", "replace"):
+        raise HTTPException(status_code=422, detail=f"Invalid mode: {mode}. Use 'merge' or 'replace'.")
+
+    raw = await file.read()
+    if len(raw) == 0:
+        raise HTTPException(status_code=400, detail="Empty file")
+    if len(raw) > MAX_UPLOAD_SIZE:
+        raise HTTPException(status_code=400, detail="File too large (max 1 MB)")
+
+    try:
+        content = raw.decode("utf-8-sig")
+    except UnicodeDecodeError:
+        raise HTTPException(status_code=400, detail="File is not valid UTF-8")
+
+    service = get_portfolio_service()
+
+    try:
+        result = service.import_from_csv(content, mode=mode)
+        return CsvImportResponse(**result)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error(f"Failed to import CSV: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Import failed: {str(e)}")
+
+
+@router.get(
+    "/holdings/export",
+    summary="Export Holdings as CSV",
+    description="Download all holdings as a CSV file.",
+)
+async def export_holdings():
+    """
+    Export all holdings as CSV download.
+
+    Returns:
+        StreamingResponse with CSV content
+    """
+    service = get_portfolio_service()
+
+    try:
+        csv_str = service.export_to_csv()
+        # Prepend UTF-8 BOM for Excel Korean support
+        bom = b"\xef\xbb\xbf"
+        output = io.BytesIO(bom + csv_str.encode("utf-8"))
+        return StreamingResponse(
+            output,
+            media_type="text/csv",
+            headers={
+                "Content-Disposition": "attachment; filename=portfolio_holdings.csv"
+            },
+        )
+    except Exception as e:
+        logger.error(f"Failed to export CSV: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Export failed: {str(e)}")
+
+
+@router.get(
+    "/holdings/template",
+    summary="Download CSV Template",
+    description="Download a CSV template for portfolio import.",
+)
+async def get_template(
+    minimal: bool = Query(default=False, description="Return minimal template (required columns only)"),
+):
+    """
+    Download a CSV template file.
+
+    Args:
+        minimal: If True, return template with required columns only
+
+    Returns:
+        StreamingResponse with template CSV
+    """
+    filename = "portfolio_template_minimal.csv" if minimal else "portfolio_template.csv"
+    template_path = TEMPLATE_DIR / filename
+
+    if not template_path.exists():
+        raise HTTPException(status_code=404, detail="Template file not found")
+
+    content = template_path.read_bytes()
+    return StreamingResponse(
+        io.BytesIO(content),
+        media_type="text/csv",
+        headers={
+            "Content-Disposition": f"attachment; filename={filename}"
+        },
+    )
 
 
 @router.get(

--- a/api/schemas/portfolio.py
+++ b/api/schemas/portfolio.py
@@ -108,6 +108,38 @@ class PortfolioSummary(BaseModel):
     )
 
 
+class CsvRowError(BaseModel):
+    """
+    Schema for a CSV row validation error.
+
+    Attributes:
+        row: 1-based row number in the CSV
+        ticker: Ticker value from the row (None if missing)
+        reason: Description of the validation error
+    """
+
+    row: int = Field(..., description="1-based row number")
+    ticker: Optional[str] = Field(default=None, description="Ticker from the row")
+    reason: str = Field(..., description="Error description")
+
+
+class CsvImportResponse(BaseModel):
+    """
+    Schema for CSV import result.
+
+    Attributes:
+        imported: Number of newly created holdings
+        updated: Number of existing holdings updated
+        skipped: Number of rows skipped due to errors
+        errors: List of row-level validation errors
+    """
+
+    imported: int = Field(..., description="Newly created holdings count")
+    updated: int = Field(..., description="Updated holdings count")
+    skipped: int = Field(..., description="Skipped rows count")
+    errors: List[CsvRowError] = Field(default_factory=list, description="Row errors")
+
+
 class SellSignal(BaseModel):
     """
     Schema for sell signal information.

--- a/api/services/portfolio_service.py
+++ b/api/services/portfolio_service.py
@@ -5,6 +5,8 @@ Business logic for portfolio management operations.
 Provides CRUD operations for holdings and P&L calculations.
 """
 
+import csv
+import io
 import json
 import logging
 import threading
@@ -48,7 +50,7 @@ class PortfolioService:
             data_path: Path to portfolio JSON file (default: data/portfolio.json)
         """
         self.data_path = data_path or self.DEFAULT_DATA_PATH
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
         self._cache = get_cache()
         self._holdings: Dict[str, Dict[str, Any]] = {}
         self._load()
@@ -353,6 +355,128 @@ class PortfolioService:
             currency=primary_currency,
             last_updated=datetime.now()
         )
+
+    def import_from_csv(self, csv_content: str, mode: str = "merge") -> Dict[str, Any]:
+        """
+        Import holdings from CSV content.
+
+        Args:
+            csv_content: CSV string with headers
+            mode: "merge" (upsert) or "replace" (clear first)
+
+        Returns:
+            Dict with imported, updated, skipped counts and errors list
+        """
+        errors = []
+        imported = 0
+        updated = 0
+
+        reader = csv.DictReader(io.StringIO(csv_content))
+        fieldnames = reader.fieldnames or []
+        lower_fields = [f.strip().lower() for f in fieldnames]
+
+        required = {"ticker", "quantity", "avg_price"}
+        if not required.issubset(set(lower_fields)):
+            missing = required - set(lower_fields)
+            raise ValueError(f"Missing required columns: {', '.join(sorted(missing))}")
+
+        # Build field mapping (handle case-insensitive headers)
+        field_map = {}
+        for original, lower in zip(fieldnames, lower_fields):
+            field_map[lower] = original
+
+        valid_rows = []
+        for row_num, row in enumerate(reader, start=2):  # row 1 is header
+            ticker_val = row.get(field_map["ticker"], "").strip()
+            qty_val = row.get(field_map["quantity"], "").strip()
+            price_val = row.get(field_map["avg_price"], "").strip()
+
+            if not ticker_val:
+                errors.append({"row": row_num, "ticker": None, "reason": "Empty ticker"})
+                continue
+
+            try:
+                quantity = int(qty_val)
+                if quantity <= 0:
+                    raise ValueError("must be > 0")
+            except (ValueError, TypeError):
+                errors.append({"row": row_num, "ticker": ticker_val, "reason": f"Invalid quantity: {qty_val}"})
+                continue
+
+            try:
+                avg_price = float(price_val)
+                if avg_price <= 0:
+                    raise ValueError("must be > 0")
+            except (ValueError, TypeError):
+                errors.append({"row": row_num, "ticker": ticker_val, "reason": f"Invalid avg_price: {price_val}"})
+                continue
+
+            parsed = {
+                "ticker": ticker_val,
+                "quantity": quantity,
+                "avg_price": avg_price,
+                "name": row.get(field_map.get("name", ""), "").strip() or ticker_val,
+                "currency": row.get(field_map.get("currency", ""), "").strip() or "KRW",
+                "note": row.get(field_map.get("note", ""), "").strip() or None,
+                "bought_at": row.get(field_map.get("bought_at", ""), "").strip() or None,
+            }
+            valid_rows.append(parsed)
+
+        with self._lock:
+            backup = {k: dict(v) for k, v in self._holdings.items()}
+
+            try:
+                if mode == "replace":
+                    self._holdings.clear()
+
+                for parsed in valid_rows:
+                    ticker = parsed["ticker"]
+                    if ticker in self._holdings and mode == "merge":
+                        existing_bought_at = self._holdings[ticker].get("bought_at")
+                        self._holdings[ticker].update(parsed)
+                        # Preserve existing bought_at if CSV didn't provide one
+                        if not parsed["bought_at"] and existing_bought_at:
+                            self._holdings[ticker]["bought_at"] = existing_bought_at
+                        updated += 1
+                    else:
+                        if not parsed["bought_at"]:
+                            parsed["bought_at"] = date.today().isoformat()
+                        self._holdings[ticker] = parsed
+                        imported += 1
+
+                self._save()
+            except Exception:
+                self._holdings = backup
+                raise
+
+        logger.info(f"CSV import: imported={imported}, updated={updated}, skipped={len(errors)}")
+
+        return {
+            "imported": imported,
+            "updated": updated,
+            "skipped": len(errors),
+            "errors": errors,
+        }
+
+    def export_to_csv(self) -> str:
+        """
+        Export all holdings as CSV string.
+
+        Returns:
+            CSV string with header and data rows
+        """
+        output = io.StringIO()
+        columns = ["ticker", "quantity", "avg_price", "name", "currency", "note", "bought_at"]
+        writer = csv.DictWriter(output, fieldnames=columns, extrasaction="ignore")
+        writer.writeheader()
+
+        for holding in self._holdings.values():
+            row = {col: holding.get(col, "") for col in columns}
+            if row["note"] is None:
+                row["note"] = ""
+            writer.writerow(row)
+
+        return output.getvalue()
 
     def get_sell_signals(
         self,

--- a/api/tests/test_portfolio.py
+++ b/api/tests/test_portfolio.py
@@ -2,9 +2,10 @@
 Tests for portfolio API endpoints.
 
 Tests the portfolio router endpoints including holdings CRUD,
-portfolio summary, and sell signals.
+portfolio summary, sell signals, and CSV import/export.
 """
 
+import io
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
@@ -487,3 +488,166 @@ class TestGetFullPortfolio:
         assert "summary" in data
         assert len(data["holdings"]) == 1
         assert data["summary"]["holdings_count"] == 1
+
+
+def _csv_upload(client, content: str, mode: str = "merge"):
+    """Helper to POST CSV content as file upload."""
+    return client.post(
+        "/api/portfolio/holdings/import",
+        files={"file": ("test.csv", io.BytesIO(content.encode("utf-8")), "text/csv")},
+        data={"mode": mode},
+    )
+
+
+class TestImportCsv:
+    """Tests for POST /api/portfolio/holdings/import endpoint."""
+
+    def test_import_csv_merge_success(self, client, mock_portfolio_service):
+        """Valid CSV merge import returns correct counts."""
+        mock_portfolio_service.import_from_csv.return_value = {
+            "imported": 2, "updated": 1, "skipped": 0, "errors": []
+        }
+        csv = "ticker,quantity,avg_price\nAAPL,10,185\nMSFT,5,420\nGOOG,3,140\n"
+        resp = _csv_upload(client, csv, "merge")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["imported"] == 2
+        assert data["updated"] == 1
+        assert data["skipped"] == 0
+
+    def test_import_csv_replace_success(self, client, mock_portfolio_service):
+        """Replace mode clears existing holdings first."""
+        mock_portfolio_service.import_from_csv.return_value = {
+            "imported": 2, "updated": 0, "skipped": 0, "errors": []
+        }
+        csv = "ticker,quantity,avg_price\nAAPL,10,185\nMSFT,5,420\n"
+        resp = _csv_upload(client, csv, "replace")
+        assert resp.status_code == 200
+        mock_portfolio_service.import_from_csv.assert_called_once()
+        call_args = mock_portfolio_service.import_from_csv.call_args
+        assert call_args[1].get("mode") == "replace" or call_args[0][1] == "replace"
+
+    def test_import_csv_validation_errors(self, client, mock_portfolio_service):
+        """Bad rows result in partial success with errors."""
+        mock_portfolio_service.import_from_csv.return_value = {
+            "imported": 1, "updated": 0, "skipped": 1,
+            "errors": [{"row": 3, "ticker": "BAD", "reason": "Invalid quantity: abc"}]
+        }
+        csv = "ticker,quantity,avg_price\nAAPL,10,185\nBAD,abc,100\n"
+        resp = _csv_upload(client, csv)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["skipped"] == 1
+        assert len(data["errors"]) == 1
+        assert data["errors"][0]["row"] == 3
+
+    def test_import_csv_empty_file(self, client, mock_portfolio_service):
+        """Empty file returns 400."""
+        resp = client.post(
+            "/api/portfolio/holdings/import",
+            files={"file": ("test.csv", io.BytesIO(b""), "text/csv")},
+            data={"mode": "merge"},
+        )
+        assert resp.status_code == 400
+
+    def test_import_csv_missing_columns(self, client, mock_portfolio_service):
+        """Missing required columns returns 400."""
+        mock_portfolio_service.import_from_csv.side_effect = ValueError(
+            "Missing required columns: avg_price"
+        )
+        csv = "ticker,quantity\nAAPL,10\n"
+        resp = _csv_upload(client, csv)
+        assert resp.status_code == 400
+        assert "Missing required columns" in resp.json()["detail"]
+
+    def test_import_csv_invalid_mode(self, client, mock_portfolio_service):
+        """Invalid mode returns 422."""
+        csv = "ticker,quantity,avg_price\nAAPL,10,185\n"
+        resp = _csv_upload(client, csv, "invalid")
+        assert resp.status_code == 422
+
+    def test_import_csv_minimal_columns(self, client, mock_portfolio_service):
+        """Only required columns still works with defaults."""
+        mock_portfolio_service.import_from_csv.return_value = {
+            "imported": 1, "updated": 0, "skipped": 0, "errors": []
+        }
+        csv = "ticker,quantity,avg_price\nAAPL,10,185.50\n"
+        resp = _csv_upload(client, csv)
+        assert resp.status_code == 200
+        assert resp.json()["imported"] == 1
+
+    def test_import_csv_unicode(self, client, mock_portfolio_service):
+        """Korean name/note in CSV works correctly."""
+        mock_portfolio_service.import_from_csv.return_value = {
+            "imported": 1, "updated": 0, "skipped": 0, "errors": []
+        }
+        csv = "ticker,quantity,avg_price,name,note\n005930.KS,50,72000,삼성전자,핵심 보유\n"
+        resp = _csv_upload(client, csv)
+        assert resp.status_code == 200
+
+
+class TestExportCsv:
+    """Tests for GET /api/portfolio/holdings/export endpoint."""
+
+    def test_export_csv_content(self, client, mock_portfolio_service):
+        """Exported CSV matches holdings data."""
+        mock_portfolio_service.export_to_csv.return_value = (
+            "ticker,quantity,avg_price,name,currency,note\r\n"
+            "AAPL,10,185.5,Apple Inc.,USD,\r\n"
+        )
+        resp = client.get("/api/portfolio/holdings/export")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "AAPL" in body
+        assert "185.5" in body
+
+    def test_export_csv_empty(self, client, mock_portfolio_service):
+        """Empty portfolio exports header-only CSV."""
+        mock_portfolio_service.export_to_csv.return_value = (
+            "ticker,quantity,avg_price,name,currency,note\r\n"
+        )
+        resp = client.get("/api/portfolio/holdings/export")
+        assert resp.status_code == 200
+        lines = resp.text.strip().split("\n")
+        # BOM + header only
+        assert len(lines) == 1
+
+    def test_export_csv_headers(self, client, mock_portfolio_service):
+        """Response has correct content-type and content-disposition."""
+        mock_portfolio_service.export_to_csv.return_value = "ticker,quantity,avg_price,name,currency,note\r\n"
+        resp = client.get("/api/portfolio/holdings/export")
+        assert resp.status_code == 200
+        assert "text/csv" in resp.headers["content-type"]
+        assert "portfolio_holdings.csv" in resp.headers["content-disposition"]
+
+
+class TestTemplate:
+    """Tests for GET /api/portfolio/holdings/template endpoint."""
+
+    def test_template_full(self, client, mock_portfolio_service):
+        """Full template returns CSV with all columns."""
+        resp = client.get("/api/portfolio/holdings/template")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "ticker" in body
+        assert "name" in body
+        assert "currency" in body
+        assert "bought_at" in body
+
+    def test_template_minimal(self, client, mock_portfolio_service):
+        """Minimal template returns only required columns."""
+        resp = client.get("/api/portfolio/holdings/template?minimal=true")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "ticker" in body
+        assert "quantity" in body
+        # Minimal should not have name column in header
+        header_line = body.strip().split("\n")[0]
+        assert "name" not in header_line
+
+    def test_template_content_disposition(self, client, mock_portfolio_service):
+        """Template response has download headers."""
+        resp = client.get("/api/portfolio/holdings/template")
+        assert resp.status_code == 200
+        assert "text/csv" in resp.headers["content-type"]
+        assert "attachment" in resp.headers["content-disposition"]

--- a/data/templates/portfolio_template.csv
+++ b/data/templates/portfolio_template.csv
@@ -1,0 +1,4 @@
+ticker,quantity,avg_price,name,currency,note,bought_at
+AAPL,10,185.50,Apple Inc.,USD,Long-term hold,2024-06-15
+005930.KS,50,72000,Samsung Electronics,KRW,Core position,2024-03-01
+MSFT,5,420.00,Microsoft Corp.,USD,Cloud growth play,2025-01-10

--- a/data/templates/portfolio_template_minimal.csv
+++ b/data/templates/portfolio_template_minimal.csv
@@ -1,0 +1,4 @@
+ticker,quantity,avg_price
+AAPL,10,185.50
+005930.KS,50,72000
+MSFT,5,420.00


### PR DESCRIPTION
## Summary
- Add `POST /holdings/import` endpoint for bulk CSV import with merge/replace modes
- Add `GET /holdings/export` endpoint with UTF-8 BOM for Excel Korean support
- Add `GET /holdings/template` endpoint for full/minimal CSV template download
- Thread-safe import with rollback on save failure, `bought_at` column for round-trip fidelity
- 14 new test cases (34 total pass)

Closes #192

## Changes
| File | Change |
|------|--------|
| `data/templates/portfolio_template{,_minimal}.csv` | CSV templates with sample data |
| `api/schemas/portfolio.py` | `CsvRowError`, `CsvImportResponse` schemas |
| `api/services/portfolio_service.py` | `import_from_csv()`, `export_to_csv()` with RLock + rollback |
| `api/routers/portfolio.py` | 3 new endpoints (before `{ticker}` wildcard) |
| `api/tests/test_portfolio.py` | 14 new test cases |
| `.gitignore` | Allow `data/templates/` to be tracked |

## Test plan
- [x] All 34 tests pass (`pytest api/tests/test_portfolio.py -v`)
- [ ] Manual: `curl /api/portfolio/holdings/template -o template.csv`
- [ ] Manual: `curl -X POST /api/portfolio/holdings/import -F "file=@template.csv" -F "mode=merge"`
- [ ] Manual: `curl /api/portfolio/holdings/export -o export.csv`
- [ ] Verify round-trip: export → import → export produces identical CSV

🤖 Generated with [Claude Code](https://claude.com/claude-code)