### PR TITLE
chore: add automatic PR team labeling

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,23 @@
+team:frontend:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'web/**'
+
+team:backend:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'api/**'
+
+team:quant:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'engine/**'
+          - 'discovery/**'
+          - 'screener/**'
+          - 'pipeline/**'
+          - 'data_enrichment/**'
+          - 'news/**'
+          - 'models/**'
+          - 'llm/**'
+          - 'kiwoom/**'
+          - 'portfolio/**'

--- a/.github/workflows/pr-team-labeler.yml
+++ b/.github/workflows/pr-team-labeler.yml
@@ -1,0 +1,22 @@
+name: PR Team Labeler
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply team labels from changed paths
+        uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- add `.github/labeler.yml` path rules for `team:frontend`, `team:backend`, `team:quant`
- add `.github/workflows/pr-team-labeler.yml` to auto-apply labels on PR open/sync/reopen
- keep labeling scoped to PRs with `pull_request_target` and `pull-requests: write`

## Test plan
- [x] Confirm workflow YAML and label config are committed
- [x] Verify only labeler-related files are included in this PR
- [ ] Open/update a PR touching `web/**` and confirm `team:frontend` is applied
- [ ] Open/update a PR touching `api/**` and confirm `team:backend` is applied
- [ ] Open/update a PR touching quant paths and confirm `team:quant` is applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)