### PR TITLE
perf: convert blocking API routers to sync handlers

### DIFF
--- a/api/routers/analysis.py
+++ b/api/routers/analysis.py
@@ -39,7 +39,7 @@ router = APIRouter(prefix="/api/analysis", tags=["Analysis"])
     description="Enrich a single stock with technical indicators, fundamental data, "
                 "and news information. This operation may take 10-30 seconds.",
 )
-async def enrich_stock(request: EnrichRequest) -> EnrichedStock:
+def enrich_stock(request: EnrichRequest) -> EnrichedStock:
     """
     Enrich a single stock with comprehensive data.
 
@@ -87,7 +87,7 @@ async def enrich_stock(request: EnrichRequest) -> EnrichedStock:
     description="Analyze a single stock using Claude AI for valuation and risk assessment. "
                 "Requires ANTHROPIC_API_KEY environment variable. May take 30+ seconds.",
 )
-async def analyze_stock(request: AnalysisRequest) -> AnalysisResult:
+def analyze_stock(request: AnalysisRequest) -> AnalysisResult:
     """
     Analyze a single stock with AI-powered valuation.
 
@@ -150,7 +150,7 @@ async def analyze_stock(request: AnalysisRequest) -> AnalysisResult:
     summary="Get Analysis Reports",
     description="Get list of available analysis reports with summaries.",
 )
-async def get_reports() -> ReportListResponse:
+def get_reports() -> ReportListResponse:
     """
     Get list of available analysis reports.
 
@@ -183,7 +183,7 @@ async def get_reports() -> ReportListResponse:
     summary="Get Report Detail",
     description="Get detailed analysis report for a specific date.",
 )
-async def get_report(
+def get_report(
     date: str,
     market: Optional[str] = Query(
         default=None,
@@ -235,7 +235,7 @@ async def get_report(
     summary="Get Enriched Data",
     description="Get enriched JSON data for a specific date and market.",
 )
-async def get_enriched_data(
+def get_enriched_data(
     date: str,
     market: str = Query(
         default="SP500",
@@ -305,7 +305,7 @@ async def get_enriched_data(
     summary="List Enriched Data Files",
     description="List all available enriched data files.",
 )
-async def list_enriched_files() -> List[dict]:
+def list_enriched_files() -> List[dict]:
     """
     List all available enriched data files.
 
@@ -334,7 +334,7 @@ async def list_enriched_files() -> List[dict]:
     summary="Get Ticker Analysis",
     description="Get combined OHLCV data, technical indicators, and fundamental data for a ticker.",
 )
-async def get_ticker_analysis(
+def get_ticker_analysis(
     ticker: str,
     period: str = Query(
         default="6mo",
@@ -466,7 +466,7 @@ async def get_ticker_analysis(
     summary="Analysis Service Status",
     description="Get analysis service status including Claude API availability.",
 )
-async def get_status() -> dict:
+def get_status() -> dict:
     """
     Get analysis service status.
 

--- a/api/routers/backtest.py
+++ b/api/routers/backtest.py
@@ -32,7 +32,7 @@ router = APIRouter(prefix="/api/backtest", tags=["Backtest"])
     summary="List available strategies",
     description="Return all available backtesting strategies with their parameter schemas.",
 )
-async def list_strategies() -> StrategiesListResponse:
+def list_strategies() -> StrategiesListResponse:
     """Return available backtesting strategies."""
     strategies = get_strategies()
     return StrategiesListResponse(strategies=strategies)
@@ -45,7 +45,7 @@ async def list_strategies() -> StrategiesListResponse:
     description="Run a backtest for a given ticker and strategy. "
     "Returns performance metrics, trade records, and equity curve.",
 )
-async def run(request: BacktestRequest) -> BacktestResponse:
+def run(request: BacktestRequest) -> BacktestResponse:
     """Run a backtest with the specified configuration."""
     try:
         result = run_backtest(request)
@@ -64,7 +64,7 @@ async def run(request: BacktestRequest) -> BacktestResponse:
     description="Run parameter optimization for a strategy. "
     "Tests all combinations of parameter values and returns the best result.",
 )
-async def optimize(request: OptimizeRequest) -> OptimizeResponse:
+def optimize(request: OptimizeRequest) -> OptimizeResponse:
     """Optimize strategy parameters for a given ticker."""
     try:
         result = optimize_backtest(request)

--- a/api/routers/market.py
+++ b/api/routers/market.py
@@ -34,7 +34,7 @@ _service = MarketService()
     summary="Get Current Quote",
     description="Retrieve current price quote for a stock ticker.",
 )
-async def get_quote(ticker: str) -> QuoteResponse:
+def get_quote(ticker: str) -> QuoteResponse:
     """
     Get current quote for a ticker.
 
@@ -64,7 +64,7 @@ async def get_quote(ticker: str) -> QuoteResponse:
     summary="Get OHLCV Data",
     description="Retrieve historical OHLCV (Open-High-Low-Close-Volume) data.",
 )
-async def get_ohlcv(
+def get_ohlcv(
     ticker: str,
     days: Annotated[
         int,
@@ -105,7 +105,7 @@ async def get_ohlcv(
     summary="Get Technical Indicators",
     description="Calculate technical indicators for a stock ticker.",
 )
-async def get_technical_indicators(ticker: str) -> TechnicalIndicators:
+def get_technical_indicators(ticker: str) -> TechnicalIndicators:
     """
     Get technical indicators for a ticker.
 

--- a/api/routers/screening.py
+++ b/api/routers/screening.py
@@ -30,7 +30,7 @@ router = APIRouter(prefix="/api/screening", tags=["Screening"])
     summary="Get Available Presets",
     description="Get list of available screening presets with their descriptions and conditions.",
 )
-async def get_presets() -> List[PresetInfo]:
+def get_presets() -> List[PresetInfo]:
     """
     Get available screening presets.
 
@@ -50,7 +50,7 @@ async def get_presets() -> List[PresetInfo]:
     summary="Get Available Universes",
     description="Get list of available stock universes (KOSPI, KOSDAQ, SP500, etc.).",
 )
-async def get_universes() -> List[UniverseInfo]:
+def get_universes() -> List[UniverseInfo]:
     """
     Get available stock universes.
 
@@ -71,7 +71,7 @@ async def get_universes() -> List[UniverseInfo]:
     description="Run stock screening with the specified preset and universe. "
                 "This operation may take several minutes depending on the universe size.",
 )
-async def run_screening(request: ScreeningRequest) -> ScreeningResponse:
+def run_screening(request: ScreeningRequest) -> ScreeningResponse:
     """
     Run stock screening.
 
@@ -122,7 +122,7 @@ async def run_screening(request: ScreeningRequest) -> ScreeningResponse:
     summary="Check Single Stock",
     description="Check a single stock against screening conditions.",
 )
-async def check_single_stock(
+def check_single_stock(
     ticker: str,
     preset: str = Query(
         default="accumulation_basic",
@@ -172,7 +172,7 @@ async def check_single_stock(
     summary="Check Single Stock with Params",
     description="Check a single stock against screening conditions with custom parameters.",
 )
-async def check_single_stock_with_params(
+def check_single_stock_with_params(
     ticker: str,
     request: SingleStockRequest,
 ) -> ScreeningResultItem:


### PR DESCRIPTION
## Summary
- convert blocking API route handlers from `async def` to sync `def` in:
  - `api/routers/screening.py`
  - `api/routers/analysis.py`
  - `api/routers/market.py`
  - `api/routers/backtest.py`
- this lets FastAPI run handlers in threadpool workers and prevents event loop blocking by sync I/O (yfinance/pykrx/pandas)

## Linked Issues
- Closes #225

## Scope
- In scope: router handler signature conversion only
- Out of scope: service-layer refactors and query optimizations

## Validation
- [x] `python3 -m py_compile api/routers/market.py api/routers/analysis.py api/routers/screening.py api/routers/backtest.py`
- [x] `./venv/bin/python -m pytest -q api/tests/test_market.py api/tests/test_analysis.py api/tests/test_screening.py api/tests/test_backtest.py`

## Risk / Rollback
- Risk: low (signature-only change, behavior preserved)
- Rollback: revert this PR commit
