### PR TITLE
feat: implement Kiwoom P6 portfolio live integration

### DIFF
--- a/kiwoom/chejan_handler.py
+++ b/kiwoom/chejan_handler.py
@@ -28,6 +28,8 @@ class ChejanOrderEvent:
     order_no: str
     code: str
     raw_status: str
+    order_qty: int
+    side: str
     filled_qty: int
     unfilled_qty: int
     fill_price: int
@@ -89,6 +91,8 @@ class ChejanHandler:
                     "code": event.code,
                     "status": event.status.value,
                     "raw_status": event.raw_status,
+                    "order_qty": event.order_qty,
+                    "side": event.side,
                     "filled_qty": event.filled_qty,
                     "unfilled_qty": event.unfilled_qty,
                     "fill_price": event.fill_price,
@@ -126,6 +130,15 @@ class ChejanHandler:
             return code[1:]
         return code
 
+    @staticmethod
+    def _normalize_side(order_category: str, buy_sell: str) -> str:
+        text = f"{order_category} {buy_sell}".upper().replace("+", "").replace("-", "")
+        if "매수" in text or "BUY" in text:
+            return "BUY"
+        if "매도" in text or "SELL" in text:
+            return "SELL"
+        return ""
+
     def _derive_status(self, raw_status: str, filled_qty: int, unfilled_qty: int) -> OrderStatus:
         status = raw_status.strip()
 
@@ -154,6 +167,11 @@ class ChejanHandler:
         order_no = self._get_chejan_data(FID.ORDER_NO)
         code = self._normalize_code(self._get_chejan_data(FID.CODE))
         raw_status = self._get_chejan_data(FID.ORDER_STATUS)
+        order_qty = self._to_int(self._get_chejan_data(FID.ORDER_QTY))
+        side = self._normalize_side(
+            self._get_chejan_data(FID.ORDER_CATEGORY),
+            self._get_chejan_data(FID.BUY_SELL),
+        )
         fill_price = self._to_int(self._get_chejan_data(FID.FILL_PRICE))
         filled_qty = self._to_int(self._get_chejan_data(FID.FILL_QTY))
         unfilled_qty = self._to_int(self._get_chejan_data(FID.UNFILLED_QTY))
@@ -163,6 +181,8 @@ class ChejanHandler:
             order_no=order_no,
             code=code,
             raw_status=raw_status,
+            order_qty=order_qty,
+            side=side,
             filled_qty=filled_qty,
             unfilled_qty=unfilled_qty,
             fill_price=fill_price,
@@ -195,4 +215,7 @@ class ChejanHandler:
 
     def _notify(self, payload: Dict[str, Any]) -> None:
         for callback in list(self._observers):
-            callback(payload)
+            try:
+                callback(payload)
+            except Exception:
+                continue

--- a/portfolio/executor.py
+++ b/portfolio/executor.py
@@ -369,6 +369,8 @@ class KiwoomExecutor(BaseExecutor):
         order_no = str(event.get("order_no", "")).strip()
         code = str(event.get("code", "")).strip()
         status = str(event.get("status", "")).strip()
+        event_qty = int(event.get("order_qty", 0) or 0)
+        event_side = str(event.get("side", "")).strip().upper()
 
         client_order_id = self._broker_to_client_order.get(order_no)
         if client_order_id is None and code:
@@ -376,14 +378,22 @@ class KiwoomExecutor(BaseExecutor):
             candidates = [
                 cid
                 for cid, submitted in self._submitted_orders.items()
-                if self._to_kiwoom_code(submitted.ticker) == code and self._client_status.get(cid) not in {
+                if self._to_kiwoom_code(submitted.ticker) == code
+                and (event_qty <= 0 or int(submitted.quantity) == event_qty)
+                and (not event_side or submitted.side.upper() == event_side)
+                and self._client_status.get(cid) not in {
                     OrderStatus.FILLED.value,
                     OrderStatus.CANCELLED.value,
                     OrderStatus.REJECTED.value,
                 }
             ]
             if candidates:
-                client_order_id = candidates[-1]
+                # Prefer the oldest open order to reduce mis-mapping when multiple
+                # provisional ids exist for the same code.
+                client_order_id = sorted(
+                    candidates,
+                    key=lambda cid: self._submitted_orders[cid].created_at,
+                )[0]
                 previous_broker = self._client_to_broker_order.get(client_order_id)
                 if previous_broker:
                     self._broker_to_client_order.pop(previous_broker, None)

--- a/portfolio/holdings.py
+++ b/portfolio/holdings.py
@@ -14,6 +14,7 @@ Usage:
 
 import yaml
 import logging
+import threading
 from pathlib import Path
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Any
@@ -89,9 +90,16 @@ class Portfolio:
 
     DEFAULT_PATH = Path(__file__).parent.parent / "config" / "portfolio.yaml"
 
-    def __init__(self, filepath: Optional[str] = None):
+    def __init__(
+        self,
+        filepath: Optional[str] = None,
+        realtime_save_interval_seconds: float = 0.5,
+    ):
         self.logger = logging.getLogger(__name__)
         self.filepath = Path(filepath) if filepath else self.DEFAULT_PATH
+        self._realtime_save_interval_seconds = max(0.0, float(realtime_save_interval_seconds))
+        self._pending_save_timer: Optional[threading.Timer] = None
+        self._pending_save_lock = threading.Lock()
         self._holdings: Dict[str, Holding] = {}
         self._load()
 
@@ -346,7 +354,7 @@ class Portfolio:
         if quantity <= 0:
             if ticker in self._holdings:
                 del self._holdings[ticker]
-                self._save()
+                self._schedule_realtime_save()
             return
 
         holding = self._holdings.get(ticker)
@@ -362,11 +370,41 @@ class Portfolio:
         else:
             holding.quantity = quantity
             holding.avg_price = avg_price
-        self._save()
+        self._schedule_realtime_save()
 
     def bind_chejan_handler(self, chejan_handler: Any) -> None:
         """ChejanHandler 옵저버로 등록해 잔고 이벤트를 실시간 반영."""
         chejan_handler.add_observer(self.sync_from_kiwoom_balance_event)
+
+    def flush_pending_sync_save(self) -> None:
+        """Flush pending throttled save from realtime balance sync."""
+        with self._pending_save_lock:
+            timer = self._pending_save_timer
+            self._pending_save_timer = None
+        if timer is not None:
+            timer.cancel()
+        self._save()
+
+    def _schedule_realtime_save(self) -> None:
+        if self._realtime_save_interval_seconds <= 0:
+            self._save()
+            return
+
+        with self._pending_save_lock:
+            if self._pending_save_timer is not None:
+                return
+            timer = threading.Timer(
+                self._realtime_save_interval_seconds,
+                self._flush_scheduled_realtime_save,
+            )
+            timer.daemon = True
+            self._pending_save_timer = timer
+            timer.start()
+
+    def _flush_scheduled_realtime_save(self) -> None:
+        with self._pending_save_lock:
+            self._pending_save_timer = None
+        self._save()
 
     def sync_from_opw00018(self, rows: List[Dict[str, Any]]) -> int:
         """OPW00018 TR 결과로 전체 보유 종목을 수동 동기화."""

--- a/portfolio/trigger.py
+++ b/portfolio/trigger.py
@@ -367,11 +367,34 @@ class RealtimeTriggerBridge:
         code = str(event.get("code", "")).strip()
         if not code:
             return []
-        ticker = f"{code}.KS"
         price = event.get("current_price")
         if price is None:
             return []
-        return self.on_price_update(ticker, float(price))
+        results: List[TriggerEvent] = []
+        for ticker in self._resolve_tickers(code, event.get("market")):
+            results.extend(self.on_price_update(ticker, float(price)))
+        return results
+
+    def _resolve_tickers(self, code: str, market: Optional[Any]) -> List[str]:
+        """Resolve ticker candidates with KS/KQ suffix from market or conditions."""
+        norm = str(code).strip().upper()
+        market_text = str(market or "").strip().upper()
+        if any(token in market_text for token in ["KOSDAQ", "KQ", "KSQ"]):
+            return [f"{norm}.KQ"]
+        if any(token in market_text for token in ["KOSPI", "KS", "STK"]):
+            return [f"{norm}.KS"]
+
+        ks = f"{norm}.KS"
+        kq = f"{norm}.KQ"
+        has_ks = len(self._checker.get_conditions(ks)) > 0
+        has_kq = len(self._checker.get_conditions(kq)) > 0
+        if has_kq and not has_ks:
+            return [kq]
+        if has_ks and not has_kq:
+            return [ks]
+        if has_ks and has_kq:
+            return [ks, kq]
+        return [ks]
 
     def bind_price_feed(self, subscribe_fn: Callable[[Callable[[Dict[str, Any]], None]], None]) -> None:
         """외부 실시간 피드의 subscribe 함수와 연결."""

--- a/tests/test_kiwoom_p5_chejan.py
+++ b/tests/test_kiwoom_p5_chejan.py
@@ -108,6 +108,31 @@ def test_observer_receives_order_and_balance_events() -> None:
     assert events[1]["type"] == "balance"
 
 
+def test_observer_exception_does_not_block_next_observer() -> None:
+    ocx = _FakeOcx()
+    handler = ChejanHandler(ocx)
+    events = []
+
+    def _broken(_payload):
+        raise RuntimeError("observer failure")
+
+    handler.add_observer(_broken)
+    handler.add_observer(events.append)
+
+    _set_order_chejan(
+        ocx,
+        order_no="334",
+        code="A005930",
+        status="접수",
+        fill_price=0,
+        fill_qty=0,
+        unfilled_qty=10,
+    )
+    handler.on_receive_chejan_data("0", 0, "")
+    assert len(events) == 1
+    assert events[0]["type"] == "order"
+
+
 def test_syncs_status_to_order_manager_history() -> None:
     ocx = _FakeOcx()
     order_manager = KiwoomOrderManager(ocx, throttle_seconds=0.0)

--- a/tests/test_kiwoom_p6_integration.py
+++ b/tests/test_kiwoom_p6_integration.py
@@ -34,9 +34,16 @@ class _FakeChejanHandler:
             return self._order_status_by_no[order_no]
         return self._status
 
-    def emit_order_event(self, order_no, code, status):
+    def emit_order_event(self, order_no, code, status, order_qty=0, side=""):
         self._order_status_by_no[order_no] = type("S", (), {"value": status})()
-        payload = {"type": "order", "order_no": order_no, "code": code, "status": status}
+        payload = {
+            "type": "order",
+            "order_no": order_no,
+            "code": code,
+            "status": status,
+            "order_qty": order_qty,
+            "side": side,
+        }
         for cb in list(self._observers):
             cb(payload)
 
@@ -95,6 +102,48 @@ def test_kiwoom_executor_execute_and_status_mapping() -> None:
     status = executor.get_order_status("cid-1")
     assert status is not None
     assert status.status == OrderStatus.FILLED.value
+
+
+def test_kiwoom_executor_fallback_remap_matches_side_and_qty() -> None:
+    order_manager = _FakeOrderManager()
+    chejan_handler = _FakeChejanHandler()
+    executor = KiwoomExecutor(
+        ocx=object(),
+        acc_no="8123456789",
+        risk_manager=_AllowRiskManager(),
+        order_manager=order_manager,
+        chejan_handler=chejan_handler,
+    )
+
+    buy_result = executor.execute(
+        Order(
+            ticker="005930.KS",
+            side="BUY",
+            quantity=2,
+            price=70000,
+            order_type="LIMIT",
+            order_id="cid-buy-2",
+        )
+    )
+    sell_result = executor.execute(
+        Order(
+            ticker="005930.KS",
+            side="SELL",
+            quantity=1,
+            price=71000,
+            order_type="LIMIT",
+            order_id="cid-sell-1",
+        )
+    )
+    assert buy_result.success is True
+    assert sell_result.success is True
+
+    # Broker number differs from provisional number and arrives without mapping.
+    chejan_handler.emit_order_event("real-777", "005930", "FILLED", order_qty=1, side="SELL")
+    buy_status = executor.get_order_status("cid-buy-2")
+    sell_status = executor.get_order_status("cid-sell-1")
+    assert buy_status is not None and buy_status.status == OrderStatus.PENDING.value
+    assert sell_status is not None and sell_status.status == OrderStatus.FILLED.value
 
 
 def test_kiwoom_executor_blocks_by_risk_rule() -> None:
@@ -222,3 +271,37 @@ def test_realtime_trigger_bridge_uses_event_feed() -> None:
     assert len(emitted) == 1
     assert len(events) == 1
     assert events[0]["ticker"] == "005930.KS"
+
+
+def test_realtime_trigger_bridge_resolves_kosdaq_suffix() -> None:
+    checker = ConditionChecker()
+    checker.add_condition("035720.KQ", "PRICE_ABOVE", 50000)
+    bridge = RealtimeTriggerBridge(checker)
+
+    emitted = bridge.on_realtime_event(
+        {"code": "035720", "current_price": 51000, "market": "KOSDAQ"}
+    )
+    assert len(emitted) == 1
+    assert emitted[0].ticker == "035720.KQ"
+
+
+def test_portfolio_realtime_sync_uses_throttled_save(tmp_path) -> None:
+    portfolio_file = tmp_path / "portfolio_throttled.yaml"
+    p = Portfolio(filepath=str(portfolio_file), realtime_save_interval_seconds=60.0)
+    save_calls = {"n": 0}
+
+    def _fake_save():
+        save_calls["n"] += 1
+
+    p._save = _fake_save  # type: ignore[method-assign]
+
+    p.sync_from_kiwoom_balance_event(
+        {"type": "balance", "code": "005930", "holding_qty": 1, "avg_buy_price": 70000}
+    )
+    p.sync_from_kiwoom_balance_event(
+        {"type": "balance", "code": "005930", "holding_qty": 2, "avg_buy_price": 70000}
+    )
+    assert save_calls["n"] == 0
+
+    p.flush_pending_sync_save()
+    assert save_calls["n"] == 1


### PR DESCRIPTION
## Summary
- What changed:
  - Added `KiwoomExecutor(BaseExecutor)` in `portfolio/executor.py` and enabled live injection via `OrderExecutor.set_live_executor(...)` path.
  - Integrated risk validation before order send using `portfolio.risk` manager.
  - Wired execution flow to `KiwoomOrderManager.send_order()` and `ChejanHandler` status lookup.
  - Added holdings sync helpers in `portfolio/holdings.py`:
    - `sync_from_kiwoom_balance_event(...)`
    - `bind_chejan_handler(...)`
    - `sync_from_opw00018(...)`
  - Added event-driven trigger adapter `RealtimeTriggerBridge` in `portfolio/trigger.py`.
  - Added `tests/test_kiwoom_p6_integration.py`.
- Why:
  - P6 connects P4/P5 Kiwoom capabilities to existing portfolio stack for live execution + realtime state propagation.

## Linked Issues
- Closes #250
- Refs #249
- Refs #248
- Refs #217

## Scope
- In scope:
  - Live executor plumbing, risk gate, holdings sync helpers, realtime trigger bridge.
- Out of scope:
  - Full live safety/kill-switch flow (P8).
  - Final production-grade OPW00018 fetcher wiring (helper method provided in holdings).

## Validation
- [x] `python3 -m py_compile ...`
- [ ] API smoke test on `8765`
- [ ] UI/manual verification (if applicable)

Commands/Results:
```bash
python -m pytest -q tests/test_kiwoom_p6_integration.py tests/test_kiwoom_p4_order.py tests/test_kiwoom_p5_chejan.py
# 15 passed

python -m pytest -q tests/test_kiwoom_p1.py tests/test_kiwoom_p2_tr.py tests/test_kiwoom_p3_realtime.py tests/test_kiwoom_p4_order.py tests/test_kiwoom_p5_chejan.py tests/test_kiwoom_p6_integration.py
# 39 passed
```

## Risk / Rollback
- Risk:
  - Medium: live path now depends on event order/timing between order manager and chejan updates.
- Rollback steps:
  - Revert commit `4529650`.

## Checklist
- [x] PR title follows conventional style (`feat:`, `fix:`, `chore:`, `docs:`)
- [x] No direct changes to unrelated files
- [ ] Docs updated (`README.md`, `WORKFLOW.md`, `AGENTS.md` if needed)
- [x] Reviewer can reproduce with listed commands
- [ ] AI cross-review label added (`impl:claude` or `impl:codex`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)