### PR TITLE
Migrate portfolio storage from JSON to database

### DIFF
--- a/api/database.py
+++ b/api/database.py
@@ -49,12 +49,14 @@ def get_db():
 def init_db() -> None:
     """Create tables and migrate legacy JSON data if present."""
     import api.models.agent_task  # noqa: F401 — register model with Base
+    import api.models.portfolio  # noqa: F401 — register model with Base
     import api.models.strategy  # noqa: F401 — register model with Base
 
     Base.metadata.create_all(bind=engine)
     logger.info("Database tables ensured")
 
     _migrate_json_data()
+    _migrate_portfolio_json()
 
 
 def _migrate_json_data() -> None:
@@ -123,6 +125,84 @@ def _migrate_json_data() -> None:
     except Exception as e:
         db.rollback()
         logger.error("JSON migration failed: %s", e)
+        return
+    finally:
+        db.close()
+
+    if migrated > 0:
+        migrated_path = json_path.with_suffix(".json.migrated")
+        try:
+            json_path.rename(migrated_path)
+            logger.info("Renamed %s → %s", json_path, migrated_path)
+        except OSError as e:
+            logger.warning("Could not rename migrated file: %s", e)
+
+
+def _migrate_portfolio_json() -> None:
+    """One-time migration: import data/portfolio.json into the DB."""
+    json_path = Path(__file__).parent.parent / "data" / "portfolio.json"
+    if not json_path.exists():
+        return
+
+    try:
+        with open(json_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception as e:
+        logger.warning("Could not read portfolio JSON for migration: %s", e)
+        return
+
+    holdings = data.get("holdings", [])
+    if not holdings:
+        return
+
+    from api.models.portfolio import Holding
+
+    db = SessionLocal()
+    migrated = 0
+    skipped = 0
+    try:
+        existing_tickers = {
+            row[0] for row in db.query(Holding.ticker).all()
+        }
+
+        for h in holdings:
+            ticker = h.get("ticker")
+            if not ticker:
+                logger.warning("Skipping portfolio record with no ticker")
+                skipped += 1
+                continue
+
+            if ticker in existing_tickers:
+                skipped += 1
+                continue
+
+            row = Holding(
+                ticker=ticker,
+                name=h.get("name"),
+                quantity=h.get("quantity", 0),
+                avg_price=h.get("avg_price", 0),
+                currency=h.get("currency", "KRW"),
+                note=h.get("note"),
+            )
+            bought_at = h.get("bought_at")
+            if bought_at:
+                try:
+                    from datetime import date as date_type
+                    row.bought_at = date_type.fromisoformat(bought_at)
+                except (ValueError, TypeError):
+                    pass
+            db.add(row)
+            existing_tickers.add(ticker)
+            migrated += 1
+
+        if migrated > 0:
+            db.commit()
+        logger.info(
+            "Portfolio JSON migration: %d migrated, %d skipped", migrated, skipped
+        )
+    except Exception as e:
+        db.rollback()
+        logger.error("Portfolio JSON migration failed: %s", e)
         return
     finally:
         db.close()

--- a/api/models/portfolio.py
+++ b/api/models/portfolio.py
@@ -1,0 +1,23 @@
+"""
+SQLAlchemy model for the holdings table.
+"""
+
+from datetime import date, datetime
+
+from sqlalchemy import Column, Date, DateTime, Float, Integer, String, Text
+
+from api.database import Base
+
+
+class Holding(Base):
+    __tablename__ = "holdings"
+
+    ticker = Column(String(32), primary_key=True)
+    name = Column(String(255), nullable=True)
+    quantity = Column(Integer, nullable=False)
+    avg_price = Column(Float, nullable=False)
+    currency = Column(String(8), nullable=False, default="KRW")
+    note = Column(Text, nullable=True)
+    bought_at = Column(Date, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)

--- a/api/services/portfolio_service.py
+++ b/api/services/portfolio_service.py
@@ -7,15 +7,15 @@ Provides CRUD operations for holdings and P&L calculations.
 
 import csv
 import io
-import json
 import logging
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, date
-from pathlib import Path
 from typing import List, Dict, Any, Optional
 
+from api.database import SessionLocal
+from api.models.portfolio import Holding
 from api.schemas.portfolio import (
     HoldingCreate,
     HoldingUpdate,
@@ -38,8 +38,6 @@ class PortfolioService:
     P&L calculations, and sell signal detection.
     """
 
-    DEFAULT_DATA_PATH = Path(__file__).parent.parent.parent / "data" / "portfolio.json"
-
     # Default sell signal thresholds
     STOP_LOSS_PCT = -10.0  # -10% triggers stop loss
     TAKE_PROFIT_PCT = 20.0  # +20% triggers take profit
@@ -47,55 +45,24 @@ class PortfolioService:
     # Price cache TTL in seconds (deduplicates concurrent requests)
     PRICE_CACHE_TTL = 10
 
-    def __init__(self, data_path: Optional[Path] = None):
-        """
-        Initialize the portfolio service.
-
-        Args:
-            data_path: Path to portfolio JSON file (default: data/portfolio.json)
-        """
-        self.data_path = data_path or self.DEFAULT_DATA_PATH
+    def __init__(self):
         self._lock = threading.RLock()
         self._cache = get_cache()
-        self._holdings: Dict[str, Dict[str, Any]] = {}
         self._price_cache: Dict[str, float] = {}
         self._price_cache_time: float = 0.0
-        self._load()
 
-    def _load(self) -> None:
-        """Load portfolio data from JSON file."""
-        if self.data_path.exists():
-            try:
-                with open(self.data_path, "r", encoding="utf-8") as f:
-                    data = json.load(f)
-                    holdings_list = data.get("holdings", [])
-                    self._holdings = {h["ticker"]: h for h in holdings_list}
-                    logger.info(f"Loaded {len(self._holdings)} holdings from {self.data_path}")
-            except Exception as e:
-                logger.warning(f"Failed to load portfolio data: {e}")
-                self._holdings = {}
-        else:
-            # Create initial data file
-            self._save()
-
-    def _save(self) -> None:
-        """Save portfolio data to JSON file."""
-        with self._lock:
-            try:
-                self.data_path.parent.mkdir(parents=True, exist_ok=True)
-
-                data = {
-                    "holdings": list(self._holdings.values()),
-                    "updated_at": datetime.now().isoformat()
-                }
-
-                with open(self.data_path, "w", encoding="utf-8") as f:
-                    json.dump(data, f, ensure_ascii=False, indent=2, default=str)
-
-                logger.debug(f"Saved portfolio data to {self.data_path}")
-            except Exception as e:
-                logger.error(f"Failed to save portfolio data: {e}")
-                raise
+    @staticmethod
+    def _row_to_dict(row: Holding) -> Dict[str, Any]:
+        """Convert ORM Holding to dict for _holding_to_response()."""
+        return {
+            "ticker": row.ticker,
+            "name": row.name,
+            "quantity": row.quantity,
+            "avg_price": row.avg_price,
+            "currency": row.currency,
+            "note": row.note,
+            "bought_at": row.bought_at,
+        }
 
     def _get_current_price(self, ticker: str) -> Optional[float]:
         """
@@ -222,18 +189,22 @@ class PortfolioService:
         Returns:
             List of HoldingResponse objects
         """
-        holdings = []
-        prices = {}
+        db = SessionLocal()
+        try:
+            rows = db.query(Holding).all()
+            holdings_dicts = [self._row_to_dict(r) for r in rows]
+        finally:
+            db.close()
 
-        if with_prices:
-            tickers = list(self._holdings.keys())
+        prices = {}
+        if with_prices and holdings_dicts:
+            tickers = [h["ticker"] for h in holdings_dicts]
             prices = self._get_current_prices(tickers)
 
-        for ticker, holding in self._holdings.items():
-            current_price = prices.get(ticker)
-            holdings.append(self._holding_to_response(holding, current_price))
-
-        return holdings
+        return [
+            self._holding_to_response(h, prices.get(h["ticker"]))
+            for h in holdings_dicts
+        ]
 
     def get_holding(self, ticker: str, with_price: bool = True) -> Optional[HoldingResponse]:
         """
@@ -246,9 +217,14 @@ class PortfolioService:
         Returns:
             HoldingResponse or None if not found
         """
-        holding = self._holdings.get(ticker)
-        if not holding:
-            return None
+        db = SessionLocal()
+        try:
+            row = db.get(Holding, ticker)
+            if not row:
+                return None
+            holding = self._row_to_dict(row)
+        finally:
+            db.close()
 
         current_price = None
         if with_price:
@@ -269,44 +245,51 @@ class PortfolioService:
             Created/updated HoldingResponse
         """
         ticker = data.ticker
-        existing = self._holdings.get(ticker)
+        db = SessionLocal()
+        try:
+            existing = db.get(Holding, ticker)
 
-        if existing:
-            # Add to existing position - calculate new average price
-            old_quantity = existing.get("quantity", 0)
-            old_avg_price = existing.get("avg_price", 0)
-            old_cost = old_quantity * old_avg_price
+            if existing:
+                # Add to existing position - calculate new average price
+                old_cost = existing.quantity * existing.avg_price
+                new_cost = data.quantity * data.avg_price
+                total_quantity = existing.quantity + data.quantity
+                new_avg_price = (old_cost + new_cost) / total_quantity if total_quantity > 0 else 0
 
-            new_cost = data.quantity * data.avg_price
-            total_quantity = old_quantity + data.quantity
-            new_avg_price = (old_cost + new_cost) / total_quantity if total_quantity > 0 else 0
+                existing.quantity = total_quantity
+                existing.avg_price = new_avg_price
+                if data.name:
+                    existing.name = data.name
+                if data.note:
+                    existing.note = data.note
+                existing.currency = data.currency
 
-            existing["quantity"] = total_quantity
-            existing["avg_price"] = new_avg_price
-            if data.name:
-                existing["name"] = data.name
-            if data.note:
-                existing["note"] = data.note
-            existing["currency"] = data.currency
+                logger.info(f"Updated holding: {ticker} (qty: {total_quantity}, avg: {new_avg_price:.2f})")
+            else:
+                # Create new holding
+                existing = Holding(
+                    ticker=ticker,
+                    name=data.name or ticker,
+                    quantity=data.quantity,
+                    avg_price=data.avg_price,
+                    currency=data.currency,
+                    note=data.note,
+                    bought_at=date.today(),
+                )
+                db.add(existing)
+                logger.info(f"Added holding: {ticker} (qty: {data.quantity}, avg: {data.avg_price:.2f})")
 
-            logger.info(f"Updated holding: {ticker} (qty: {total_quantity}, avg: {new_avg_price:.2f})")
-        else:
-            # Create new holding
-            self._holdings[ticker] = {
-                "ticker": ticker,
-                "name": data.name or ticker,
-                "quantity": data.quantity,
-                "avg_price": data.avg_price,
-                "currency": data.currency,
-                "note": data.note,
-                "bought_at": date.today().isoformat(),
-            }
-            logger.info(f"Added holding: {ticker} (qty: {data.quantity}, avg: {data.avg_price:.2f})")
-
-        self._save()
+            db.commit()
+            db.refresh(existing)
+            holding = self._row_to_dict(existing)
+        except Exception:
+            db.rollback()
+            raise
+        finally:
+            db.close()
 
         current_price = self._get_current_price(ticker)
-        return self._holding_to_response(self._holdings[ticker], current_price)
+        return self._holding_to_response(holding, current_price)
 
     def update_holding(self, ticker: str, data: HoldingUpdate) -> Optional[HoldingResponse]:
         """
@@ -319,21 +302,30 @@ class PortfolioService:
         Returns:
             Updated HoldingResponse or None if not found
         """
-        holding = self._holdings.get(ticker)
-        if not holding:
-            return None
+        db = SessionLocal()
+        try:
+            row = db.get(Holding, ticker)
+            if not row:
+                return None
 
-        if data.quantity is not None:
-            holding["quantity"] = data.quantity
-        if data.avg_price is not None:
-            holding["avg_price"] = data.avg_price
-        if data.name is not None:
-            holding["name"] = data.name
-        if data.note is not None:
-            holding["note"] = data.note
+            if data.quantity is not None:
+                row.quantity = data.quantity
+            if data.avg_price is not None:
+                row.avg_price = data.avg_price
+            if data.name is not None:
+                row.name = data.name
+            if data.note is not None:
+                row.note = data.note
 
-        self._save()
-        logger.info(f"Updated holding: {ticker}")
+            db.commit()
+            db.refresh(row)
+            holding = self._row_to_dict(row)
+            logger.info(f"Updated holding: {ticker}")
+        except Exception:
+            db.rollback()
+            raise
+        finally:
+            db.close()
 
         current_price = self._get_current_price(ticker)
         return self._holding_to_response(holding, current_price)
@@ -348,12 +340,20 @@ class PortfolioService:
         Returns:
             True if removed, False if not found
         """
-        if ticker in self._holdings:
-            del self._holdings[ticker]
-            self._save()
+        db = SessionLocal()
+        try:
+            row = db.get(Holding, ticker)
+            if not row:
+                return False
+            db.delete(row)
+            db.commit()
             logger.info(f"Removed holding: {ticker}")
             return True
-        return False
+        except Exception:
+            db.rollback()
+            raise
+        finally:
+            db.close()
 
     def get_summary(self) -> PortfolioSummary:
         """
@@ -458,32 +458,59 @@ class PortfolioService:
             }
             valid_rows.append(parsed)
 
-        with self._lock:
-            backup = {k: dict(v) for k, v in self._holdings.items()}
+        db = SessionLocal()
+        try:
+            if mode == "replace":
+                db.query(Holding).delete()
 
-            try:
-                if mode == "replace":
-                    self._holdings.clear()
+            existing_tickers = {
+                row[0] for row in db.query(Holding.ticker).all()
+            }
 
-                for parsed in valid_rows:
-                    ticker = parsed["ticker"]
-                    if ticker in self._holdings and mode == "merge":
-                        existing_bought_at = self._holdings[ticker].get("bought_at")
-                        self._holdings[ticker].update(parsed)
-                        # Preserve existing bought_at if CSV didn't provide one
-                        if not parsed["bought_at"] and existing_bought_at:
-                            self._holdings[ticker]["bought_at"] = existing_bought_at
-                        updated += 1
-                    else:
-                        if not parsed["bought_at"]:
-                            parsed["bought_at"] = date.today().isoformat()
-                        self._holdings[ticker] = parsed
-                        imported += 1
+            for parsed in valid_rows:
+                ticker = parsed["ticker"]
+                bought_at_val = parsed["bought_at"]
+                bought_at_date = None
+                if bought_at_val:
+                    try:
+                        bought_at_date = date.fromisoformat(bought_at_val)
+                    except (ValueError, TypeError):
+                        bought_at_date = None
 
-                self._save()
-            except Exception:
-                self._holdings = backup
-                raise
+                if ticker in existing_tickers and mode == "merge":
+                    row = db.get(Holding, ticker)
+                    existing_bought_at = row.bought_at
+                    row.name = parsed["name"]
+                    row.quantity = parsed["quantity"]
+                    row.avg_price = parsed["avg_price"]
+                    row.currency = parsed["currency"]
+                    row.note = parsed["note"]
+                    # Preserve existing bought_at if CSV didn't provide one
+                    if bought_at_date:
+                        row.bought_at = bought_at_date
+                    elif existing_bought_at:
+                        pass  # keep existing
+                    updated += 1
+                else:
+                    new_row = Holding(
+                        ticker=ticker,
+                        name=parsed["name"],
+                        quantity=parsed["quantity"],
+                        avg_price=parsed["avg_price"],
+                        currency=parsed["currency"],
+                        note=parsed["note"],
+                        bought_at=bought_at_date or date.today(),
+                    )
+                    db.merge(new_row)
+                    existing_tickers.add(ticker)
+                    imported += 1
+
+            db.commit()
+        except Exception:
+            db.rollback()
+            raise
+        finally:
+            db.close()
 
         logger.info(f"CSV import: imported={imported}, updated={updated}, skipped={len(errors)}")
 
@@ -501,15 +528,24 @@ class PortfolioService:
         Returns:
             CSV string with header and data rows
         """
+        db = SessionLocal()
+        try:
+            rows = db.query(Holding).all()
+            holdings_dicts = [self._row_to_dict(r) for r in rows]
+        finally:
+            db.close()
+
         output = io.StringIO()
         columns = ["ticker", "quantity", "avg_price", "name", "currency", "note", "bought_at"]
         writer = csv.DictWriter(output, fieldnames=columns, extrasaction="ignore")
         writer.writeheader()
 
-        for holding in self._holdings.values():
+        for holding in holdings_dicts:
             row = {col: holding.get(col, "") for col in columns}
             if row["note"] is None:
                 row["note"] = ""
+            if isinstance(row["bought_at"], date):
+                row["bought_at"] = row["bought_at"].isoformat()
             writer.writerow(row)
 
         return output.getvalue()

--- a/api/tests/test_portfolio.py
+++ b/api/tests/test_portfolio.py
@@ -6,7 +6,6 @@ portfolio summary, sell signals, and CSV import/export.
 """
 
 import io
-import json
 import time
 from datetime import datetime
 from unittest.mock import MagicMock, patch
@@ -657,102 +656,123 @@ class TestTemplate:
         assert "attachment" in resp.headers["content-disposition"]
 
 
-def _write_holdings_json(path, holdings):
-    """Helper to write a portfolio JSON file with the given holdings."""
-    data = {
-        "holdings": holdings,
-        "updated_at": "2024-01-01",
-    }
-    path.write_text(json.dumps(data), encoding="utf-8")
+def _setup_test_db(holdings):
+    """Create an in-memory SQLite DB and seed it with holdings dicts.
+
+    Returns a patched SessionLocal bound to the in-memory engine.
+    """
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+
+    from api.database import Base
+    from api.models.portfolio import Holding
+
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(bind=engine)
+    TestSession = sessionmaker(bind=engine)
+
+    db = TestSession()
+    for h in holdings:
+        db.add(Holding(
+            ticker=h["ticker"],
+            name=h.get("name"),
+            quantity=h["quantity"],
+            avg_price=h["avg_price"],
+            currency=h.get("currency", "KRW"),
+        ))
+    db.commit()
+    db.close()
+
+    return TestSession
 
 
 class TestPriceCache:
     """Tests for PortfolioService price cache and parallel fetch behavior."""
 
-    def test_price_cache_reuse(self, tmp_path):
+    def test_price_cache_reuse(self):
         """Cached prices are reused on the second call within TTL."""
         # Arrange
-        data_file = tmp_path / "portfolio.json"
-        _write_holdings_json(data_file, [
+        test_session = _setup_test_db([
             {"ticker": "AAPL", "name": "Apple", "quantity": 10, "avg_price": 150.0, "currency": "USD"},
             {"ticker": "MSFT", "name": "Microsoft", "quantity": 5, "avg_price": 300.0, "currency": "USD"},
         ])
-        service = PortfolioService(data_path=data_file)
 
-        price_map = {"AAPL": 175.0, "MSFT": 320.0}
+        with patch("api.services.portfolio_service.SessionLocal", test_session):
+            service = PortfolioService()
+            price_map = {"AAPL": 175.0, "MSFT": 320.0}
 
-        with patch.object(service, "_get_current_price", side_effect=lambda t: price_map[t]) as mock_price:
-            # Act
-            service.get_all_holdings(with_prices=True)
-            service.get_all_holdings(with_prices=True)
+            with patch.object(service, "_get_current_price", side_effect=lambda t: price_map[t]) as mock_price:
+                # Act
+                service.get_all_holdings(with_prices=True)
+                service.get_all_holdings(with_prices=True)
 
-            # Assert - second call should reuse cache, so only 2 calls total
-            assert mock_price.call_count == 2
+                # Assert - second call should reuse cache, so only 2 calls total
+                assert mock_price.call_count == 2
 
-    def test_price_cache_expiry(self, tmp_path):
+    def test_price_cache_expiry(self):
         """Expired cache triggers a fresh fetch on the next call."""
         # Arrange
-        data_file = tmp_path / "portfolio.json"
-        _write_holdings_json(data_file, [
+        test_session = _setup_test_db([
             {"ticker": "AAPL", "name": "Apple", "quantity": 10, "avg_price": 150.0, "currency": "USD"},
             {"ticker": "MSFT", "name": "Microsoft", "quantity": 5, "avg_price": 300.0, "currency": "USD"},
         ])
-        service = PortfolioService(data_path=data_file)
 
-        price_map = {"AAPL": 175.0, "MSFT": 320.0}
+        with patch("api.services.portfolio_service.SessionLocal", test_session):
+            service = PortfolioService()
+            price_map = {"AAPL": 175.0, "MSFT": 320.0}
 
-        with patch.object(service, "_get_current_price", side_effect=lambda t: price_map[t]) as mock_price:
-            # Act - first call fetches prices
-            service.get_all_holdings(with_prices=True)
+            with patch.object(service, "_get_current_price", side_effect=lambda t: price_map[t]) as mock_price:
+                # Act - first call fetches prices
+                service.get_all_holdings(with_prices=True)
 
-            # Expire the cache by backdating the timestamp
-            service._price_cache_time = time.monotonic() - 11
+                # Expire the cache by backdating the timestamp
+                service._price_cache_time = time.monotonic() - 11
 
-            # Second call should re-fetch because cache is expired
-            service.get_all_holdings(with_prices=True)
+                # Second call should re-fetch because cache is expired
+                service.get_all_holdings(with_prices=True)
 
-            # Assert - 2 calls per invocation = 4 total
-            assert mock_price.call_count == 4
+                # Assert - 2 calls per invocation = 4 total
+                assert mock_price.call_count == 4
 
-    def test_parallel_price_fetch(self, tmp_path):
+    def test_parallel_price_fetch(self):
         """_get_current_prices returns correct prices for all tickers."""
         # Arrange
-        data_file = tmp_path / "portfolio.json"
-        _write_holdings_json(data_file, [
+        test_session = _setup_test_db([
             {"ticker": "AAPL", "name": "Apple", "quantity": 10, "avg_price": 150.0, "currency": "USD"},
             {"ticker": "MSFT", "name": "Microsoft", "quantity": 5, "avg_price": 300.0, "currency": "USD"},
             {"ticker": "GOOG", "name": "Alphabet", "quantity": 3, "avg_price": 140.0, "currency": "USD"},
         ])
-        service = PortfolioService(data_path=data_file)
 
-        price_map = {"AAPL": 175.0, "MSFT": 320.0, "GOOG": 155.0}
+        with patch("api.services.portfolio_service.SessionLocal", test_session):
+            service = PortfolioService()
+            price_map = {"AAPL": 175.0, "MSFT": 320.0, "GOOG": 155.0}
 
-        with patch.object(service, "_get_current_price", side_effect=lambda t: price_map[t]):
-            # Act
-            result = service._get_current_prices(["AAPL", "MSFT", "GOOG"])
+            with patch.object(service, "_get_current_price", side_effect=lambda t: price_map[t]):
+                # Act
+                result = service._get_current_prices(["AAPL", "MSFT", "GOOG"])
 
-            # Assert
-            assert result["AAPL"] == 175.0
-            assert result["MSFT"] == 320.0
-            assert result["GOOG"] == 155.0
+                # Assert
+                assert result["AAPL"] == 175.0
+                assert result["MSFT"] == 320.0
+                assert result["GOOG"] == 155.0
 
-    def test_summary_reuses_cached_prices(self, tmp_path):
+    def test_summary_reuses_cached_prices(self):
         """get_summary reuses prices cached by a prior get_all_holdings call."""
         # Arrange
-        data_file = tmp_path / "portfolio.json"
-        _write_holdings_json(data_file, [
+        test_session = _setup_test_db([
             {"ticker": "AAPL", "name": "Apple", "quantity": 10, "avg_price": 150.0, "currency": "USD"},
             {"ticker": "MSFT", "name": "Microsoft", "quantity": 5, "avg_price": 300.0, "currency": "USD"},
         ])
-        service = PortfolioService(data_path=data_file)
 
-        price_map = {"AAPL": 175.0, "MSFT": 320.0}
+        with patch("api.services.portfolio_service.SessionLocal", test_session):
+            service = PortfolioService()
+            price_map = {"AAPL": 175.0, "MSFT": 320.0}
 
-        with patch.object(service, "_get_current_price", side_effect=lambda t: price_map[t]) as mock_price:
-            # Act - first call populates the cache
-            service.get_all_holdings(with_prices=True)
-            # get_summary internally calls get_all_holdings(with_prices=True)
-            service.get_summary()
+            with patch.object(service, "_get_current_price", side_effect=lambda t: price_map[t]) as mock_price:
+                # Act - first call populates the cache
+                service.get_all_holdings(with_prices=True)
+                # get_summary internally calls get_all_holdings(with_prices=True)
+                service.get_summary()
 
-            # Assert - prices fetched only once (2 tickers), not twice (4 calls)
-            assert mock_price.call_count == 2
+                # Assert - prices fetched only once (2 tickers), not twice (4 calls)
+                assert mock_price.call_count == 2


### PR DESCRIPTION
## Summary
- Add SQLAlchemy `Holding` model (`api/models/portfolio.py`) with `ticker` as primary key
- Add one-time `data/portfolio.json` → DB migration in `init_db()`, following the existing `_migrate_json_data()` pattern
- Rewrite `PortfolioService` to use `SessionLocal()` DB queries instead of in-memory dict + JSON file I/O
- Keep price cache, P&L calculation, CSV import/export, and sell signal logic unchanged
- Update `TestPriceCache` tests to use in-memory SQLite via patched `SessionLocal`

## Test plan
- [x] All 38 portfolio tests pass (`pytest api/tests/test_portfolio.py -v`)
- [ ] Manual: `python -c "from api.database import init_db; init_db()"` — verify `holdings` table created
- [ ] Manual: If `data/portfolio.json` exists, verify it's renamed to `.json.migrated` after migration
- [ ] Manual: `curl http://localhost:8002/api/portfolio/holdings` — verify API returns holdings from DB

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)