### PR TITLE
Fix task-tracker hook reliability and add debug mode

### DIFF
--- a/.claude/hooks/agent-task-tracker.py
+++ b/.claude/hooks/agent-task-tracker.py
@@ -6,20 +6,64 @@ Reads TaskCreate/TaskUpdate tool events from stdin and forwards them
 to the local agent-task API via fire-and-forget curl.
 
 Any error is silently swallowed so the hook never blocks the main session.
+
+Debug mode:
+  Set AGENT_TASK_HOOK_DEBUG=1 to write trace logs to a user-specific log file.
+  Log path: /tmp/agent-task-hook-{uid}.log (permissions 0600)
 """
 
 import json
+import os
 import subprocess
 import sys
+from datetime import datetime
+from typing import Any, Dict, Optional
+from urllib.parse import quote
 
 API_BASE = "http://127.0.0.1:8765/api/agent-tasks"
+DEBUG = os.environ.get("AGENT_TASK_HOOK_DEBUG") == "1"
+DEBUG_LOG = f"/tmp/agent-task-hook-{os.getuid()}.log"
+
+
+def _log(msg: str) -> None:
+    """Append a line to the debug log (only when DEBUG is enabled)."""
+    if not DEBUG:
+        return
+    try:
+        fd = os.open(DEBUG_LOG, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+        with os.fdopen(fd, "a", encoding="utf-8") as f:
+            f.write(f"[{datetime.now().isoformat()}] {msg}\n")
+    except Exception:
+        pass
+
+
+def _extract_task_id(source: Dict[str, Any]) -> str:
+    """Extract task_id from a dict, trying multiple key conventions."""
+    return str(
+        source.get("task_id")
+        or source.get("taskId")
+        or source.get("id")
+        or ""
+    )
+
+
+def _extract_meta(tool_input: Dict[str, Any], key: str) -> Optional[str]:
+    """Extract a meta field from top-level first, then metadata fallback."""
+    val = tool_input.get(key)
+    if val is not None:
+        return val
+    metadata = tool_input.get("metadata")
+    if isinstance(metadata, dict):
+        return metadata.get(key)
+    return None
 
 
 def main() -> None:
     try:
         raw = sys.stdin.read()
         event = json.loads(raw)
-    except Exception:
+    except Exception as e:
+        _log(f"Failed to parse stdin: {e}")
         sys.exit(0)
 
     tool_name = event.get("tool_name", "")
@@ -27,22 +71,27 @@ def main() -> None:
     tool_response = event.get("tool_response", {})
     session_id = event.get("session_id", "")
 
+    _log(f"Event: tool={tool_name}, input_keys={list(tool_input.keys())}")
+
     if tool_name == "TaskCreate":
         # Extract task_id from the tool_response (created task)
-        task_id = tool_response.get("taskId") or tool_response.get("id", "")
+        task_id = _extract_task_id(tool_response)
         if not task_id:
+            _log("TaskCreate: no task_id found in response, skipping")
             sys.exit(0)
 
         payload = {
-            "task_id": str(task_id),
+            "task_id": task_id,
             "session_id": session_id or None,
-            "agent_type": tool_input.get("metadata", {}).get("agent_type") if tool_input.get("metadata") else None,
-            "team_name": tool_input.get("metadata", {}).get("team_name") if tool_input.get("metadata") else None,
+            "agent_type": _extract_meta(tool_input, "agent_type"),
+            "team_name": _extract_meta(tool_input, "team_name"),
             "subject": tool_input.get("subject", ""),
             "description": tool_input.get("description"),
             "status": "pending",
             "metadata_json": tool_input.get("metadata"),
         }
+
+        _log(f"TaskCreate: task_id={task_id}, status=pending")
 
         subprocess.Popen(
             [
@@ -58,12 +107,13 @@ def main() -> None:
         )
 
     elif tool_name == "TaskUpdate":
-        task_id = tool_input.get("taskId") or tool_input.get("id", "")
+        task_id = _extract_task_id(tool_input)
         if not task_id:
+            _log("TaskUpdate: no task_id found in input, skipping")
             sys.exit(0)
 
         payload = {
-            "task_id": str(task_id),
+            "task_id": task_id,
             "session_id": session_id or None,
         }
         if tool_input.get("status") is not None:
@@ -75,10 +125,22 @@ def main() -> None:
         if tool_input.get("metadata") is not None:
             payload["metadata_json"] = tool_input["metadata"]
 
+        # Extract meta fields for update too
+        agent_type = _extract_meta(tool_input, "agent_type")
+        if agent_type is not None:
+            payload["agent_type"] = agent_type
+        team_name = _extract_meta(tool_input, "team_name")
+        if team_name is not None:
+            payload["team_name"] = team_name
+
+        _log(f"TaskUpdate: task_id={task_id}, status={payload.get('status')}")
+
+        # URL-encode task_id to safely handle special characters
+        safe_id = quote(str(task_id), safe="")
         subprocess.Popen(
             [
                 "curl", "-s", "-X", "PUT",
-                f"{API_BASE}/{task_id}",
+                f"{API_BASE}/{safe_id}",
                 "-H", "Content-Type: application/json",
                 "-d", json.dumps(payload),
                 "--connect-timeout", "2",
@@ -89,10 +151,13 @@ def main() -> None:
             start_new_session=True,
         )
 
+    else:
+        _log(f"Ignored tool: {tool_name}")
+
 
 if __name__ == "__main__":
     try:
         main()
-    except Exception:
-        pass
+    except Exception as e:
+        _log(f"Unhandled exception: {e}")
     sys.exit(0)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -495,10 +495,24 @@ PostToolUse 훅이 자동으로 `http://127.0.0.1:8765/api/agent-tasks`에 전�
 | 필드 | 설명 |
 |------|------|
 | `session_id` | 현재 세션 ID |
-| `agent_type` | 서브에이전트 타입 (metadata에 포함) |
-| `team_name` | 팀 이름 (metadata에 포함) |
+| `agent_type` | 서브에이전트 타입 (top-level 또는 metadata 내부) |
+| `team_name` | 팀 이름 (top-level 또는 metadata 내부) |
 | `description` | 작업 상세 설명 |
 | `files_modified` | 수정된 파일 목록 (TaskUpdate 시) |
+
+### task_id 식별 우선순위
+
+훅은 아래 순서로 task_id를 탐색한다:
+1. `task_id` (snake_case)
+2. `taskId` (camelCase)
+3. `id`
+
+### agent_type / team_name 추출
+
+top-level 필드를 우선 사용하고, 없으면 `metadata` 내부에서 fallback:
+```
+tool_input.agent_type → tool_input.metadata.agent_type
+```
 
 ### status 허용값
 
@@ -506,6 +520,22 @@ PostToolUse 훅이 자동으로 `http://127.0.0.1:8765/api/agent-tasks`에 전�
 
 ### 훅 동작 방식
 
-- `.claude/hooks/agent-task-tracker.py`가 PostToolUse 훅으로 실행
+- `~/.claude/hooks/agent-task-tracker.py`가 PostToolUse 훅으로 실행 (절대경로)
 - `subprocess.Popen` + `start_new_session=True`로 비동기 fire-and-forget
 - API 실패 시에도 본 작업은 블로킹되지 않음 (항상 exit 0)
+- 프로젝트 사본: `.claude/hooks/agent-task-tracker.py` (레퍼런스용)
+
+### 디버그 모드
+
+기본은 무소음(silent). 문제 추적 시:
+```bash
+export AGENT_TASK_HOOK_DEBUG=1
+```
+활성화하면 `/tmp/agent-task-hook.log`에 이벤트별 trace 로그가 기록된다.
+디버그 완료 후 `unset AGENT_TASK_HOOK_DEBUG`로 비활성화.
+
+### 실행 전제 조건
+
+- API 서버가 `127.0.0.1:8765`에서 실행 중이어야 함
+- 훅 command는 `~/.claude/settings.json`에 **절대경로**로 등록됨
+- 작업 디렉토리와 무관하게 실행됨


### PR DESCRIPTION
## Summary
- Support `task_id` (snake_case) key in TaskUpdate — previously only `taskId`/`id` were recognized, causing update events to silently drop
- Extract `agent_type`/`team_name` from top-level first, fallback to `metadata` dict
- URL-encode `task_id` in PUT path to safely handle special characters
- Add `AGENT_TASK_HOOK_DEBUG=1` env var for opt-in trace logging to `/tmp/agent-task-hook-{uid}.log`
- Use `os.open()` with `0o600` permissions and uid-based log path for security
- Use `Optional[str]` type hints for Python 3.9+ compatibility
- Update CLAUDE.md section 12 with extraction rules, debug mode, and prerequisites

## Test plan
- [x] Unit test: `task_id`, `taskId`, `id` all correctly extracted
- [x] Unit test: `agent_type`/`team_name` top-level priority with metadata fallback
- [x] Debug mode: log written only when `AGENT_TASK_HOOK_DEBUG=1`
- [x] Debug mode: log path includes uid, permissions 0600
- [x] Python syntax valid (ast.parse)
- [ ] Manual: simulate hook with `echo '...' | AGENT_TASK_HOOK_DEBUG=1 python3 .claude/hooks/agent-task-tracker.py`

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)