### PR TITLE
feat: add i18n to ReportList/ReportCard and fix dashboard reports link (#134)

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -318,7 +318,27 @@
   },
   "reports": {
     "title": "Analysis Reports",
-    "subtitle": "View past analysis reports and AI-powered stock insights"
+    "subtitle": "View past analysis reports and AI-powered stock insights",
+    "failedToLoad": "Failed to Load Reports",
+    "retry": "Retry",
+    "noReports": "No Reports Available",
+    "runScreening": "Run a screening to generate analysis reports",
+    "reportCount": "{count, plural, one {# report} other {# reports}}",
+    "filterAll": "All Time",
+    "filterToday": "Today",
+    "filterWeek": "Last 7 Days",
+    "filterMonth": "Last 30 Days",
+    "noFilterMatch": "No reports match the selected filter",
+    "dateToday": "Today",
+    "dateYesterday": "Yesterday",
+    "dateDaysAgo": "{days} days ago",
+    "totalStocks": "Total Stocks",
+    "buySignals": "BUY Signals",
+    "stocksData": "Stocks Data",
+    "preview": "Preview",
+    "viewFullReport": "View Full Report",
+    "buy": "BUY",
+    "stocksUnit": "stocks"
   },
   "stockDetail": {
     "financialOverview": "Financial Overview",
@@ -866,6 +886,7 @@
     "us": "US Market",
     "kr": "Korea Market",
     "kospi": "KOSPI",
+    "kosdaq": "KOSDAQ",
     "nasdaq": "NASDAQ",
     "sp500": "S&P 500"
   }

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -318,7 +318,27 @@
   },
   "reports": {
     "title": "분석 리포트",
-    "subtitle": "과거 분석 리포트와 AI 종목 인사이트 보기"
+    "subtitle": "과거 분석 리포트와 AI 종목 인사이트 보기",
+    "failedToLoad": "리포트 로드 실패",
+    "retry": "재시도",
+    "noReports": "리포트가 없습니다",
+    "runScreening": "스크리닝을 실행하여 분석 리포트를 생성하세요",
+    "reportCount": "{count}개 리포트",
+    "filterAll": "전체 기간",
+    "filterToday": "오늘",
+    "filterWeek": "최근 7일",
+    "filterMonth": "최근 30일",
+    "noFilterMatch": "선택한 필터에 맞는 리포트가 없습니다",
+    "dateToday": "오늘",
+    "dateYesterday": "어제",
+    "dateDaysAgo": "{days}일 전",
+    "totalStocks": "총 종목 수",
+    "buySignals": "매수 신호",
+    "stocksData": "종목 데이터",
+    "preview": "미리보기",
+    "viewFullReport": "전체 리포트 보기",
+    "buy": "매수",
+    "stocksUnit": "종목"
   },
   "stockDetail": {
     "financialOverview": "재무 개요",
@@ -866,6 +886,7 @@
     "us": "미국 시장",
     "kr": "한국 시장",
     "kospi": "KOSPI",
+    "kosdaq": "KOSDAQ",
     "nasdaq": "NASDAQ",
     "sp500": "S&P 500"
   }

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -312,7 +312,27 @@
   },
   "reports": {
     "title": "分析报告",
-    "subtitle": "查看历史分析报告和AI股票洞察"
+    "subtitle": "查看历史分析报告和AI股票洞察",
+    "failedToLoad": "加载报告失败",
+    "retry": "重试",
+    "noReports": "暂无报告",
+    "runScreening": "运行筛选以生成分析报告",
+    "reportCount": "{count} 份报告",
+    "filterAll": "全部时间",
+    "filterToday": "今天",
+    "filterWeek": "最近 7 天",
+    "filterMonth": "最近 30 天",
+    "noFilterMatch": "没有匹配所选筛选条件的报告",
+    "dateToday": "今天",
+    "dateYesterday": "昨天",
+    "dateDaysAgo": "{days} 天前",
+    "totalStocks": "总股票数",
+    "buySignals": "买入信号",
+    "stocksData": "股票数据",
+    "preview": "预览",
+    "viewFullReport": "查看完整报告",
+    "buy": "买入",
+    "stocksUnit": "只股票"
   },
   "stockDetail": {
     "financialOverview": "财务概览",
@@ -860,6 +880,7 @@
     "us": "美国市场",
     "kr": "韩国市场",
     "kospi": "KOSPI",
+    "kosdaq": "KOSDAQ",
     "nasdaq": "NASDAQ",
     "sp500": "标普 500"
   }

--- a/web/src/components/analysis/ReportCard.tsx
+++ b/web/src/components/analysis/ReportCard.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import { useState } from 'react';
-import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+import { useLocale } from 'next-intl';
+import { Link } from '@/i18n/navigation';
 import {
   FileText,
   Calendar,
@@ -24,6 +26,9 @@ interface ReportCardProps {
  * Displays a single analysis report summary with expandable details
  */
 export default function ReportCard({ report, className = '' }: ReportCardProps) {
+  const t = useTranslations('reports');
+  const tMarkets = useTranslations('markets');
+  const locale = useLocale();
   const [isExpanded, setIsExpanded] = useState(false);
   const [detailData, setDetailData] = useState<ReportDetail | null>(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -36,7 +41,7 @@ export default function ReportCard({ report, className = '' }: ReportCardProps) 
       const month = dateStr.slice(4, 6);
       const day = dateStr.slice(6, 8);
       const date = new Date(`${year}-${month}-${day}`);
-      return new Intl.DateTimeFormat('en-US', {
+      return new Intl.DateTimeFormat(locale, {
         weekday: 'short',
         month: 'short',
         day: 'numeric',
@@ -48,15 +53,12 @@ export default function ReportCard({ report, className = '' }: ReportCardProps) 
   };
 
   const getMarketLabel = (market: string) => {
-    const marketLabels: Record<string, string> = {
-      us: 'US Market',
-      kr: 'Korea Market',
-      kospi: 'KOSPI',
-      kosdaq: 'KOSDAQ',
-      nasdaq: 'NASDAQ',
-      sp500: 'S&P 500',
-    };
-    return marketLabels[market.toLowerCase()] || market.toUpperCase();
+    const key = market.toLowerCase().replace(/[^a-z0-9]/g, '');
+    try {
+      return tMarkets(key);
+    } catch {
+      return market.toUpperCase();
+    }
   };
 
   const handleToggle = async () => {
@@ -115,12 +117,12 @@ export default function ReportCard({ report, className = '' }: ReportCardProps) 
             {report.buy_count > 0 && (
               <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900 dark:text-green-200">
                 <TrendingUp className="h-3 w-3" />
-                {report.buy_count} BUY
+                {report.buy_count} {t('buy')}
               </span>
             )}
             {report.total_stocks > 0 && (
               <span className="text-xs text-[var(--foreground-muted)]">
-                ({report.total_stocks} stocks)
+                ({report.total_stocks} {t('stocksUnit')})
               </span>
             )}
           </div>
@@ -161,7 +163,7 @@ export default function ReportCard({ report, className = '' }: ReportCardProps) 
               <div className="grid grid-cols-3 gap-3">
                 <div className="rounded-lg bg-[var(--background)] p-3">
                   <span className="text-xs text-[var(--foreground-muted)]">
-                    Total Stocks
+                    {t('totalStocks')}
                   </span>
                   <p className="text-lg font-semibold text-[var(--foreground)]">
                     {report.total_stocks.toLocaleString()}
@@ -169,7 +171,7 @@ export default function ReportCard({ report, className = '' }: ReportCardProps) 
                 </div>
                 <div className="rounded-lg bg-[var(--background)] p-3">
                   <span className="text-xs text-[var(--foreground-muted)]">
-                    BUY Signals
+                    {t('buySignals')}
                   </span>
                   <p className="text-lg font-semibold text-green-600 dark:text-green-400">
                     {report.buy_count}
@@ -177,7 +179,7 @@ export default function ReportCard({ report, className = '' }: ReportCardProps) 
                 </div>
                 <div className="rounded-lg bg-[var(--background)] p-3">
                   <span className="text-xs text-[var(--foreground-muted)]">
-                    Stocks Data
+                    {t('stocksData')}
                   </span>
                   <p className="text-lg font-semibold text-[var(--foreground)]">
                     {detailData.stocks.length}
@@ -188,7 +190,7 @@ export default function ReportCard({ report, className = '' }: ReportCardProps) 
               {/* Content preview */}
               {detailData.content && (
                 <div className="rounded-lg bg-[var(--background)] p-3">
-                  <span className="text-xs text-[var(--foreground-muted)]">Preview</span>
+                  <span className="text-xs text-[var(--foreground-muted)]">{t('preview')}</span>
                   <p className="mt-1 text-sm text-[var(--foreground)] line-clamp-3">
                     {getContentPreview(detailData.content)}
                   </p>
@@ -201,7 +203,7 @@ export default function ReportCard({ report, className = '' }: ReportCardProps) 
                 className="inline-flex items-center gap-2 rounded-lg bg-[var(--color-primary)] px-4 py-2 text-sm font-medium text-white hover:opacity-90 transition-opacity"
               >
                 <ExternalLink className="h-4 w-4" />
-                View Full Report
+                {t('viewFullReport')}
               </Link>
             </div>
           )}

--- a/web/src/components/analysis/ReportList.tsx
+++ b/web/src/components/analysis/ReportList.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useEffect, useState, useMemo, useCallback } from 'react';
+import { useTranslations } from 'next-intl';
+import { useLocale } from 'next-intl';
 import { FileText, Calendar, Filter, RefreshCw } from 'lucide-react';
 import ReportCard from './ReportCard';
 import { Button } from '@/components/ui';
@@ -21,6 +23,8 @@ export default function ReportList({
   initialLimit = 10,
   className = '',
 }: ReportListProps) {
+  const t = useTranslations('reports');
+  const locale = useLocale();
   const [reports, setReports] = useState<ReportSummary[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -33,11 +37,11 @@ export default function ReportList({
       const data = await getReports(initialLimit);
       setReports(data);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load reports');
+      setError(err instanceof Error ? err.message : t('failedToLoad'));
     } finally {
       setIsLoading(false);
     }
-  }, [initialLimit]);
+  }, [initialLimit, t]);
 
   useEffect(() => {
     fetchReports();
@@ -65,7 +69,8 @@ export default function ReportList({
     }
 
     return reports.filter((report) => {
-      const reportDate = new Date(report.date);
+      const d = report.date;
+      const reportDate = new Date(Number(d.slice(0, 4)), Number(d.slice(4, 6)) - 1, Number(d.slice(6, 8)));
       return reportDate >= filterDate;
     });
   }, [reports, dateFilter]);
@@ -87,21 +92,23 @@ export default function ReportList({
 
   const formatGroupDate = (dateStr: string) => {
     try {
-      const date = new Date(dateStr);
+      const y = Number(dateStr.slice(0, 4));
+      const m = Number(dateStr.slice(4, 6)) - 1;
+      const d = Number(dateStr.slice(6, 8));
+      const date = new Date(y, m, d);
       const today = new Date();
       today.setHours(0, 0, 0, 0);
-      const reportDate = new Date(dateStr);
-      reportDate.setHours(0, 0, 0, 0);
+      const reportDate = new Date(y, m, d);
 
       const diffDays = Math.floor(
         (today.getTime() - reportDate.getTime()) / (1000 * 60 * 60 * 24)
       );
 
-      if (diffDays === 0) return 'Today';
-      if (diffDays === 1) return 'Yesterday';
-      if (diffDays < 7) return `${diffDays} days ago`;
+      if (diffDays === 0) return t('dateToday');
+      if (diffDays === 1) return t('dateYesterday');
+      if (diffDays < 7) return t('dateDaysAgo', { days: diffDays });
 
-      return new Intl.DateTimeFormat('en-US', {
+      return new Intl.DateTimeFormat(locale, {
         weekday: 'long',
         month: 'long',
         day: 'numeric',
@@ -139,7 +146,7 @@ export default function ReportList({
         <div className="flex flex-col items-center text-center">
           <FileText className="h-10 w-10 text-red-500 mb-3" />
           <h3 className="text-lg font-medium text-red-800 dark:text-red-200">
-            Failed to Load Reports
+            {t('failedToLoad')}
           </h3>
           <p className="mt-1 text-sm text-red-600 dark:text-red-400">{error}</p>
           <Button
@@ -149,7 +156,7 @@ export default function ReportList({
             onClick={fetchReports}
           >
             <RefreshCw className="h-4 w-4 mr-2" />
-            Retry
+            {t('retry')}
           </Button>
         </div>
       </div>
@@ -163,10 +170,10 @@ export default function ReportList({
         <div className="flex flex-col items-center text-center">
           <FileText className="h-12 w-12 text-[var(--foreground-muted)] mb-4" />
           <h3 className="text-lg font-medium text-[var(--foreground)]">
-            No Reports Available
+            {t('noReports')}
           </h3>
           <p className="mt-1 text-sm text-[var(--foreground-muted)]">
-            Run a screening to generate analysis reports
+            {t('runScreening')}
           </p>
         </div>
       </div>
@@ -180,7 +187,7 @@ export default function ReportList({
         <div className="flex items-center gap-2">
           <Filter className="h-4 w-4 text-[var(--foreground-muted)]" />
           <span className="text-sm text-[var(--foreground-muted)]">
-            {filteredReports.length} report{filteredReports.length !== 1 ? 's' : ''}
+            {t('reportCount', { count: filteredReports.length })}
           </span>
         </div>
 
@@ -191,10 +198,10 @@ export default function ReportList({
             onChange={(e) => setDateFilter(e.target.value)}
             className="rounded-lg border border-[var(--border)] bg-[var(--background-secondary)] px-3 py-1.5 text-sm text-[var(--foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]"
           >
-            <option value="all">All Time</option>
-            <option value="today">Today</option>
-            <option value="week">Last 7 Days</option>
-            <option value="month">Last 30 Days</option>
+            <option value="all">{t('filterAll')}</option>
+            <option value="today">{t('filterToday')}</option>
+            <option value="week">{t('filterWeek')}</option>
+            <option value="month">{t('filterMonth')}</option>
           </select>
         </div>
       </div>
@@ -203,7 +210,7 @@ export default function ReportList({
       {filteredReports.length === 0 && (
         <div className="rounded-lg border border-[var(--border)] bg-[var(--background-secondary)] p-6 text-center">
           <p className="text-[var(--foreground-muted)]">
-            No reports match the selected filter
+            {t('noFilterMatch')}
           </p>
         </div>
       )}

--- a/web/src/components/dashboard/RecentReportsCard.tsx
+++ b/web/src/components/dashboard/RecentReportsCard.tsx
@@ -135,7 +135,7 @@ export default function RecentReportsCard() {
         ))}
 
         <Link
-          href="/analysis"
+          href="/reports"
           className="flex items-center justify-center gap-2 px-6 py-3 text-sm font-medium text-[var(--color-primary)] hover:bg-[var(--background)] transition-colors"
         >
           {t('viewAllReports')}


### PR DESCRIPTION
## Summary
- Replace all hardcoded English strings in `ReportList` and `ReportCard` with `next-intl` translation keys (`reports` namespace, 22 keys across en/ko/zh)
- Switch `ReportCard` Link import to locale-aware `@/i18n/navigation` and use `useTranslations('markets')` for market labels
- Fix `YYYYMMDD` date parsing to use local `Date` constructor, avoiding UTC timezone offset issues
- Fix dashboard "View All Reports" link from `/analysis` to `/reports`

Closes #134

## Test plan
- [ ] `npm run lint` passes (0 errors)
- [ ] Navigate to `/en/reports`, `/ko/reports`, `/zh/reports` — verify translated strings
- [ ] Dashboard "View All Reports" links to `/reports` not `/analysis`
- [ ] Report date filters (Today/Week/Month) work correctly across timezones
- [ ] Report card market labels display correctly for all markets including KOSDAQ

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Codex Review**: LGTM (3 rounds — kosdaq key, BUY/stocks hardcode, timezone fix all addressed)