### PR TITLE
Fix strategy execution stuck at 100% progress

### DIFF
--- a/api/services/strategy_service.py
+++ b/api/services/strategy_service.py
@@ -878,10 +878,8 @@ def execute_strategy(
                     )
                 )
 
-    # Enrich both intermediate and final stocks with fundamentals.
-    all_items = [stock for node in node_results.values() for stock in node.stocks]
-    all_items.extend(final_items)
-    _enrich_fundamentals(all_items)
+    # Enrich only final results (intermediate nodes don't display PER/PBR).
+    _enrich_fundamentals(final_items)
 
     conditions_used = [type(c).__name__ for c in leaf_conditions]
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -328,15 +328,9 @@ export function runStrategyStream(
       const decoder = new TextDecoder();
       let buffer = '';
 
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
+      let currentEvent = '';
 
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split('\n');
-        buffer = lines.pop() ?? '';
-
-        let currentEvent = '';
+      const processLines = (lines: string[]) => {
         for (const line of lines) {
           if (line.startsWith('event: ')) {
             currentEvent = line.slice(7).trim();
@@ -357,6 +351,21 @@ export function runStrategyStream(
             currentEvent = '';
           }
         }
+      };
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() ?? '';
+        processLines(lines);
+      }
+
+      // Process any remaining data in buffer after stream closes
+      if (buffer.trim()) {
+        processLines(buffer.split('\n'));
       }
     } catch (err) {
       if ((err as Error).name === 'AbortError') return;


### PR DESCRIPTION
## Summary
- **Backend**: Narrow `_enrich_fundamentals` to only final result items instead of all intermediate + final node stocks, eliminating the post-100% yfinance API bottleneck (e.g. ~950 calls → ~225)
- **Frontend**: Fix SSE `ReadableStream` buffer handling so the final `result` event is not silently dropped when the stream closes

## Test plan
- [ ] Run a strategy with 500+ universe stocks → verify results appear immediately after 100% (no hang)
- [ ] Verify final result table shows PER/PBR/dividend yield correctly
- [ ] Verify intermediate node tabs display stock lists (PER/PBR may be null — expected)
- [ ] Check browser console for JS errors during strategy execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)