### PR TITLE
perf: harden Kiwoom P4/P5 event and order handling

### DIFF
--- a/kiwoom/chejan_handler.py
+++ b/kiwoom/chejan_handler.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import queue
+import threading
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Set
 
 from kiwoom.constants import ChejanGubun, FID
 
@@ -42,14 +44,23 @@ class ChejanHandler:
         ocx: Any,
         order_manager: Any | None = None,
         get_chejan_data_fn: Optional[Callable[[int], str]] = None,
+        async_notify: bool = True,
     ) -> None:
         self._ocx = ocx
         self._order_manager = order_manager
         self._get_chejan_data_fn = get_chejan_data_fn
+        self._async_notify = async_notify
 
         self._order_status: Dict[str, OrderStatus] = {}
         self._positions: Dict[str, Dict[str, int]] = {}
         self._observers: List[Callable[[Dict[str, Any]], None]] = []
+        self._state_lock = threading.RLock()
+        self._observer_lock = threading.RLock()
+        self._notify_queue: "queue.Queue[Dict[str, Any]]" = queue.Queue()
+        self._notify_worker: Optional[threading.Thread] = None
+        if self._async_notify:
+            self._notify_worker = threading.Thread(target=self._notify_loop, daemon=True)
+            self._notify_worker.start()
 
         self._bind_events()
 
@@ -60,27 +71,31 @@ class ChejanHandler:
             self._ocx._callbacks["OnReceiveChejanData"] = self.on_receive_chejan_data
 
     def add_observer(self, callback: Callable[[Dict[str, Any]], None]) -> None:
-        self._observers.append(callback)
+        with self._observer_lock:
+            self._observers.append(callback)
 
     def remove_observer(self, callback: Callable[[Dict[str, Any]], None]) -> None:
-        if callback in self._observers:
-            self._observers.remove(callback)
+        with self._observer_lock:
+            if callback in self._observers:
+                self._observers.remove(callback)
 
     def get_order_status(self, order_no: str) -> Optional[OrderStatus]:
-        return self._order_status.get(order_no)
+        with self._state_lock:
+            return self._order_status.get(order_no)
 
     @property
     def positions(self) -> Dict[str, Dict[str, int]]:
-        return dict(self._positions)
+        with self._state_lock:
+            return dict(self._positions)
 
     def on_receive_chejan_data(self, sGubun: str, nItemCnt: int, sFidList: str) -> None:
-        _ = nItemCnt
-        _ = sFidList
+        requested_fids = self._parse_fid_list(sFidList) if nItemCnt > 0 else set()
         if sGubun == ChejanGubun.ORDER.value:
-            event = self._parse_order_event()
+            event = self._parse_order_event(requested_fids)
             if not event.order_no:
                 return
-            self._order_status[event.order_no] = event.status
+            with self._state_lock:
+                self._order_status[event.order_no] = event.status
             self._sync_order_manager(event)
             self._notify(
                 {
@@ -95,12 +110,28 @@ class ChejanHandler:
                 }
             )
         elif sGubun == ChejanGubun.BALANCE.value:
-            position = self._parse_balance_event()
+            position = self._parse_balance_event(requested_fids)
             if not position:
                 return
             code = position["code"]
-            self._positions[code] = position
+            with self._state_lock:
+                self._positions[code] = position
             self._notify({"type": "balance", **position})
+
+    @staticmethod
+    def _parse_fid_list(s_fid_list: str) -> Set[int]:
+        if not s_fid_list:
+            return set()
+        parsed: Set[int] = set()
+        for token in s_fid_list.split(";"):
+            token = token.strip()
+            if not token:
+                continue
+            try:
+                parsed.add(int(token))
+            except ValueError:
+                continue
+        return parsed
 
     def _get_chejan_data(self, fid: int) -> str:
         if self._get_chejan_data_fn is not None:
@@ -150,13 +181,29 @@ class ChejanHandler:
             return OrderStatus.FILLED
         return OrderStatus.PENDING
 
-    def _parse_order_event(self) -> ChejanOrderEvent:
-        order_no = self._get_chejan_data(FID.ORDER_NO)
-        code = self._normalize_code(self._get_chejan_data(FID.CODE))
-        raw_status = self._get_chejan_data(FID.ORDER_STATUS)
-        fill_price = self._to_int(self._get_chejan_data(FID.FILL_PRICE))
-        filled_qty = self._to_int(self._get_chejan_data(FID.FILL_QTY))
-        unfilled_qty = self._to_int(self._get_chejan_data(FID.UNFILLED_QTY))
+    def _get_fid_values(self, required_fids: List[int], requested_fids: Set[int]) -> Dict[int, str]:
+        if not requested_fids:
+            return {fid: self._get_chejan_data(fid) for fid in required_fids}
+        return {fid: self._get_chejan_data(fid) for fid in required_fids if fid in requested_fids}
+
+    def _parse_order_event(self, requested_fids: Set[int]) -> ChejanOrderEvent:
+        values = self._get_fid_values(
+            [
+                FID.ORDER_NO,
+                FID.CODE,
+                FID.ORDER_STATUS,
+                FID.FILL_PRICE,
+                FID.FILL_QTY,
+                FID.UNFILLED_QTY,
+            ],
+            requested_fids,
+        )
+        order_no = values.get(FID.ORDER_NO, "")
+        code = self._normalize_code(values.get(FID.CODE, ""))
+        raw_status = values.get(FID.ORDER_STATUS, "")
+        fill_price = self._to_int(values.get(FID.FILL_PRICE, ""))
+        filled_qty = self._to_int(values.get(FID.FILL_QTY, ""))
+        unfilled_qty = self._to_int(values.get(FID.UNFILLED_QTY, ""))
 
         status = self._derive_status(raw_status, filled_qty, unfilled_qty)
         return ChejanOrderEvent(
@@ -169,19 +216,31 @@ class ChejanHandler:
             status=status,
         )
 
-    def _parse_balance_event(self) -> Optional[Dict[str, int]]:
-        code = self._normalize_code(self._get_chejan_data(FID.CODE))
+    def _parse_balance_event(self, requested_fids: Set[int]) -> Optional[Dict[str, int]]:
+        values = self._get_fid_values(
+            [
+                FID.CODE,
+                FID.HOLDING_QTY,
+                FID.AVG_BUY_PRICE,
+                FID.TOTAL_COST,
+                FID.ORDERABLE_QTY,
+                FID.DAY_PNL,
+                FID.PNL_RATE,
+            ],
+            requested_fids,
+        )
+        code = self._normalize_code(values.get(FID.CODE, ""))
         if not code:
             return None
 
         return {
             "code": code,
-            "holding_qty": self._to_int(self._get_chejan_data(FID.HOLDING_QTY)),
-            "avg_buy_price": self._to_int(self._get_chejan_data(FID.AVG_BUY_PRICE)),
-            "total_cost": self._to_int(self._get_chejan_data(FID.TOTAL_COST)),
-            "orderable_qty": self._to_int(self._get_chejan_data(FID.ORDERABLE_QTY)),
-            "day_pnl": self._to_int(self._get_chejan_data(FID.DAY_PNL)),
-            "pnl_rate": self._to_int(self._get_chejan_data(FID.PNL_RATE)),
+            "holding_qty": self._to_int(values.get(FID.HOLDING_QTY, "")),
+            "avg_buy_price": self._to_int(values.get(FID.AVG_BUY_PRICE, "")),
+            "total_cost": self._to_int(values.get(FID.TOTAL_COST, "")),
+            "orderable_qty": self._to_int(values.get(FID.ORDERABLE_QTY, "")),
+            "day_pnl": self._to_int(values.get(FID.DAY_PNL, "")),
+            "pnl_rate": self._to_int(values.get(FID.PNL_RATE, "")),
         }
 
     def _sync_order_manager(self, event: ChejanOrderEvent) -> None:
@@ -193,9 +252,25 @@ class ChejanHandler:
         order.status = event.status.value.lower()
         order.message = event.raw_status
 
-    def _notify(self, payload: Dict[str, Any]) -> None:
-        for callback in list(self._observers):
+    def _notify_loop(self) -> None:
+        while True:
+            payload = self._notify_queue.get()
+            try:
+                self._dispatch(payload)
+            finally:
+                self._notify_queue.task_done()
+
+    def _dispatch(self, payload: Dict[str, Any]) -> None:
+        with self._observer_lock:
+            observers = list(self._observers)
+        for callback in observers:
             try:
                 callback(payload)
             except Exception:
                 continue
+
+    def _notify(self, payload: Dict[str, Any]) -> None:
+        if self._async_notify:
+            self._notify_queue.put(payload)
+            return
+        self._dispatch(payload)

--- a/kiwoom/order.py
+++ b/kiwoom/order.py
@@ -77,17 +77,22 @@ class KiwoomOrderManager:
         self,
         ocx: Any,
         throttle_seconds: float = 1.0,
+        max_history_size: int = 2000,
+        history_ttl_seconds: Optional[float] = 86400.0,
         sleep_fn: Callable[[float], None] = time.sleep,
         time_fn: Callable[[], float] = time.monotonic,
     ) -> None:
         self._ocx = ocx
         self._throttle_seconds = throttle_seconds
+        self._max_history_size = max_history_size
+        self._history_ttl_seconds = history_ttl_seconds
         self._sleep = sleep_fn
         self._time = time_fn
 
         self.order_history: Dict[str, Order] = {}
         self._order_by_rq_name: Dict[str, str] = {}
         self._queue: "queue.Queue[_OrderTask]" = queue.Queue()
+        self._lock = threading.RLock()
         self._last_sent_at: float = 0.0
         self._counter = 0
         self._rq_counter = 0
@@ -168,26 +173,66 @@ class KiwoomOrderManager:
         """Handle OnReceiveMsg and update tracked order status/message."""
         _ = screen_no
         _ = tr_code
-        order_no = self._order_by_rq_name.get(rq_name)
-        if not order_no:
-            return
-        order = self.order_history.get(order_no)
-        if not order:
-            return
+        with self._lock:
+            order_no = self._order_by_rq_name.get(rq_name)
+            if not order_no:
+                return
+            order = self.order_history.get(order_no)
+            if not order:
+                return
 
-        order.message = msg or ""
-        if any(token in (msg or "") for token in ["실패", "거부", "오류", "error", "Error"]):
-            order.status = "rejected"
-        else:
-            order.status = "accepted"
+            order.message = msg or ""
+            if any(token in (msg or "") for token in ["실패", "거부", "오류", "error", "Error"]):
+                order.status = "rejected"
+            else:
+                order.status = "accepted"
 
     def _next_order_no(self) -> str:
-        self._counter += 1
-        return f"mock-{self._counter:08d}"
+        with self._lock:
+            self._counter += 1
+            return f"mock-{self._counter:08d}"
 
     def _next_api_rq_name(self, rq_name: str) -> str:
-        self._rq_counter += 1
-        return f"{rq_name}#{self._rq_counter}"
+        with self._lock:
+            self._rq_counter += 1
+            return f"{rq_name}#{self._rq_counter}"
+
+    def _cleanup_history(self) -> None:
+        if not self.order_history:
+            return
+
+        now_wall = time.time()
+        stale_order_nos = set()
+
+        if self._history_ttl_seconds is not None and self._history_ttl_seconds > 0:
+            for order_no, order in self.order_history.items():
+                ref_ts = order.sent_at or order.created_at
+                if now_wall - ref_ts >= self._history_ttl_seconds:
+                    stale_order_nos.add(order_no)
+
+        if (
+            self._max_history_size > 0
+            and len(self.order_history) - len(stale_order_nos) > self._max_history_size
+        ):
+            survivors = [
+                (order_no, order)
+                for order_no, order in self.order_history.items()
+                if order_no not in stale_order_nos
+            ]
+            survivors.sort(key=lambda item: item[1].sent_at or item[1].created_at)
+            overflow = len(survivors) - self._max_history_size
+            if overflow > 0:
+                stale_order_nos.update(order_no for order_no, _ in survivors[:overflow])
+
+        if not stale_order_nos:
+            return
+
+        for order_no in stale_order_nos:
+            self.order_history.pop(order_no, None)
+
+        stale_rq_names = [rq_name for rq_name, order_no in self._order_by_rq_name.items() if order_no in stale_order_nos]
+        for rq_name in stale_rq_names:
+            self._order_by_rq_name.pop(rq_name, None)
 
     def _worker_loop(self) -> None:
         while True:
@@ -239,8 +284,10 @@ class KiwoomOrderManager:
                     status="sent",
                     sent_at=time.time(),
                 )
-                self.order_history[order_no] = order
-                self._order_by_rq_name[task.api_rq_name] = order_no
+                with self._lock:
+                    self.order_history[order_no] = order
+                    self._order_by_rq_name[task.api_rq_name] = order_no
+                    self._cleanup_history()
                 task.result_holder["order_no"] = order_no
                 task.done_event.set()
             except Exception as exc:  # pragma: no cover

--- a/tests/test_kiwoom_p4_order.py
+++ b/tests/test_kiwoom_p4_order.py
@@ -213,3 +213,52 @@ def test_duplicate_base_rq_name_is_uniquified_for_api_calls() -> None:
     manager.on_receive_msg("1001", second_api_rq, "SendOrder", "정상처리")
     assert manager.order_history[second_no].status == "accepted"
     assert manager.order_history[first_no].status == "sent"
+
+
+def test_order_history_retention_by_max_size() -> None:
+    ocx = _FakeOcx(return_value=0)
+    manager = KiwoomOrderManager(
+        ocx,
+        throttle_seconds=0.0,
+        max_history_size=2,
+        history_ttl_seconds=None,
+    )
+
+    first_no = manager.send_order(
+        rq_name="retention_1",
+        screen_no="1001",
+        acc_no="8123456789",
+        order_type=int(OrderType.NEW_BUY),
+        code="005930",
+        qty=1,
+        price=1000,
+        hoga_type=HogaType.LIMIT.value,
+        org_order_no="",
+    )
+    second_no = manager.send_order(
+        rq_name="retention_2",
+        screen_no="1001",
+        acc_no="8123456789",
+        order_type=int(OrderType.NEW_BUY),
+        code="005930",
+        qty=1,
+        price=1000,
+        hoga_type=HogaType.LIMIT.value,
+        org_order_no="",
+    )
+    third_no = manager.send_order(
+        rq_name="retention_3",
+        screen_no="1001",
+        acc_no="8123456789",
+        order_type=int(OrderType.NEW_BUY),
+        code="005930",
+        qty=1,
+        price=1000,
+        hoga_type=HogaType.LIMIT.value,
+        org_order_no="",
+    )
+
+    assert len(manager.order_history) == 2
+    assert first_no not in manager.order_history
+    assert second_no in manager.order_history
+    assert third_no in manager.order_history

--- a/tests/test_kiwoom_p5_chejan.py
+++ b/tests/test_kiwoom_p5_chejan.py
@@ -37,7 +37,7 @@ def _set_order_chejan(ocx: _FakeOcx, *, order_no: str, code: str, status: str, f
 
 def test_order_state_machine_transitions() -> None:
     ocx = _FakeOcx()
-    handler = ChejanHandler(ocx)
+    handler = ChejanHandler(ocx, async_notify=False)
 
     _set_order_chejan(ocx, order_no="111", code="A005930", status="접수", fill_price=0, fill_qty=0, unfilled_qty=10)
     handler.on_receive_chejan_data("0", 0, "")
@@ -58,7 +58,7 @@ def test_order_state_machine_transitions() -> None:
 
 def test_cancelled_status_mapping() -> None:
     ocx = _FakeOcx()
-    handler = ChejanHandler(ocx)
+    handler = ChejanHandler(ocx, async_notify=False)
 
     _set_order_chejan(ocx, order_no="222", code="A005930", status="취소", fill_price=0, fill_qty=0, unfilled_qty=0)
     handler.on_receive_chejan_data("0", 0, "")
@@ -67,7 +67,7 @@ def test_cancelled_status_mapping() -> None:
 
 def test_balance_event_updates_positions() -> None:
     ocx = _FakeOcx()
-    handler = ChejanHandler(ocx)
+    handler = ChejanHandler(ocx, async_notify=False)
 
     ocx._chejan_values = {
         FID.CODE: "A005930",
@@ -86,7 +86,7 @@ def test_balance_event_updates_positions() -> None:
 
 def test_observer_receives_order_and_balance_events() -> None:
     ocx = _FakeOcx()
-    handler = ChejanHandler(ocx)
+    handler = ChejanHandler(ocx, async_notify=False)
     events = []
     handler.add_observer(events.append)
 
@@ -110,7 +110,7 @@ def test_observer_receives_order_and_balance_events() -> None:
 
 def test_observer_exception_does_not_block_next_observer() -> None:
     ocx = _FakeOcx()
-    handler = ChejanHandler(ocx)
+    handler = ChejanHandler(ocx, async_notify=False)
     events = []
 
     def _broken(_payload):
@@ -142,8 +142,20 @@ def test_syncs_status_to_order_manager_history() -> None:
         org_order_no="",
     )
 
-    handler = ChejanHandler(ocx, order_manager=order_manager)
+    handler = ChejanHandler(ocx, order_manager=order_manager, async_notify=False)
     _set_order_chejan(ocx, order_no=order_no, code="A005930", status="체결", fill_price=70000, fill_qty=1, unfilled_qty=0)
     handler.on_receive_chejan_data("0", 0, "")
 
     assert order_manager.order_history[order_no].status == "filled"
+
+
+def test_order_event_parses_only_requested_fids() -> None:
+    ocx = _FakeOcx()
+    handler = ChejanHandler(ocx, async_notify=False)
+
+    _set_order_chejan(ocx, order_no="555", code="A005930", status="체결", fill_price=70000, fill_qty=3, unfilled_qty=7)
+    handler.on_receive_chejan_data("0", 3, f"{FID.ORDER_NO};{FID.CODE};{FID.ORDER_STATUS}")
+
+    get_calls = [call for call in ocx.calls if "GetChejanData" in call[0]]
+    assert len(get_calls) == 3
+    assert handler.get_order_status("555") == OrderStatus.CONFIRMED


### PR DESCRIPTION
## Summary
- optimize Chejan parsing to read only requested FIDs from `sFidList` instead of always querying all fixed fields
- isolate observer notifications with async queue dispatch and lock-protected observer/state access to prevent slow observers from blocking event flow
- add order retention policy in `KiwoomOrderManager` (`max_history_size`, `history_ttl_seconds`) and cleanup of both history/index maps to avoid unbounded growth

## Test plan
- [x] `./venv/bin/python -m pytest tests/test_kiwoom_p4_order.py tests/test_kiwoom_p5_chejan.py`
- [x] verify added tests:
  - `test_order_event_parses_only_requested_fids`
  - `test_order_history_retention_by_max_size`

## Links
- closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)