### PR TITLE
feat: open stock detail popup on portfolio holding click

### DIFF
--- a/web/src/app/[locale]/portfolio/page.tsx
+++ b/web/src/app/[locale]/portfolio/page.tsx
@@ -210,6 +210,18 @@ export default function PortfolioPage() {
     setIsDeleteModalOpen(true);
   }, []);
 
+  const handleRowClick = useCallback((holding: Holding) => {
+    const width = 900;
+    const height = 700;
+    const left = (screen.width - width) / 2;
+    const top = (screen.height - height) / 2;
+    window.open(
+      `/${locale}/analysis/${encodeURIComponent(holding.ticker)}?popup=true`,
+      `analysis_${holding.ticker}`,
+      `width=${width},height=${height},left=${left},top=${top},scrollbars=yes,resizable=yes`
+    );
+  }, [locale]);
+
   const getPnlTrend = (value: number): 'up' | 'down' | 'neutral' => {
     if (value > 0) return 'up';
     if (value < 0) return 'down';
@@ -361,6 +373,7 @@ export default function PortfolioPage() {
         <HoldingsTable
           holdings={filteredHoldings}
           isLoading={isLoading}
+          onRowClick={handleRowClick}
           onEdit={handleEditClick}
           onDelete={handleDeleteClick}
         />

--- a/web/src/components/portfolio/HoldingsTable.tsx
+++ b/web/src/components/portfolio/HoldingsTable.tsx
@@ -14,6 +14,8 @@ interface HoldingsTableProps {
   holdings: Holding[];
   /** Whether data is loading */
   isLoading?: boolean;
+  /** Callback when a holding row is clicked */
+  onRowClick?: (holding: Holding) => void;
   /** Callback when edit button is clicked */
   onEdit?: (holding: Holding) => void;
   /** Callback when delete button is clicked */
@@ -71,6 +73,7 @@ function getPnlColorClass(value: number | null): string {
 export default function HoldingsTable({
   holdings,
   isLoading,
+  onRowClick,
   onEdit,
   onDelete,
 }: HoldingsTableProps) {
@@ -208,7 +211,8 @@ export default function HoldingsTable({
             {sortedHoldings.map((holding) => (
               <tr
                 key={holding.ticker}
-                className="border-b border-[var(--border)] hover:bg-blue-50/50 dark:hover:bg-blue-900/10 transition-colors"
+                onClick={() => onRowClick?.(holding)}
+                className={`border-b border-[var(--border)] hover:bg-blue-50/50 dark:hover:bg-blue-900/10 transition-colors ${onRowClick ? 'cursor-pointer' : ''}`}
               >
                 <td className="px-5 py-4">
                   <span className="font-mono font-medium text-[var(--color-primary)]">
@@ -245,7 +249,7 @@ export default function HoldingsTable({
                 <td className={`px-5 py-4 text-right font-mono ${getPnlColorClass(holding.pnl_pct)}`}>
                   {formatPercent(holding.pnl_pct)}
                 </td>
-                <td className="px-5 py-4">
+                <td className="px-5 py-4" onClick={(e) => e.stopPropagation()}>
                   <div className="flex items-center justify-center gap-2">
                     {onEdit && (
                       <button
@@ -280,6 +284,7 @@ export default function HoldingsTable({
           <MobileCard
             key={holding.ticker}
             holding={holding}
+            onRowClick={onRowClick}
             onEdit={onEdit}
             onDelete={onDelete}
           />
@@ -291,6 +296,7 @@ export default function HoldingsTable({
 
 interface MobileCardProps {
   holding: Holding;
+  onRowClick?: (holding: Holding) => void;
   onEdit?: (holding: Holding) => void;
   onDelete?: (holding: Holding) => void;
 }
@@ -298,7 +304,7 @@ interface MobileCardProps {
 /**
  * Mobile card component for responsive display
  */
-function MobileCard({ holding, onEdit, onDelete }: MobileCardProps) {
+function MobileCard({ holding, onRowClick, onEdit, onDelete }: MobileCardProps) {
   const t = useTranslations('portfolio');
   const locale = useLocale();
   const formatCurrency = (value: number | null, currency?: string) => formatCurrencyUtil(value, currency, locale);
@@ -306,7 +312,10 @@ function MobileCard({ holding, onEdit, onDelete }: MobileCardProps) {
   const formatQuantity = (value: number) => formatQuantityUtil(value, locale);
 
   return (
-    <div className="p-4">
+    <div
+      className={`p-4 ${onRowClick ? 'cursor-pointer' : ''}`}
+      onClick={() => onRowClick?.(holding)}
+    >
       <div className="flex items-start justify-between">
         <div>
           <div className="flex items-center gap-2">
@@ -323,7 +332,7 @@ function MobileCard({ holding, onEdit, onDelete }: MobileCardProps) {
           </div>
           <p className="mt-1 text-sm text-[var(--foreground)]">{holding.name || '-'}</p>
         </div>
-        <div className="flex items-center gap-1">
+        <div className="flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
           {onEdit && (
             <button
               type="button"


### PR DESCRIPTION
## Summary
- Portfolio 테이블에서 종목 행을 클릭하면 분석 팝업(`/analysis/[ticker]?popup=true`)이 열림
- 데스크톱(테이블 row)과 모바일(카드) 모두 지원
- Edit/Delete 버튼은 `stopPropagation`으로 팝업 트리거 방지
- 기존 분석 팝업 페이지를 재활용하여 추가 컴포넌트 없이 구현

## Changes
| File | Change |
|------|--------|
| `web/src/components/portfolio/HoldingsTable.tsx` | Add `onRowClick` prop, cursor-pointer, stopPropagation on action buttons |
| `web/src/app/[locale]/portfolio/page.tsx` | Add `handleRowClick` with `window.open` popup logic |

## Test plan
- [x] ESLint: 0 errors
- [x] Build: passes
- [x] E2E: 54/54 tests passed
- [x] Verified: row click opens popup centered on screen
- [x] Verified: edit/delete buttons still work independently

Closes #209

Codex reviewed