### PR TITLE
fix: resolve portfolio sort and mobile locale switcher bugs

### DIFF
--- a/web/src/components/layout/MainLayout.tsx
+++ b/web/src/components/layout/MainLayout.tsx
@@ -6,6 +6,7 @@ import { useTranslations } from 'next-intl';
 import { Menu, X } from 'lucide-react';
 import Sidebar from './Sidebar';
 import Footer from './Footer';
+import LocaleSwitcher from './LocaleSwitcher';
 
 interface MainLayoutProps {
   children: ReactNode;
@@ -33,20 +34,25 @@ export default function MainLayout({ children }: MainLayoutProps) {
     <div className="min-h-screen bg-[var(--background)]">
       <Sidebar isOpen={isSidebarOpen} onClose={closeSidebar} />
 
-      {/* Floating mobile menu button */}
-      <button
-        type="button"
-        className="fixed top-4 left-4 z-50 lg:hidden p-2 rounded-lg bg-[#101622] text-white shadow-lg hover:bg-[#1a2435] transition-colors"
-        onClick={toggleSidebar}
-        aria-label={isSidebarOpen ? t('closeSidebar') : t('openSidebar')}
-        aria-expanded={isSidebarOpen}
-      >
-        {isSidebarOpen ? (
-          <X className="h-5 w-5" />
-        ) : (
-          <Menu className="h-5 w-5" />
-        )}
-      </button>
+      {/* Floating mobile header bar */}
+      <div className="fixed top-4 left-4 right-4 z-50 lg:hidden flex items-center justify-between">
+        <button
+          type="button"
+          className="p-2 rounded-lg bg-[#101622] text-white shadow-lg hover:bg-[#1a2435] transition-colors"
+          onClick={toggleSidebar}
+          aria-label={isSidebarOpen ? t('closeSidebar') : t('openSidebar')}
+          aria-expanded={isSidebarOpen}
+        >
+          {isSidebarOpen ? (
+            <X className="h-5 w-5" />
+          ) : (
+            <Menu className="h-5 w-5" />
+          )}
+        </button>
+        <div className="rounded-lg bg-[#101622] shadow-lg">
+          <LocaleSwitcher variant="sidebar" />
+        </div>
+      </div>
 
       {/* Main content area */}
       <div className="lg:ml-[var(--sidebar-width)] min-h-screen flex flex-col transition-sidebar">

--- a/web/src/components/portfolio/HoldingsTable.tsx
+++ b/web/src/components/portfolio/HoldingsTable.tsx
@@ -118,15 +118,13 @@ export default function HoldingsTable({
   }, [holdings, sortField, sortDirection]);
 
   const handleSort = useCallback((field: SortField) => {
-    setSortField((prevField) => {
-      if (prevField === field) {
-        setSortDirection((prev) => (prev === 'asc' ? 'desc' : 'asc'));
-        return prevField;
-      }
+    if (sortField === field) {
+      setSortDirection((prev) => (prev === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortField(field);
       setSortDirection('asc');
-      return field;
-    });
-  }, []);
+    }
+  }, [sortField]);
 
   if (isLoading) {
     return (


### PR DESCRIPTION
## Summary
- **#208**: Fix portfolio descending sort not working — nested `setSortDirection` inside `setSortField` callback caused React batching issues. Refactored to use direct state comparison instead.
- **#207**: Fix language switcher not visible on mobile — added `LocaleSwitcher` to the floating mobile header bar in `MainLayout`, so users can switch locale without opening the sidebar.
- **#199**: Investigated and closed as **cannot reproduce** — `proxy.ts` middleware correctly resolves locale for popup windows. All 3 locales (en/ko/zh) verified working.

## Changes
| File | Change |
|------|--------|
| `web/src/components/portfolio/HoldingsTable.tsx` | Refactor `handleSort` to avoid nested setState |
| `web/src/components/layout/MainLayout.tsx` | Add LocaleSwitcher to mobile floating header bar |

## Test plan
- [x] ESLint: 0 errors (12 pre-existing warnings in unrelated files)
- [x] Build: passes
- [x] E2E: 44/44 tests passed
- [x] Manual: verified sort toggle works for all columns (asc/desc)
- [x] Manual: verified LocaleSwitcher visible on mobile viewport
- [x] Manual: verified popup locale works for en/ko/zh

Closes #208
Closes #207

Codex reviewed