### PR TITLE
feat: add return_turnaround condition for QuantCanvas

### DIFF
--- a/api/tests/test_strategy.py
+++ b/api/tests/test_strategy.py
@@ -42,6 +42,12 @@ class TestConditionsEndpoint:
         assert "type" in param
         assert "description" in param
 
+    def test_return_turnaround_condition_exposed(self):
+        response = client.get("/api/strategy/conditions")
+        data = response.json()
+        cond_map = {c["key"]: c for c in data["conditions"]}
+        assert "return_turnaround" in cond_map
+
 
 class TestRunStrategyEndpoint:
     """Test POST /api/strategy/run."""

--- a/docs/SCREENER_CONDITIONS.md
+++ b/docs/SCREENER_CONDITIONS.md
@@ -7,7 +7,7 @@ This document describes the condition-based stock screening architecture used in
 ## Table of Contents
 
 1. [Overview](#overview)
-2. [Available Condition Classes (28)](#available-condition-classes-28)
+2. [Available Condition Classes (29)](#available-condition-classes-29)
 3. [Combining Conditions](#combining-conditions)
 4. [Adding New Conditions](#adding-new-conditions)
 5. [Parameter Configuration Examples](#parameter-configuration-examples)
@@ -28,9 +28,9 @@ The screener module uses a **condition-based architecture** where each screening
 
 ---
 
-## Available Condition Classes (28)
+## Available Condition Classes (29)
 
-### Price Conditions (price.py - 4)
+### Price Conditions (price.py - 5)
 
 | Condition | Description | Key Parameters |
 |-----------|-------------|----------------|
@@ -38,6 +38,7 @@ The screener module uses a **condition-based architecture** where each screening
 | `MaxPriceCondition` | Maximum stock price | `max_price` |
 | `PriceRangeCondition` | Price within range | `min_price`, `max_price` |
 | `PriceChangeCondition` | Price change percentage | `min_change_pct`, `max_change_pct`, `days` |
+| `ReturnTurnaroundCondition` | Return reversal between previous/recent windows | `period_days`, `prev_max_return_pct`, `min_return_pct` |
 
 ### Volume Conditions (volume.py - 3)
 
@@ -225,6 +226,7 @@ MinPriceCondition(min_price=5000)
 MaxPriceCondition(max_price=100000)
 PriceRangeCondition(min_price=5000, max_price=50000)
 PriceChangeCondition(min_change_pct=-5.0, max_change_pct=5.0, days=5)
+ReturnTurnaroundCondition(period_days=5, prev_max_return_pct=-2.0, min_return_pct=2.0)
 ```
 
 ### Volume Conditions
@@ -355,7 +357,7 @@ screener/
 ├── conditions/
 │   ├── __init__.py        # Exports all conditions
 │   ├── base.py            # BaseCondition, ConditionResult, ConditionError
-│   ├── price.py           # Price conditions (4)
+│   ├── price.py           # Price conditions (5)
 │   ├── volume.py          # Volume conditions (3)
 │   ├── ma.py              # Moving average conditions (5)
 │   ├── rsi.py             # RSI conditions (3)

--- a/screener/conditions/__init__.py
+++ b/screener/conditions/__init__.py
@@ -38,6 +38,7 @@ from .price import (
     MaxPriceCondition,
     PriceRangeCondition,
     PriceChangeCondition,
+    ReturnTurnaroundCondition,
     DrawdownFromHighCondition,
 )
 
@@ -117,6 +118,7 @@ __all__ = [
 
     # Price
     'MinPriceCondition', 'MaxPriceCondition', 'PriceRangeCondition', 'PriceChangeCondition',
+    'ReturnTurnaroundCondition',
     'DrawdownFromHighCondition',
 
     # Volume

--- a/screener/conditions/price.py
+++ b/screener/conditions/price.py
@@ -233,6 +233,89 @@ class PriceChangeCondition(BaseCondition):
 
 
 @register_condition(
+    key="return_turnaround",
+    label="Return Turnaround",
+    description="Previous N-day return <= threshold and recent N-day return >= threshold",
+    category="price",
+    params=[
+        {"name": "period_days", "type": "int", "default": 5, "description": "Return period (days)"},
+        {"name": "prev_max_return_pct", "type": "float", "default": -2.0, "description": "Max previous return %"},
+        {"name": "min_return_pct", "type": "float", "default": 2.0, "description": "Min recent return %"},
+    ],
+)
+class ReturnTurnaroundCondition(BaseCondition):
+    """이전 구간 약세 -> 최근 구간 반등 전환 조건"""
+
+    def __init__(
+        self,
+        period_days: int = 5,
+        prev_max_return_pct: float = -2.0,
+        min_return_pct: float = 2.0,
+    ):
+        self.period_days = max(1, period_days)
+        self.prev_max_return_pct = prev_max_return_pct
+        self.min_return_pct = min_return_pct
+
+    @property
+    def name(self) -> str:
+        return f"return_turnaround_{self.period_days}d"
+
+    @property
+    def required_days(self) -> int:
+        return (self.period_days * 2) + 10
+
+    def evaluate(self, ticker: str, data: pd.DataFrame) -> ConditionResult:
+        if len(data) < (self.period_days * 2 + 1):
+            return ConditionResult(
+                matched=False,
+                condition_name=self.name,
+                details={"error": "Insufficient data"},
+            )
+
+        current_price = data["close"].iloc[-1]
+        boundary_price = data["close"].iloc[-(self.period_days + 1)]
+        prev_price = data["close"].iloc[-(self.period_days * 2 + 1)]
+
+        if boundary_price <= 0 or prev_price <= 0:
+            return ConditionResult(
+                matched=False,
+                condition_name=self.name,
+                details={"error": "Invalid price data for return calculation"},
+            )
+
+        recent_return_pct = (current_price - boundary_price) / boundary_price * 100
+        prev_return_pct = (boundary_price - prev_price) / prev_price * 100
+
+        matched = (
+            prev_return_pct <= self.prev_max_return_pct
+            and recent_return_pct >= self.min_return_pct
+        )
+
+        return ConditionResult(
+            matched=matched,
+            condition_name=self.name,
+            details={
+                "current_price": float(current_price),
+                "boundary_price": float(boundary_price),
+                "prev_price": float(prev_price),
+                "recent_return_pct": round(float(recent_return_pct), 3),
+                "prev_return_pct": round(float(prev_return_pct), 3),
+                "period_days": self.period_days,
+                "prev_max_return_pct": self.prev_max_return_pct,
+                "min_return_pct": self.min_return_pct,
+            },
+        )
+
+    def __repr__(self) -> str:
+        return (
+            "ReturnTurnaroundCondition("
+            f"period_days={self.period_days}, "
+            f"prev_max_return_pct={self.prev_max_return_pct}, "
+            f"min_return_pct={self.min_return_pct})"
+        )
+
+
+@register_condition(
     key="drawdown_from_high",
     label="Drawdown From N-day High",
     description="Drop % from N-day rolling high",

--- a/tests/test_return_turnaround_condition.py
+++ b/tests/test_return_turnaround_condition.py
@@ -1,0 +1,40 @@
+import pandas as pd
+
+from screener.conditions.price import ReturnTurnaroundCondition
+from screener.conditions.registry import get_condition_metadata
+
+
+def _make_df(closes):
+    return pd.DataFrame({"close": closes})
+
+
+def test_return_turnaround_matched():
+    # prev 5d: 100 -> 95 (-5%), recent 5d: 95 -> 100 (+5.26%)
+    closes = [100, 99, 98, 97, 96, 95, 96, 97, 98, 99, 100]
+    cond = ReturnTurnaroundCondition(period_days=5, prev_max_return_pct=-2.0, min_return_pct=2.0)
+    result = cond.evaluate("TEST", _make_df(closes))
+    assert bool(result.matched) is True
+    assert result.details["prev_return_pct"] <= -2.0
+    assert result.details["recent_return_pct"] >= 2.0
+
+
+def test_return_turnaround_not_matched_when_recent_is_weak():
+    # prev 5d: -5%, recent 5d: +1.05% (below min_return_pct=2)
+    closes = [100, 99, 98, 97, 96, 95, 95.2, 95.4, 95.6, 95.8, 96]
+    cond = ReturnTurnaroundCondition(period_days=5, prev_max_return_pct=-2.0, min_return_pct=2.0)
+    result = cond.evaluate("TEST", _make_df(closes))
+    assert bool(result.matched) is False
+    assert result.details["recent_return_pct"] < 2.0
+
+
+def test_return_turnaround_insufficient_data():
+    cond = ReturnTurnaroundCondition(period_days=5)
+    result = cond.evaluate("TEST", _make_df([100, 99, 98]))
+    assert bool(result.matched) is False
+    assert "error" in result.details
+
+
+def test_return_turnaround_registered_metadata():
+    metadata = get_condition_metadata()
+    assert "return_turnaround" in metadata
+    assert metadata["return_turnaround"]["category"] == "price"

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -454,6 +454,16 @@
       },
       "help": "Finds stocks that rose or fell by a certain % over recent days."
     },
+    "return_turnaround": {
+      "label": "Return Turnaround",
+      "desc": "Prev N-day return <= threshold and recent N-day return >= threshold",
+      "params": {
+        "period_days": "Period (days)",
+        "prev_max_return_pct": "Prev max return %",
+        "min_return_pct": "Min recent return %"
+      },
+      "help": "Finds reversal setups where prior returns were weak, then recent returns turned positive."
+    },
     "min_volume": {
       "label": "Min Volume",
       "desc": "Volume >= threshold",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -454,6 +454,16 @@
       },
       "help": "최근 며칠간 일정 비율 이상 오르거나 내린 주식을 찾습니다."
     },
+    "return_turnaround": {
+      "label": "수익률 전환",
+      "desc": "직전 N일 수익률 <= 기준, 최근 N일 수익률 >= 기준",
+      "params": {
+        "period_days": "기간 (일)",
+        "prev_max_return_pct": "직전 최대 수익률 %",
+        "min_return_pct": "최근 최소 수익률 %"
+      },
+      "help": "직전 구간 약세 후 최근 구간에서 반등 전환한 종목을 찾습니다."
+    },
     "min_volume": {
       "label": "최소 거래량",
       "desc": "거래량 >= 기준값",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -448,6 +448,16 @@
       },
       "help": "查找近期涨跌幅达到一定百分比的股票。"
     },
+    "return_turnaround": {
+      "label": "收益率反转",
+      "desc": "前N日收益率 <= 阈值 且 近N日收益率 >= 阈值",
+      "params": {
+        "period_days": "周期（天）",
+        "prev_max_return_pct": "前期最大收益率 %",
+        "min_return_pct": "近期最小收益率 %"
+      },
+      "help": "查找先走弱后转强的反转形态股票。"
+    },
     "min_volume": {
       "label": "最小成交量",
       "desc": "成交量 >= 阈值",


### PR DESCRIPTION
## Summary
- add new price condition `return_turnaround` in `screener/conditions/price.py`
- expose condition via `screener/conditions/__init__.py`
- add unit tests for match/fail/insufficient-data/metadata registration
- ensure strategy conditions API exposes `return_turnaround`
- add i18n labels/descriptions/params for `en/ko/zh`
- update condition architecture docs with the new condition and counts

## Linked Issues
- Closes #219

## Scope
- In scope: backend condition implementation + i18n keys + docs update
- Out of scope: new preset wiring

## Validation
- [x] `python3 -m py_compile screener/conditions/price.py screener/conditions/__init__.py tests/test_return_turnaround_condition.py api/tests/test_strategy.py`
- [x] `./venv/bin/python -m pytest -q tests/test_return_turnaround_condition.py api/tests/test_strategy.py`

## Risk / Rollback
- Risk: low (new condition only, no changes to existing condition logic)
- Rollback: revert this PR commit
