### PR TITLE
feat: add exchange-rate endpoint and base-currency portfolio summary

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -12,7 +12,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from api.config import get_settings
 from api.database import init_db
-from api.routers import analysis_router, health_router, portfolio_router, screening_router
+from api.routers import analysis_router, exchange_rates_router, health_router, portfolio_router, screening_router
 from api.routers.backtest import router as backtest_router
 from api.routers.market import router as market_router
 from api.routers.search import router as search_router
@@ -86,6 +86,7 @@ def create_app() -> FastAPI:
     app.include_router(market_router)
     app.include_router(analysis_router)
     app.include_router(portfolio_router)
+    app.include_router(exchange_rates_router)
     app.include_router(screening_router)
     app.include_router(search_router)
     app.include_router(strategy_router)

--- a/api/routers/__init__.py
+++ b/api/routers/__init__.py
@@ -5,6 +5,7 @@ Export all routers for registration in the main application.
 """
 
 from api.routers.analysis import router as analysis_router
+from api.routers.exchange_rates import router as exchange_rates_router
 from api.routers.health import router as health_router
 from api.routers.market import router as market_router
 from api.routers.portfolio import router as portfolio_router
@@ -16,6 +17,7 @@ from api.routers.strategy import router as strategy_router
 __all__ = [
     "analysis_router",
     "backtest_router",
+    "exchange_rates_router",
     "health_router",
     "market_router",
     "portfolio_router",

--- a/api/routers/exchange_rates.py
+++ b/api/routers/exchange_rates.py
@@ -1,0 +1,40 @@
+"""
+Exchange rate router.
+"""
+
+import logging
+
+from fastapi import APIRouter, HTTPException, Query
+
+from api.schemas.exchange_rate import ExchangeRatesResponse
+from api.services.exchange_rate_service import get_exchange_rate_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/api/exchange-rates",
+    tags=["Exchange Rates"],
+)
+
+
+@router.get(
+    "",
+    response_model=ExchangeRatesResponse,
+    summary="Get Exchange Rates",
+    description="Get latest exchange rates for a base currency (cached for 1 hour).",
+)
+async def get_exchange_rates(
+    base: str = Query(default="USD", min_length=3, max_length=3, description="Base currency"),
+) -> ExchangeRatesResponse:
+    """
+    Return exchange rates relative to the requested base currency.
+    """
+    service = get_exchange_rate_service()
+    try:
+        result = service.get_rates(base=base)
+        return ExchangeRatesResponse(**result)
+    except RuntimeError as e:
+        raise HTTPException(status_code=503, detail=str(e))
+    except Exception as e:
+        logger.error("Failed to get exchange rates: %s", e, exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to get exchange rates: {e}")

--- a/api/routers/portfolio.py
+++ b/api/routers/portfolio.py
@@ -372,7 +372,14 @@ async def remove_holding(ticker: str) -> None:
     summary="Get Portfolio Summary",
     description="Get aggregated portfolio summary with total P&L.",
 )
-async def get_summary() -> PortfolioSummary:
+async def get_summary(
+    base_currency: Optional[str] = Query(
+        default=None,
+        min_length=3,
+        max_length=3,
+        description="Convert summary totals into this base currency (e.g., USD, KRW, SGD)",
+    ),
+) -> PortfolioSummary:
     """
     Get portfolio summary.
 
@@ -385,8 +392,11 @@ async def get_summary() -> PortfolioSummary:
     service = get_portfolio_service()
 
     try:
-        return service.get_summary()
-
+        return service.get_summary(base_currency=base_currency)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except RuntimeError as e:
+        raise HTTPException(status_code=503, detail=str(e))
     except Exception as e:
         logger.error(f"Failed to get portfolio summary: {e}", exc_info=True)
         raise HTTPException(

--- a/api/schemas/__init__.py
+++ b/api/schemas/__init__.py
@@ -20,6 +20,7 @@ from api.schemas.analysis import (
     SearchResult,
 )
 from api.schemas.common import ApiResponse, ErrorResponse, HealthResponse
+from api.schemas.exchange_rate import ExchangeRatesResponse
 from api.schemas.market import (
     OHLCVItem,
     OHLCVResponse,
@@ -89,6 +90,7 @@ __all__ = [
     "ApiResponse",
     "ErrorResponse",
     "HealthResponse",
+    "ExchangeRatesResponse",
     # Market
     "OHLCVItem",
     "OHLCVResponse",

--- a/api/schemas/exchange_rate.py
+++ b/api/schemas/exchange_rate.py
@@ -1,0 +1,23 @@
+"""
+Exchange rate schemas for API responses.
+"""
+
+from datetime import datetime
+from typing import Dict
+
+from pydantic import BaseModel, Field
+
+
+class ExchangeRatesResponse(BaseModel):
+    """
+    Exchange rates response schema.
+
+    Attributes:
+        base: Base currency code.
+        rates: Currency -> rate map where 1 base equals rate[currency].
+        updated_at: Timestamp when rates were last updated.
+    """
+
+    base: str = Field(..., description="Base currency code", examples=["USD"])
+    rates: Dict[str, float] = Field(..., description="Currency rate map")
+    updated_at: datetime = Field(..., description="Rates update timestamp")

--- a/api/schemas/portfolio.py
+++ b/api/schemas/portfolio.py
@@ -153,6 +153,7 @@ class SellSignal(BaseModel):
         trigger_price: Price that triggered the signal (optional)
         avg_price: Average purchase price
         pnl_pct: Current profit/loss percentage
+        currency: Holding currency code
     """
 
     ticker: str = Field(..., description="Stock ticker symbol")
@@ -167,6 +168,7 @@ class SellSignal(BaseModel):
     trigger_price: Optional[float] = Field(default=None, description="Trigger price")
     avg_price: float = Field(..., description="Average purchase price")
     pnl_pct: float = Field(..., description="Current profit/loss percentage")
+    currency: str = Field(..., description="Holding currency code")
 
 
 class PortfolioResponse(BaseModel):

--- a/api/services/exchange_rate_service.py
+++ b/api/services/exchange_rate_service.py
@@ -1,0 +1,102 @@
+"""
+Exchange rate service.
+
+Fetches exchange rates from a public API and caches them for one hour.
+Falls back to stale cached rates on upstream failures.
+"""
+
+import logging
+import threading
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+class ExchangeRateService:
+    """Provides exchange rates with in-memory TTL cache and fallback."""
+
+    DEFAULT_BASE = "USD"
+    DEFAULT_SYMBOLS = ("KRW", "SGD", "JPY", "EUR", "GBP", "CNY", "HKD")
+    CACHE_TTL_SECONDS = 3600
+    API_TIMEOUT_SECONDS = 8
+
+    def __init__(self):
+        self._lock = threading.RLock()
+        self._cache: Dict[str, Dict[str, Any]] = {}
+        self._cache_time: Dict[str, float] = {}
+
+    def get_rates(self, base: str = DEFAULT_BASE) -> Dict[str, Any]:
+        """
+        Get exchange rates for a base currency.
+
+        Returns cached rates when fresh, otherwise fetches from upstream.
+        On fetch failure, returns stale cached rates if available.
+        """
+        base_norm = (base or self.DEFAULT_BASE).upper().strip()
+        now = time.monotonic()
+
+        with self._lock:
+            cached = self._cache.get(base_norm)
+            cached_at = self._cache_time.get(base_norm, 0.0)
+            if cached and (now - cached_at) < self.CACHE_TTL_SECONDS:
+                return cached
+
+        try:
+            fetched = self._fetch_rates(base_norm)
+            with self._lock:
+                self._cache[base_norm] = fetched
+                self._cache_time[base_norm] = now
+            return fetched
+        except Exception as e:
+            logger.warning("Exchange rate fetch failed for base=%s: %s", base_norm, e)
+            with self._lock:
+                stale = self._cache.get(base_norm)
+                if stale:
+                    return stale
+            raise RuntimeError(f"Exchange rate unavailable for base {base_norm}") from e
+
+    def _fetch_rates(self, base: str) -> Dict[str, Any]:
+        """Fetch rates from frankfurter.app for the configured symbol set."""
+        symbols = ",".join(self.DEFAULT_SYMBOLS)
+        url = (
+            "https://api.frankfurter.app/latest"
+            f"?from={base}&to={symbols}"
+        )
+        resp = requests.get(url, timeout=self.API_TIMEOUT_SECONDS)
+        resp.raise_for_status()
+        payload = resp.json()
+
+        rates = payload.get("rates")
+        if not isinstance(rates, dict) or not rates:
+            raise ValueError("Invalid exchange rate payload")
+
+        cleaned_rates: Dict[str, float] = {}
+        for currency, value in rates.items():
+            try:
+                cleaned_rates[currency.upper()] = float(value)
+            except (TypeError, ValueError):
+                continue
+
+        if not cleaned_rates:
+            raise ValueError("No valid exchange rates in payload")
+
+        return {
+            "base": str(payload.get("base", base)).upper(),
+            "rates": cleaned_rates,
+            "updated_at": datetime.now(timezone.utc),
+        }
+
+
+_exchange_rate_service: Optional[ExchangeRateService] = None
+
+
+def get_exchange_rate_service() -> ExchangeRateService:
+    """Get singleton exchange rate service."""
+    global _exchange_rate_service
+    if _exchange_rate_service is None:
+        _exchange_rate_service = ExchangeRateService()
+    return _exchange_rate_service

--- a/api/services/portfolio_service.py
+++ b/api/services/portfolio_service.py
@@ -23,6 +23,7 @@ from api.schemas.portfolio import (
     PortfolioSummary,
     SellSignal,
 )
+from api.services.exchange_rate_service import ExchangeRateService, get_exchange_rate_service
 
 # Import data cache for current price retrieval
 from utils.data_cache import OHLCVCache, get_cache
@@ -48,8 +49,26 @@ class PortfolioService:
     def __init__(self):
         self._lock = threading.RLock()
         self._cache = get_cache()
+        self._fx: ExchangeRateService = get_exchange_rate_service()
         self._price_cache: Dict[str, float] = {}
         self._price_cache_time: float = 0.0
+
+    @staticmethod
+    def _convert_to_base(
+        amount: float,
+        currency: str,
+        base_currency: str,
+        rates: Dict[str, float],
+    ) -> float:
+        """Convert an amount from currency to base_currency using rates(base->currency)."""
+        from_currency = (currency or base_currency).upper()
+        base = base_currency.upper()
+        if from_currency == base:
+            return amount
+        rate = rates.get(from_currency)
+        if rate is None or rate <= 0:
+            raise ValueError(f"Missing exchange rate for currency: {from_currency}")
+        return amount / rate
 
     @staticmethod
     def _row_to_dict(row: Holding) -> Dict[str, Any]:
@@ -355,7 +374,7 @@ class PortfolioService:
         finally:
             db.close()
 
-    def get_summary(self) -> PortfolioSummary:
+    def get_summary(self, base_currency: Optional[str] = None) -> PortfolioSummary:
         """
         Get portfolio summary with total P&L.
 
@@ -367,20 +386,39 @@ class PortfolioService:
         total_investment = 0.0
         total_market_value = 0.0
 
+        # Determine primary currency (most common) for default summary currency
+        currencies = [h.currency for h in holdings]
+        primary_currency = max(set(currencies), key=currencies.count) if currencies else "KRW"
+
+        target_currency = (base_currency or primary_currency).upper()
+        fx_rates: Dict[str, float] = {}
+        if base_currency:
+            fx_payload = self._fx.get_rates(base=target_currency)
+            fx_rates = fx_payload.get("rates", {})
+
         for h in holdings:
-            total_investment += h.cost_basis
-            if h.market_value is not None:
-                total_market_value += h.market_value
-            else:
-                # Use cost basis if market value unavailable
-                total_market_value += h.cost_basis
+            investment = h.cost_basis
+            market_value = h.market_value if h.market_value is not None else h.cost_basis
+
+            if base_currency:
+                investment = self._convert_to_base(
+                    amount=investment,
+                    currency=h.currency,
+                    base_currency=target_currency,
+                    rates=fx_rates,
+                )
+                market_value = self._convert_to_base(
+                    amount=market_value,
+                    currency=h.currency,
+                    base_currency=target_currency,
+                    rates=fx_rates,
+                )
+
+            total_investment += investment
+            total_market_value += market_value
 
         total_pnl = total_market_value - total_investment
         total_pnl_pct = (total_pnl / total_investment * 100) if total_investment > 0 else 0
-
-        # Determine primary currency (most common)
-        currencies = [h.currency for h in holdings]
-        primary_currency = max(set(currencies), key=currencies.count) if currencies else "KRW"
 
         return PortfolioSummary(
             total_investment=total_investment,
@@ -388,7 +426,7 @@ class PortfolioService:
             total_pnl=total_pnl,
             total_pnl_pct=total_pnl_pct,
             holdings_count=len(holdings),
-            currency=primary_currency,
+            currency=target_currency,
             last_updated=datetime.now()
         )
 
@@ -587,7 +625,8 @@ class PortfolioService:
                     current_price=h.current_price,
                     trigger_price=h.avg_price * (1 + stop_loss / 100),
                     avg_price=h.avg_price,
-                    pnl_pct=h.pnl_pct
+                    pnl_pct=h.pnl_pct,
+                    currency=h.currency,
                 )
 
             # Check take profit
@@ -600,7 +639,8 @@ class PortfolioService:
                     current_price=h.current_price,
                     trigger_price=h.avg_price * (1 + take_profit / 100),
                     avg_price=h.avg_price,
-                    pnl_pct=h.pnl_pct
+                    pnl_pct=h.pnl_pct,
+                    currency=h.currency,
                 )
 
             if signal:

--- a/api/tests/test_exchange_rates.py
+++ b/api/tests/test_exchange_rates.py
@@ -1,0 +1,52 @@
+"""
+Tests for exchange rates API endpoint.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+
+class TestExchangeRatesEndpoint:
+    """Tests for GET /api/exchange-rates."""
+
+    def test_get_exchange_rates_default_base(self, client):
+        with patch("api.routers.exchange_rates.get_exchange_rate_service") as mock_factory:
+            mock_service = mock_factory.return_value
+            mock_service.get_rates.return_value = {
+                "base": "USD",
+                "rates": {"KRW": 1350.5, "JPY": 149.8},
+                "updated_at": datetime.now(timezone.utc),
+            }
+
+            response = client.get("/api/exchange-rates")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["base"] == "USD"
+            assert "KRW" in data["rates"]
+            mock_service.get_rates.assert_called_once_with(base="USD")
+
+    def test_get_exchange_rates_custom_base(self, client):
+        with patch("api.routers.exchange_rates.get_exchange_rate_service") as mock_factory:
+            mock_service = mock_factory.return_value
+            mock_service.get_rates.return_value = {
+                "base": "SGD",
+                "rates": {"USD": 0.74, "KRW": 996.0},
+                "updated_at": datetime.now(timezone.utc),
+            }
+
+            response = client.get("/api/exchange-rates?base=sgd")
+
+            assert response.status_code == 200
+            assert response.json()["base"] == "SGD"
+            mock_service.get_rates.assert_called_once_with(base="sgd")
+
+    def test_get_exchange_rates_upstream_unavailable(self, client):
+        with patch("api.routers.exchange_rates.get_exchange_rate_service") as mock_factory:
+            mock_service = mock_factory.return_value
+            mock_service.get_rates.side_effect = RuntimeError("Exchange rate unavailable for base USD")
+
+            response = client.get("/api/exchange-rates")
+
+            assert response.status_code == 503
+            assert "Exchange rate unavailable" in response.json()["detail"]

--- a/api/tests/test_portfolio.py
+++ b/api/tests/test_portfolio.py
@@ -350,6 +350,24 @@ class TestGetPortfolioSummary:
         assert data["total_pnl_pct"] == 20.0
         assert data["holdings_count"] == 5
 
+    def test_get_summary_with_base_currency(self, client, mock_portfolio_service):
+        """Test GET /api/portfolio/summary passes base_currency to service."""
+        mock_portfolio_service.get_summary.return_value = {
+            "total_investment": 7407.41,
+            "total_market_value": 8888.89,
+            "total_pnl": 1481.48,
+            "total_pnl_pct": 20.0,
+            "holdings_count": 2,
+            "currency": "USD",
+            "last_updated": datetime.now().isoformat(),
+        }
+
+        response = client.get("/api/portfolio/summary?base_currency=usd")
+
+        assert response.status_code == 200
+        mock_portfolio_service.get_summary.assert_called_once_with(base_currency="usd")
+        assert response.json()["currency"] == "USD"
+
     def test_get_summary_empty_portfolio(self, client, mock_portfolio_service):
         """Test GET /api/portfolio/summary with empty portfolio."""
         # Arrange
@@ -388,7 +406,8 @@ class TestGetSellSignals:
                 "current_price": 180.0,
                 "trigger_price": 180.0,
                 "avg_price": 150.0,
-                "pnl_pct": 20.0
+                "pnl_pct": 20.0,
+                "currency": "USD",
             },
             {
                 "ticker": "MSFT",
@@ -398,7 +417,8 @@ class TestGetSellSignals:
                 "current_price": 270.0,
                 "trigger_price": 270.0,
                 "avg_price": 300.0,
-                "pnl_pct": -10.0
+                "pnl_pct": -10.0,
+                "currency": "USD",
             }
         ]
 
@@ -413,6 +433,7 @@ class TestGetSellSignals:
         assert len(data["signals"]) == 2
         assert data["signals"][0]["signal_type"] == "take_profit"
         assert data["signals"][1]["signal_type"] == "stop_loss"
+        assert data["signals"][0]["currency"] == "USD"
 
     def test_get_sell_signals_empty(self, client, mock_portfolio_service):
         """Test GET /api/portfolio/sell-signals with no signals."""
@@ -776,3 +797,33 @@ class TestPriceCache:
 
                 # Assert - prices fetched only once (2 tickers), not twice (4 calls)
                 assert mock_price.call_count == 2
+
+
+class TestSummaryCurrencyConversion:
+    """Tests for PortfolioService summary currency conversion."""
+
+    def test_get_summary_converts_to_requested_base_currency(self):
+        test_session = _setup_test_db([
+            {"ticker": "005930.KS", "name": "Samsung", "quantity": 10, "avg_price": 10000.0, "currency": "KRW"},
+            {"ticker": "AAPL", "name": "Apple", "quantity": 2, "avg_price": 100.0, "currency": "USD"},
+        ])
+
+        with patch("api.services.portfolio_service.SessionLocal", test_session):
+            service = PortfolioService()
+            # Keep market values equal to cost basis for deterministic totals.
+            with patch.object(service, "_get_current_price", return_value=None):
+                with patch.object(service._fx, "get_rates") as mock_rates:
+                    # Base USD: 1 USD = 1350 KRW
+                    mock_rates.return_value = {
+                        "base": "USD",
+                        "rates": {"KRW": 1350.0, "JPY": 150.0},
+                        "updated_at": datetime.now(),
+                    }
+
+                    summary = service.get_summary(base_currency="USD")
+
+                    # 100,000 KRW -> 74.074... USD, plus 200 USD = 274.074...
+                    assert summary.currency == "USD"
+                    assert summary.total_investment == pytest.approx(274.074074, rel=1e-6)
+                    assert summary.total_market_value == pytest.approx(274.074074, rel=1e-6)
+                    assert summary.total_pnl == pytest.approx(0.0, abs=1e-9)


### PR DESCRIPTION
## Summary
- add new endpoint `GET /api/exchange-rates` with 1-hour in-memory cache and stale-cache fallback
- extend `GET /api/portfolio/summary` with optional `base_currency` query param for converted totals
- add `currency` field to `SellSignal` response schema
- wire new exchange-rates router into FastAPI app
- add tests for exchange-rates endpoint and base-currency summary conversion

## Linked Issues
- Closes #213

## Scope
- In scope: backend API/schema/service changes for exchange rates and summary conversion
- Out of scope: frontend formatting and UI usage of new endpoints

## Validation
- [x] `python3 -m py_compile api/main.py api/routers/portfolio.py api/routers/exchange_rates.py api/services/portfolio_service.py api/services/exchange_rate_service.py api/schemas/portfolio.py api/schemas/exchange_rate.py`
- [x] `./venv/bin/python -m pytest -q api/tests/test_portfolio.py api/tests/test_exchange_rates.py`

## Risk / Rollback
- Risk: low-medium (new external rate fetch dependency, but cache fallback is included)
- Rollback: revert this PR commit
