### PR TITLE
Add price cache and parallel fetch to PortfolioService

### DIFF
--- a/api/services/portfolio_service.py
+++ b/api/services/portfolio_service.py
@@ -10,6 +10,8 @@ import io
 import json
 import logging
 import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, date
 from pathlib import Path
 from typing import List, Dict, Any, Optional
@@ -42,6 +44,9 @@ class PortfolioService:
     STOP_LOSS_PCT = -10.0  # -10% triggers stop loss
     TAKE_PROFIT_PCT = 20.0  # +20% triggers take profit
 
+    # Price cache TTL in seconds (deduplicates concurrent requests)
+    PRICE_CACHE_TTL = 10
+
     def __init__(self, data_path: Optional[Path] = None):
         """
         Initialize the portfolio service.
@@ -53,6 +58,8 @@ class PortfolioService:
         self._lock = threading.RLock()
         self._cache = get_cache()
         self._holdings: Dict[str, Dict[str, Any]] = {}
+        self._price_cache: Dict[str, float] = {}
+        self._price_cache_time: float = 0.0
         self._load()
 
     def _load(self) -> None:
@@ -112,18 +119,47 @@ class PortfolioService:
         """
         Get current prices for multiple tickers.
 
+        Uses a short-lived in-memory cache (PRICE_CACHE_TTL seconds)
+        to deduplicate concurrent requests from the same page load.
+        Fetches prices in parallel using ThreadPoolExecutor.
+
         Args:
             tickers: List of ticker symbols
 
         Returns:
             Dict mapping ticker to current price
         """
-        prices = {}
-        for ticker in tickers:
-            price = self._get_current_price(ticker)
-            if price is not None:
-                prices[ticker] = price
-        return prices
+        if not tickers:
+            return {}
+
+        with self._lock:
+            now = time.monotonic()
+
+            # Return cached prices if still fresh and all requested tickers are present
+            if (now - self._price_cache_time < self.PRICE_CACHE_TTL
+                    and all(t in self._price_cache for t in tickers)):
+                return {t: self._price_cache[t] for t in tickers}
+
+            # Parallel fetch with ThreadPoolExecutor
+            prices: Dict[str, float] = {}
+            with ThreadPoolExecutor(max_workers=min(len(tickers), 8)) as executor:
+                futures = {
+                    executor.submit(self._get_current_price, t): t
+                    for t in tickers
+                }
+                for future in as_completed(futures):
+                    ticker = futures[future]
+                    try:
+                        price = future.result()
+                        if price is not None:
+                            prices[ticker] = price
+                    except Exception as e:
+                        logger.warning(f"Failed to fetch price for {ticker}: {e}")
+
+            # Update cache
+            self._price_cache = prices
+            self._price_cache_time = time.monotonic()
+            return prices
 
     def _holding_to_response(
         self,

--- a/api/tests/test_portfolio.py
+++ b/api/tests/test_portfolio.py
@@ -6,10 +6,14 @@ portfolio summary, sell signals, and CSV import/export.
 """
 
 import io
+import json
+import time
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+from api.services.portfolio_service import PortfolioService
 
 
 class TestGetHoldings:
@@ -651,3 +655,104 @@ class TestTemplate:
         assert resp.status_code == 200
         assert "text/csv" in resp.headers["content-type"]
         assert "attachment" in resp.headers["content-disposition"]
+
+
+def _write_holdings_json(path, holdings):
+    """Helper to write a portfolio JSON file with the given holdings."""
+    data = {
+        "holdings": holdings,
+        "updated_at": "2024-01-01",
+    }
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+class TestPriceCache:
+    """Tests for PortfolioService price cache and parallel fetch behavior."""
+
+    def test_price_cache_reuse(self, tmp_path):
+        """Cached prices are reused on the second call within TTL."""
+        # Arrange
+        data_file = tmp_path / "portfolio.json"
+        _write_holdings_json(data_file, [
+            {"ticker": "AAPL", "name": "Apple", "quantity": 10, "avg_price": 150.0, "currency": "USD"},
+            {"ticker": "MSFT", "name": "Microsoft", "quantity": 5, "avg_price": 300.0, "currency": "USD"},
+        ])
+        service = PortfolioService(data_path=data_file)
+
+        price_map = {"AAPL": 175.0, "MSFT": 320.0}
+
+        with patch.object(service, "_get_current_price", side_effect=lambda t: price_map[t]) as mock_price:
+            # Act
+            service.get_all_holdings(with_prices=True)
+            service.get_all_holdings(with_prices=True)
+
+            # Assert - second call should reuse cache, so only 2 calls total
+            assert mock_price.call_count == 2
+
+    def test_price_cache_expiry(self, tmp_path):
+        """Expired cache triggers a fresh fetch on the next call."""
+        # Arrange
+        data_file = tmp_path / "portfolio.json"
+        _write_holdings_json(data_file, [
+            {"ticker": "AAPL", "name": "Apple", "quantity": 10, "avg_price": 150.0, "currency": "USD"},
+            {"ticker": "MSFT", "name": "Microsoft", "quantity": 5, "avg_price": 300.0, "currency": "USD"},
+        ])
+        service = PortfolioService(data_path=data_file)
+
+        price_map = {"AAPL": 175.0, "MSFT": 320.0}
+
+        with patch.object(service, "_get_current_price", side_effect=lambda t: price_map[t]) as mock_price:
+            # Act - first call fetches prices
+            service.get_all_holdings(with_prices=True)
+
+            # Expire the cache by backdating the timestamp
+            service._price_cache_time = time.monotonic() - 11
+
+            # Second call should re-fetch because cache is expired
+            service.get_all_holdings(with_prices=True)
+
+            # Assert - 2 calls per invocation = 4 total
+            assert mock_price.call_count == 4
+
+    def test_parallel_price_fetch(self, tmp_path):
+        """_get_current_prices returns correct prices for all tickers."""
+        # Arrange
+        data_file = tmp_path / "portfolio.json"
+        _write_holdings_json(data_file, [
+            {"ticker": "AAPL", "name": "Apple", "quantity": 10, "avg_price": 150.0, "currency": "USD"},
+            {"ticker": "MSFT", "name": "Microsoft", "quantity": 5, "avg_price": 300.0, "currency": "USD"},
+            {"ticker": "GOOG", "name": "Alphabet", "quantity": 3, "avg_price": 140.0, "currency": "USD"},
+        ])
+        service = PortfolioService(data_path=data_file)
+
+        price_map = {"AAPL": 175.0, "MSFT": 320.0, "GOOG": 155.0}
+
+        with patch.object(service, "_get_current_price", side_effect=lambda t: price_map[t]):
+            # Act
+            result = service._get_current_prices(["AAPL", "MSFT", "GOOG"])
+
+            # Assert
+            assert result["AAPL"] == 175.0
+            assert result["MSFT"] == 320.0
+            assert result["GOOG"] == 155.0
+
+    def test_summary_reuses_cached_prices(self, tmp_path):
+        """get_summary reuses prices cached by a prior get_all_holdings call."""
+        # Arrange
+        data_file = tmp_path / "portfolio.json"
+        _write_holdings_json(data_file, [
+            {"ticker": "AAPL", "name": "Apple", "quantity": 10, "avg_price": 150.0, "currency": "USD"},
+            {"ticker": "MSFT", "name": "Microsoft", "quantity": 5, "avg_price": 300.0, "currency": "USD"},
+        ])
+        service = PortfolioService(data_path=data_file)
+
+        price_map = {"AAPL": 175.0, "MSFT": 320.0}
+
+        with patch.object(service, "_get_current_price", side_effect=lambda t: price_map[t]) as mock_price:
+            # Act - first call populates the cache
+            service.get_all_holdings(with_prices=True)
+            # get_summary internally calls get_all_holdings(with_prices=True)
+            service.get_summary()
+
+            # Assert - prices fetched only once (2 tickers), not twice (4 calls)
+            assert mock_price.call_count == 2


### PR DESCRIPTION
## Summary
- Add 10-second TTL in-memory price cache to `PortfolioService` to deduplicate concurrent price fetches from `/holdings`, `/summary`, and `/sell-signals` endpoints
- Replace sequential for-loop in `_get_current_prices()` with `ThreadPoolExecutor` for parallel I/O (max 8 workers)
- Protect cache check/update with `self._lock` to prevent cache stampede under concurrent requests

Closes #205

## Test plan
- [x] `test_price_cache_reuse` — cached prices reused within TTL (2 calls, not 4)
- [x] `test_price_cache_expiry` — expired cache triggers re-fetch (4 calls total)
- [x] `test_parallel_price_fetch` — parallel fetch returns correct prices for all tickers
- [x] `test_summary_reuses_cached_prices` — `get_summary()` reuses cache from prior `get_all_holdings()`
- [x] All 38 existing + new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)