### PR TITLE
feat: add persistent TTL cache for fundamentals and statements

### DIFF
--- a/api/services/strategy_service.py
+++ b/api/services/strategy_service.py
@@ -78,9 +78,9 @@ def _fetch_kr_fundamentals(tickers: List[str]) -> Dict[str, Dict[str, Optional[f
         cached = _fundamental_cache.get("fundamental_kr", ticker, FUNDAMENTAL_TTL_SECONDS)
         if cached is not None:
             fundamentals[ticker] = {
-                "per": _to_optional_float(cached.get("per")),
-                "pbr": _to_optional_float(cached.get("pbr")),
-                "dividend_yield": _to_optional_float(cached.get("dividend_yield")),
+                "per": cached.get("per"),
+                "pbr": cached.get("pbr"),
+                "dividend_yield": cached.get("dividend_yield"),
             }
         else:
             missing_tickers.append(ticker)
@@ -150,9 +150,9 @@ def _fetch_us_fundamentals(tickers: List[str]) -> Dict[str, Dict[str, Optional[f
         cached = _fundamental_cache.get("fundamental_us", ticker, FUNDAMENTAL_TTL_SECONDS)
         if cached is not None:
             fundamentals[ticker] = {
-                "per": _to_optional_float(cached.get("per")),
-                "pbr": _to_optional_float(cached.get("pbr")),
-                "dividend_yield": _to_optional_float(cached.get("dividend_yield")),
+                "per": cached.get("per"),
+                "pbr": cached.get("pbr"),
+                "dividend_yield": cached.get("dividend_yield"),
             }
         else:
             missing_tickers.append(ticker)
@@ -170,7 +170,10 @@ def _fetch_us_fundamentals(tickers: List[str]) -> Dict[str, Dict[str, Optional[f
     except Exception:
         tickers_obj = None
 
-    def _fetch_one(ticker: str) -> Dict[str, Optional[float]]:
+    def _is_success_payload(payload: Dict[str, Optional[float]]) -> bool:
+        return any(v is not None for v in payload.values())
+
+    def _fetch_one(ticker: str) -> tuple[Dict[str, Optional[float]], bool]:
         try:
             info: Dict[str, Any] = {}
             if tickers_obj is not None:
@@ -180,24 +183,26 @@ def _fetch_us_fundamentals(tickers: List[str]) -> Dict[str, Dict[str, Optional[f
             if not info:
                 info = yf.Ticker(ticker).info or {}
 
-            return {
+            payload = {
                 "per": _to_optional_float(info.get("trailingPE")),
                 "pbr": _to_optional_float(info.get("priceToBook")),
                 "dividend_yield": _normalize_dividend_yield(info.get("dividendYield")),
             }
+            return payload, _is_success_payload(payload)
         except Exception:
             return {
                 "per": None,
                 "pbr": None,
                 "dividend_yield": None,
-            }
+            }, False
 
     max_workers = min(8, len(missing_tickers))
     if max_workers <= 1:
         ticker = missing_tickers[0]
-        fetched = _fetch_one(ticker)
+        fetched, success = _fetch_one(ticker)
         fundamentals[ticker] = fetched
-        _fundamental_cache.set("fundamental_us", ticker, fetched)
+        if success:
+            _fundamental_cache.set("fundamental_us", ticker, fetched)
         return fundamentals
 
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
@@ -206,16 +211,16 @@ def _fetch_us_fundamentals(tickers: List[str]) -> Dict[str, Dict[str, Optional[f
             for future in as_completed(future_map, timeout=10):
                 ticker = future_map[future]
                 try:
-                    fetched = future.result(timeout=5)
+                    fetched, success = future.result(timeout=5)
                     fundamentals[ticker] = fetched
-                    _fundamental_cache.set("fundamental_us", ticker, fetched)
+                    if success:
+                        _fundamental_cache.set("fundamental_us", ticker, fetched)
                 except Exception:
                     fundamentals[ticker] = {
                         "per": None,
                         "pbr": None,
                         "dividend_yield": None,
                     }
-                    _fundamental_cache.set("fundamental_us", ticker, fundamentals[ticker])
         except TimeoutError:
             logger.warning("US fundamentals fetch timed out; filling remaining with None")
             for future, ticker in future_map.items():
@@ -226,7 +231,6 @@ def _fetch_us_fundamentals(tickers: List[str]) -> Dict[str, Dict[str, Optional[f
                         "pbr": None,
                         "dividend_yield": None,
                     }
-                    _fundamental_cache.set("fundamental_us", ticker, fundamentals[ticker])
 
     return fundamentals
 

--- a/screener/conditions/fundamental.py
+++ b/screener/conditions/fundamental.py
@@ -111,13 +111,18 @@ def _get_financial_statements(ticker: str) -> Tuple[pd.DataFrame, pd.DataFrame, 
     return _statement_cache[ticker]
 
 
-def clear_info_cache() -> None:
-    """Clear the module-level info cache.
+def clear_info_cache(include_persistent: bool = False) -> None:
+    """Clear in-memory caches used by fundamental conditions.
 
-    Call this between screening runs to free memory and ensure fresh data.
+    Args:
+        include_persistent: When True, also clear on-disk persistent cache
+            for yfinance info/statements.
     """
     _info_cache.clear()
     _statement_cache.clear()
+    if include_persistent:
+        _persistent_cache.clear(namespace="yf_info")
+        _persistent_cache.clear(namespace="yf_statements")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_fundamental_persistent_cache.py
+++ b/tests/test_fundamental_persistent_cache.py
@@ -1,3 +1,5 @@
+import json
+import sys
 from types import SimpleNamespace
 
 import pandas as pd
@@ -35,6 +37,18 @@ def test_get_info_uses_persistent_cache(monkeypatch, tmp_path):
     monkeypatch.setattr(fundamental_module.yf, "Ticker", FailTicker)
     second = fundamental_module._get_info("AAPL")
     assert second["trailingPE"] == 10.5
+
+
+def test_clear_info_cache_with_persistent_option(monkeypatch, tmp_path):
+    cache = FundamentalCache(cache_dir=str(tmp_path / "clear_cache"))
+    monkeypatch.setattr(fundamental_module, "_persistent_cache", cache)
+    fundamental_module.clear_info_cache()
+
+    cache.set("yf_info", "AAPL", {"trailingPE": 9.5})
+    assert cache.get("yf_info", "AAPL", ttl_seconds=3600) is not None
+
+    fundamental_module.clear_info_cache(include_persistent=True)
+    assert cache.get("yf_info", "AAPL", ttl_seconds=3600) is None
 
 
 def test_get_financial_statements_uses_persistent_cache(monkeypatch, tmp_path):
@@ -94,7 +108,7 @@ def test_fetch_us_fundamentals_uses_persistent_cache(monkeypatch, tmp_path):
             self.tickers = {}
 
     fake_yf = SimpleNamespace(Ticker=FakeYFTicker, Tickers=FakeYFTickers)
-    monkeypatch.setitem(__import__("sys").modules, "yfinance", fake_yf)
+    monkeypatch.setitem(sys.modules, "yfinance", fake_yf)
 
     first = strategy_service._fetch_us_fundamentals(["AAPL"])
     assert first["AAPL"]["per"] == 22.0
@@ -104,3 +118,80 @@ def test_fetch_us_fundamentals_uses_persistent_cache(monkeypatch, tmp_path):
     second = strategy_service._fetch_us_fundamentals(["AAPL"])
     assert second["AAPL"]["per"] == 22.0
     assert calls["count"] == 1
+
+
+def test_fetch_us_fundamentals_failure_not_cached(monkeypatch, tmp_path):
+    cache = FundamentalCache(cache_dir=str(tmp_path / "us_fund_cache_fail"))
+    monkeypatch.setattr(strategy_service, "_fundamental_cache", cache)
+
+    calls = {"count": 0}
+
+    class FlakyYFTicker:
+        def __init__(self, ticker: str):
+            calls["count"] += 1
+            if calls["count"] == 1:
+                raise RuntimeError("temporary yfinance outage")
+            self.info = {"trailingPE": 18.0, "priceToBook": 3.5, "dividendYield": 0.01}
+
+    class FakeYFTickers:
+        def __init__(self, joined: str):
+            self.tickers = {}
+
+    fake_yf = SimpleNamespace(Ticker=FlakyYFTicker, Tickers=FakeYFTickers)
+    monkeypatch.setitem(sys.modules, "yfinance", fake_yf)
+
+    first = strategy_service._fetch_us_fundamentals(["MSFT"])
+    assert first["MSFT"]["per"] is None
+    assert calls["count"] == 1
+
+    # Must re-fetch (not cached as None), and then succeed.
+    second = strategy_service._fetch_us_fundamentals(["MSFT"])
+    assert second["MSFT"]["per"] == 18.0
+    assert calls["count"] == 2
+
+
+def test_fetch_kr_fundamentals_uses_persistent_cache(monkeypatch, tmp_path):
+    cache = FundamentalCache(cache_dir=str(tmp_path / "kr_fund_cache"))
+    monkeypatch.setattr(strategy_service, "_fundamental_cache", cache)
+
+    calls = {"count": 0}
+
+    def fake_get_market_fundamental_by_ticker(date: str, market: str):
+        calls["count"] += 1
+        return pd.DataFrame(
+            {"PER": [11.0], "PBR": [0.9], "DIV": [2.2]},
+            index=["005930"],
+        )
+
+    fake_pykrx_stock = SimpleNamespace(get_market_fundamental_by_ticker=fake_get_market_fundamental_by_ticker)
+    fake_pykrx = SimpleNamespace(stock=fake_pykrx_stock)
+    monkeypatch.setitem(sys.modules, "pykrx", fake_pykrx)
+
+    first = strategy_service._fetch_kr_fundamentals(["005930.KS"])
+    assert first["005930.KS"]["per"] == 11.0
+    assert calls["count"] >= 1
+
+    # Second call should hit cache and avoid pykrx function invocation.
+    calls_before = calls["count"]
+    second = strategy_service._fetch_kr_fundamentals(["005930.KS"])
+    assert second["005930.KS"]["pbr"] == 0.9
+    assert calls["count"] == calls_before
+
+
+def test_fundamental_cache_ttl_expiry_and_corrupt_file(tmp_path):
+    cache = FundamentalCache(cache_dir=str(tmp_path / "ttl_cache"))
+    cache.set("ns", "AAPL", {"per": 10.0})
+    assert cache.get("ns", "AAPL", ttl_seconds=3600) == {"per": 10.0}
+    assert cache.get("ns", "AAPL", ttl_seconds=0) is None
+
+    bad_path = tmp_path / "ttl_cache" / "ns__MSFT.json"
+    bad_path.write_text("{not-json}", encoding="utf-8")
+    assert cache.get("ns", "MSFT", ttl_seconds=3600) is None
+
+    stale_path = tmp_path / "ttl_cache" / "ns__GOOG.json"
+    stale_path.write_text(
+        json.dumps({"_updated_at": "2000-01-01T00:00:00+00:00", "payload": {"per": 9.0}}),
+        encoding="utf-8",
+    )
+    removed = cache.clear_expired(ttl_seconds=60, namespace="ns")
+    assert removed >= 1

--- a/utils/fundamental_cache.py
+++ b/utils/fundamental_cache.py
@@ -46,6 +46,10 @@ class FundamentalCache:
             if updated_dt.tzinfo is None:
                 updated_dt = updated_dt.replace(tzinfo=timezone.utc)
             if datetime.now(timezone.utc) - updated_dt > timedelta(seconds=ttl_seconds):
+                try:
+                    path.unlink()
+                except Exception:
+                    pass
                 return None
 
             if isinstance(payload, dict):
@@ -68,3 +72,66 @@ class FundamentalCache:
             path.write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
         except Exception as e:
             logger.debug("Failed to write cache %s: %s", path, e)
+
+    def clear(self, namespace: Optional[str] = None, key: Optional[str] = None) -> int:
+        """
+        Delete cached files and return removed file count.
+
+        Args:
+            namespace: Optional namespace filter.
+            key: Optional cache key filter (requires namespace).
+        """
+        removed = 0
+
+        if namespace and key:
+            target = self._cache_path(namespace, key)
+            if target.exists():
+                target.unlink()
+                return 1
+            return 0
+
+        if namespace:
+            pattern = f"{self._safe_key(namespace)}__*.json"
+        else:
+            pattern = "*.json"
+
+        for path in self.cache_dir.glob(pattern):
+            try:
+                path.unlink()
+                removed += 1
+            except Exception:
+                continue
+        return removed
+
+    def clear_expired(self, ttl_seconds: int, namespace: Optional[str] = None) -> int:
+        """
+        Remove expired cache files and return removed file count.
+        """
+        removed = 0
+        pattern = f"{self._safe_key(namespace)}__*.json" if namespace else "*.json"
+        now = datetime.now(timezone.utc)
+
+        for path in self.cache_dir.glob(pattern):
+            try:
+                raw = json.loads(path.read_text(encoding="utf-8"))
+                updated_at = raw.get("_updated_at")
+                if not updated_at:
+                    path.unlink()
+                    removed += 1
+                    continue
+
+                updated_dt = datetime.fromisoformat(updated_at)
+                if updated_dt.tzinfo is None:
+                    updated_dt = updated_dt.replace(tzinfo=timezone.utc)
+
+                if now - updated_dt > timedelta(seconds=ttl_seconds):
+                    path.unlink()
+                    removed += 1
+            except Exception:
+                # Corrupted cache files are removed proactively.
+                try:
+                    path.unlink()
+                    removed += 1
+                except Exception:
+                    pass
+        return removed


### PR DESCRIPTION
## Summary
- add `utils/fundamental_cache.py`: file-based JSON TTL cache helper
- apply 24h persistent cache for KR/US fundamentals in `api/services/strategy_service.py`
- apply 24h (`info`) + 7d (`income_stmt`/`balance_sheet`/`cashflow`) persistent cache in `screener/conditions/fundamental.py`
- add regression tests to verify persistent cache hit behavior across in-memory cache reset

## Linked Issues
- Closes #204

## Scope
- In scope: persistent cache layer for fundamental and financial statement fetch paths
- Out of scope: DB schema migration, frontend changes, batch API redesign

## Validation
- [x] `python3 -m py_compile api/services/strategy_service.py screener/conditions/fundamental.py utils/fundamental_cache.py tests/test_fundamental_persistent_cache.py`
- [x] `./venv/bin/python -m pytest -q tests/test_fundamental_persistent_cache.py`
- [x] `./venv/bin/python -m pytest -q tests/test_fundamental_persistent_cache.py api/tests/test_portfolio.py api/tests/test_exchange_rates.py`

## Risk / Rollback
- Risk: low-medium (new filesystem cache path + serialization/deserialization)
- Rollback: revert this PR commit
