### PR TITLE
Fix strategy execution stuck at 100% progress (#195)

### DIFF
--- a/api/routers/strategy.py
+++ b/api/routers/strategy.py
@@ -27,6 +27,7 @@ from api.schemas.strategy import (
 )
 from api.services.strategy_save_service import get_strategy_save_service
 from api.services.strategy_service import (
+    enrich_fundamentals,
     execute_strategy,
     execute_strategy_with_progress,
     get_available_conditions,
@@ -246,10 +247,13 @@ async def run_strategy_stream(request: StrategyExecuteRequest):
 
     def _run():
         try:
+            # Skip enrichment here — do it after sending 'done' so the
+            # client sees progress reach 100% without waiting for API calls.
             result = execute_strategy_with_progress(
                 graph=request.graph,
                 universe_override=request.universe_override,
                 progress_callback=_progress_cb,
+                skip_enrich=True,
             )
             if cancel_event.is_set():
                 return
@@ -267,6 +271,14 @@ async def run_strategy_stream(request: StrategyExecuteRequest):
                 )
             except queue.Full:
                 return
+            if cancel_event.is_set():
+                return
+            # Enrich fundamentals (PER/PBR) after 'done' event is sent.
+            # Failure is non-fatal — return results without PER/PBR.
+            try:
+                enrich_fundamentals(result["results"])
+            except Exception:
+                logger.warning("Enrichment failed; returning results without fundamentals")
             if cancel_event.is_set():
                 return
             try:
@@ -310,13 +322,17 @@ async def run_strategy_stream(request: StrategyExecuteRequest):
                     yield f"event: progress\ndata: {item.model_dump_json()}\n\n"
                     if item.status in ("done", "error"):
                         if item.status == "done":
-                            # Final result follows
-                            try:
-                                final = progress_queue.get(timeout=10)
+                            # Wait for enriched result with heartbeats
+                            final = None
+                            for _ in range(6):  # 6 x 5s = 30s max
+                                try:
+                                    final = progress_queue.get(timeout=5)
+                                    break
+                                except queue.Empty:
+                                    yield ": heartbeat\n\n"
+                            if final is not None:
                                 resp = StrategyExecuteResponse(**final)
                                 yield f"event: result\ndata: {resp.model_dump_json()}\n\n"
-                            except queue.Empty:
-                                pass
                         break
                 elif isinstance(item, dict):
                     resp = StrategyExecuteResponse(**item)

--- a/api/services/strategy_service.py
+++ b/api/services/strategy_service.py
@@ -189,7 +189,7 @@ def _fetch_us_fundamentals(tickers: List[str]) -> Dict[str, Dict[str, Optional[f
     return fundamentals
 
 
-def _enrich_fundamentals(items: List[StrategyResultItem]) -> None:
+def enrich_fundamentals(items: List[StrategyResultItem]) -> None:
     """Fill PER/PBR/dividend_yield for strategy result items (best effort)."""
     if not items:
         return
@@ -710,15 +710,18 @@ def execute_strategy_with_progress(
     graph: StrategyGraph,
     universe_override: Optional[str] = None,
     progress_callback: Optional[Callable[[int, int, int], None]] = None,
+    skip_enrich: bool = False,
 ) -> Dict[str, Any]:
     """Execute a visual strategy graph with an optional progress callback.
 
     Same as execute_strategy but forwards progress_callback to the screener.
+    Set skip_enrich=True when the caller will enrich separately (e.g. streaming).
     """
     return execute_strategy(
         graph=graph,
         universe_override=universe_override,
         progress_callback=progress_callback,
+        skip_enrich=skip_enrich,
     )
 
 
@@ -726,6 +729,7 @@ def execute_strategy(
     graph: StrategyGraph,
     universe_override: Optional[str] = None,
     progress_callback: Optional[Callable[[int, int, int], None]] = None,
+    skip_enrich: bool = False,
 ) -> Dict[str, Any]:
     """
     Execute a visual strategy graph.
@@ -879,7 +883,9 @@ def execute_strategy(
                 )
 
     # Enrich only final results (intermediate nodes don't display PER/PBR).
-    _enrich_fundamentals(final_items)
+    # skip_enrich=True lets streaming callers send progress before enriching.
+    if not skip_enrich:
+        enrich_fundamentals(final_items)
 
     conditions_used = [type(c).__name__ for c in leaf_conditions]
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -363,7 +363,8 @@ export function runStrategyStream(
         processLines(lines);
       }
 
-      // Process any remaining data in buffer after stream closes
+      // Flush any remaining bytes from the TextDecoder
+      buffer += decoder.decode(new Uint8Array(), { stream: false });
       if (buffer.trim()) {
         processLines(buffer.split('\n'));
       }


### PR DESCRIPTION
## Summary
- Split `enrich_fundamentals` out of the SSE streaming path so "done" event sends immediately after screening
- Enrichment runs post-"done" with 5s heartbeat loop (30s max) to keep SSE alive during API calls
- Enrichment failure degrades gracefully (results returned without PER/PBR)
- Frontend: flush TextDecoder residual bytes on stream close

Closes #195

## Changes
| File | Change |
|------|--------|
| `api/services/strategy_service.py` | Add `skip_enrich` param; rename to public `enrich_fundamentals` |
| `api/routers/strategy.py` | SSE streaming: skip_enrich=True, enrich after "done", heartbeat loop |
| `web/src/lib/api.ts` | TextDecoder flush with `stream: false` on close |

## Test plan
- [x] 41 tests pass (portfolio + strategy)
- [ ] Manual: Run a strategy with 900+ tickers, verify progress reaches 100% and results appear within ~30s
- [ ] Manual: Verify non-streaming `POST /api/strategy/run` still enriches results

🤖 Generated with [Claude Code](https://claude.com/claude-code)