### PR TITLE
feat: add Kiwoom P8 safety controls and audit pipeline

### DIFF
--- a/kiwoom/__init__.py
+++ b/kiwoom/__init__.py
@@ -7,6 +7,7 @@ for the Korean stock market via Kiwoom Securities API.
 from kiwoom.connection import KiwoomConnection
 from kiwoom.chejan_handler import ChejanHandler, OrderStatus
 from kiwoom.order import KiwoomOrderManager, Order
+from kiwoom.safety import AuditLogger, DuplicateOrderGuard, KillSwitch, KiwoomSafetyManager, SafetyViolation
 from kiwoom.condition_search import ConditionDefinition, ConditionSearchManager
 from kiwoom.realtime import RealtimeSubscriptionManager, ScreenManager
 from kiwoom.tr import KiwoomTrClient, TrRequest
@@ -27,6 +28,11 @@ __all__ = [
     "OrderStatus",
     "KiwoomOrderManager",
     "Order",
+    "KiwoomSafetyManager",
+    "KillSwitch",
+    "AuditLogger",
+    "DuplicateOrderGuard",
+    "SafetyViolation",
     "ConditionDefinition",
     "ConditionSearchManager",
     "KiwoomTrClient",

--- a/kiwoom/chejan_handler.py
+++ b/kiwoom/chejan_handler.py
@@ -9,6 +9,7 @@ from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Set
 
 from kiwoom.constants import ChejanGubun, FID
+from kiwoom.safety import KiwoomSafetyManager
 
 
 class OrderStatus(str, Enum):
@@ -45,11 +46,13 @@ class ChejanHandler:
         order_manager: Any | None = None,
         get_chejan_data_fn: Optional[Callable[[int], str]] = None,
         async_notify: bool = True,
+        safety_manager: Optional[KiwoomSafetyManager] = None,
     ) -> None:
         self._ocx = ocx
         self._order_manager = order_manager
         self._get_chejan_data_fn = get_chejan_data_fn
         self._async_notify = async_notify
+        self._safety_manager = safety_manager
 
         self._order_status: Dict[str, OrderStatus] = {}
         self._positions: Dict[str, Dict[str, int]] = {}
@@ -109,6 +112,19 @@ class ChejanHandler:
                     "fill_price": event.fill_price,
                 }
             )
+            if self._safety_manager is not None:
+                self._safety_manager.on_chejan_event(
+                    {
+                        "type": "order",
+                        "order_no": event.order_no,
+                        "code": event.code,
+                        "status": event.status.value,
+                        "raw_status": event.raw_status,
+                        "filled_qty": event.filled_qty,
+                        "unfilled_qty": event.unfilled_qty,
+                        "fill_price": event.fill_price,
+                    }
+                )
         elif sGubun == ChejanGubun.BALANCE.value:
             position = self._parse_balance_event(requested_fids)
             if not position:
@@ -117,6 +133,8 @@ class ChejanHandler:
             with self._state_lock:
                 self._positions[code] = position
             self._notify({"type": "balance", **position})
+            if self._safety_manager is not None:
+                self._safety_manager.on_chejan_event({"type": "balance", **position})
 
     @staticmethod
     def _parse_fid_list(s_fid_list: str) -> Set[int]:

--- a/kiwoom/connection.py
+++ b/kiwoom/connection.py
@@ -12,7 +12,7 @@ import logging
 import platform
 import threading
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from kiwoom.constants import ErrorCode
 
@@ -138,11 +138,25 @@ class KiwoomConnection:
 
     _LOGIN_TIMEOUT: int = 60  # 로그인 대기 타임아웃 (초)
 
-    def __init__(self, mock: bool = False) -> None:
+    def __init__(
+        self,
+        mock: bool = False,
+        reconnect_attempts: int = 3,
+        reconnect_interval: float = 2.0,
+        on_disconnect: Optional[Callable[[int], None]] = None,
+        on_reconnect_failure: Optional[Callable[[int], None]] = None,
+    ) -> None:
         self._mock = mock or (not IS_WINDOWS)
         self._connected: bool = False
         self._login_event = threading.Event()
         self._login_error_code: Optional[int] = None
+        self._login_lock = threading.RLock()
+        self._reconnect_lock = threading.RLock()
+        self._reconnecting: bool = False
+        self._reconnect_attempts = reconnect_attempts
+        self._reconnect_interval = reconnect_interval
+        self._on_disconnect = on_disconnect
+        self._on_reconnect_failure = on_reconnect_failure
 
         # OCX 컨트롤 초기화
         if self._mock:
@@ -165,36 +179,37 @@ class KiwoomConnection:
         bool
             *True* if the login succeeded, *False* on timeout or error.
         """
-        logger.info("Requesting Kiwoom login …")
-        self._login_event.clear()
-        self._login_error_code = None
+        with self._login_lock:
+            logger.info("Requesting Kiwoom login …")
+            self._login_event.clear()
+            self._login_error_code = None
 
-        # CommConnect 호출 (OCX에 로그인 요청)
-        ret = self._ocx.dynamicCall("CommConnect()")
-        if ret != 0:
-            logger.warning(
-                "CommConnect returned %d (%s)", ret, _error_description(ret)
-            )
-            return False
+            # CommConnect 호출 (OCX에 로그인 요청)
+            ret = self._ocx.dynamicCall("CommConnect()")
+            if ret != 0:
+                logger.warning(
+                    "CommConnect returned %d (%s)", ret, _error_description(ret)
+                )
+                return False
 
-        # OnEventConnect 콜백 대기 (타임아웃 포함)
-        arrived = self._login_event.wait(timeout=self._LOGIN_TIMEOUT)
-        if not arrived:
-            logger.warning("Login timed out after %ds", self._LOGIN_TIMEOUT)
-            return False
+            # OnEventConnect 콜백 대기 (타임아웃 포함)
+            arrived = self._login_event.wait(timeout=self._LOGIN_TIMEOUT)
+            if not arrived:
+                logger.warning("Login timed out after %ds", self._LOGIN_TIMEOUT)
+                return False
 
-        # 에러코드 확인
-        if self._login_error_code != 0:
-            logger.warning(
-                "Login failed: code=%s (%s)",
-                self._login_error_code,
-                _error_description(self._login_error_code or -1),
-            )
-            return False
+            # 에러코드 확인
+            if self._login_error_code != 0:
+                logger.warning(
+                    "Login failed: code=%s (%s)",
+                    self._login_error_code,
+                    _error_description(self._login_error_code or -1),
+                )
+                return False
 
-        self._connected = True
-        logger.info("Kiwoom login successful")
-        return True
+            self._connected = True
+            logger.info("Kiwoom login successful")
+            return True
 
     def logout(self) -> None:
         """Tear down the current session."""
@@ -261,17 +276,53 @@ class KiwoomConnection:
         err_code : int
             ``0`` on success; negative value on failure.
         """
+        was_connected = self._connected
         self._login_error_code = err_code
         if err_code == 0:
+            self._connected = True
             logger.info("OnEventConnect: login succeeded (code=0)")
         else:
+            self._connected = False
             logger.warning(
                 "OnEventConnect: login failed — code=%d (%s)",
                 err_code,
                 _error_description(err_code),
             )
+            if was_connected and self._on_disconnect is not None:
+                try:
+                    self._on_disconnect(err_code)
+                except Exception:
+                    logger.exception("on_disconnect callback failed")
+            if was_connected:
+                self._schedule_reconnect(err_code)
         # 대기 중인 login() 스레드에 완료 시그널 전송
         self._login_event.set()
+
+    def _schedule_reconnect(self, err_code: int) -> None:
+        with self._reconnect_lock:
+            if self._reconnecting:
+                return
+            self._reconnecting = True
+
+        def _reconnect() -> None:
+            try:
+                for attempt in range(1, self._reconnect_attempts + 1):
+                    logger.warning("Reconnect attempt %d/%d", attempt, self._reconnect_attempts)
+                    if self.login():
+                        logger.info("Reconnect succeeded")
+                        return
+                    if attempt < self._reconnect_attempts:
+                        time.sleep(self._reconnect_interval)
+                if self._on_reconnect_failure is not None:
+                    try:
+                        self._on_reconnect_failure(err_code)
+                    except Exception:
+                        logger.exception("on_reconnect_failure callback failed")
+            finally:
+                with self._reconnect_lock:
+                    self._reconnecting = False
+
+        threading.Thread(target=_reconnect, daemon=True).start()
 
     # -- Private helpers (내부 유틸) --
 

--- a/kiwoom/order.py
+++ b/kiwoom/order.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, Optional
 
 from kiwoom.constants import HogaType, OrderType
+from kiwoom.safety import KiwoomSafetyManager
 
 
 _ALLOWED_HOGA = {item.value for item in HogaType}
@@ -66,6 +67,7 @@ class _OrderTask:
     price: int
     hoga_type: str
     org_order_no: str
+    order_signature: Any
     done_event: threading.Event
     result_holder: Dict[str, Any]
 
@@ -79,6 +81,8 @@ class KiwoomOrderManager:
         throttle_seconds: float = 1.0,
         max_history_size: int = 2000,
         history_ttl_seconds: Optional[float] = 86400.0,
+        connection: Optional[Any] = None,
+        safety_manager: Optional[KiwoomSafetyManager] = None,
         sleep_fn: Callable[[float], None] = time.sleep,
         time_fn: Callable[[], float] = time.monotonic,
     ) -> None:
@@ -88,6 +92,8 @@ class KiwoomOrderManager:
         self._history_ttl_seconds = history_ttl_seconds
         self._sleep = sleep_fn
         self._time = time_fn
+        self._connection = connection
+        self._safety_manager = safety_manager
 
         self.order_history: Dict[str, Order] = {}
         self._order_by_rq_name: Dict[str, str] = {}
@@ -144,6 +150,18 @@ class KiwoomOrderManager:
         if hoga_type == HogaType.MARKET.value and price != 0:
             raise ValueError("market order must use price=0")
 
+        order_signature = None
+        if self._safety_manager is not None:
+            order_signature = self._safety_manager.validate_pre_order(
+                connection=self._connection,
+                order_type=order_type,
+                code=code,
+                qty=qty,
+                price=price,
+                acc_no=acc_no,
+                org_order_no=org_order_no,
+            )
+
         done_event = threading.Event()
         result_holder: Dict[str, Any] = {}
         task = _OrderTask(
@@ -157,6 +175,7 @@ class KiwoomOrderManager:
             price=price,
             hoga_type=hoga_type,
             org_order_no=org_order_no,
+            order_signature=order_signature,
             done_event=done_event,
             result_holder=result_holder,
         )
@@ -168,6 +187,36 @@ class KiwoomOrderManager:
         if "order_no" not in result_holder:
             raise RuntimeError("order send timeout")
         return result_holder["order_no"]
+
+    def cancel_open_orders(self) -> int:
+        with self._lock:
+            candidates = [
+                order
+                for order in self.order_history.values()
+                if order.status in {"sent", "accepted", "placed", "confirmed", "partial"}
+                and order.order_type in {int(OrderType.NEW_BUY), int(OrderType.NEW_SELL)}
+                and order.order_no
+            ]
+
+        cancelled = 0
+        for order in candidates:
+            cancel_type = int(OrderType.CANCEL_BUY) if order.order_type == int(OrderType.NEW_BUY) else int(OrderType.CANCEL_SELL)
+            try:
+                self.send_order(
+                    rq_name=f"kill_cancel_{order.order_no}",
+                    screen_no=order.screen_no,
+                    acc_no=order.acc_no,
+                    order_type=cancel_type,
+                    code=order.code,
+                    qty=order.qty,
+                    price=0,
+                    hoga_type=HogaType.LIMIT.value,
+                    org_order_no=order.order_no,
+                )
+                cancelled += 1
+            except Exception:
+                continue
+        return cancelled
 
     def on_receive_msg(self, screen_no: str, rq_name: str, tr_code: str, msg: str) -> None:
         """Handle OnReceiveMsg and update tracked order status/message."""
@@ -259,6 +308,18 @@ class KiwoomOrderManager:
 
                 if isinstance(ret, int) and ret < 0:
                     task.result_holder["error"] = f"SendOrder failed: {ret}"
+                    if self._safety_manager is not None:
+                        self._safety_manager.on_order_submit(
+                            rq_name=task.rq_name,
+                            api_rq_name=task.api_rq_name,
+                            acc_no=task.acc_no,
+                            order_type=task.order_type,
+                            code=task.code,
+                            qty=task.qty,
+                            price=task.price,
+                            status="failed",
+                            message=str(ret),
+                        )
                     task.done_event.set()
                     continue
 
@@ -288,6 +349,19 @@ class KiwoomOrderManager:
                     self.order_history[order_no] = order
                     self._order_by_rq_name[task.api_rq_name] = order_no
                     self._cleanup_history()
+                if self._safety_manager is not None:
+                    self._safety_manager.on_order_submit(
+                        rq_name=task.rq_name,
+                        api_rq_name=task.api_rq_name,
+                        acc_no=task.acc_no,
+                        order_type=task.order_type,
+                        code=task.code,
+                        qty=task.qty,
+                        price=task.price,
+                        status="sent",
+                        order_no=order_no,
+                        signature=task.order_signature,
+                    )
                 task.result_holder["order_no"] = order_no
                 task.done_event.set()
             except Exception as exc:  # pragma: no cover

--- a/kiwoom/safety.py
+++ b/kiwoom/safety.py
@@ -1,0 +1,234 @@
+"""Safety utilities for live Kiwoom trading."""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Callable, Dict, Optional, Tuple
+
+from kiwoom.constants import OrderType
+
+
+class SafetyViolation(RuntimeError):
+    """Raised when a safety rule blocks order submission."""
+
+
+@dataclass(frozen=True)
+class OrderSignature:
+    """A lightweight signature for duplicate-order detection."""
+
+    code: str
+    side: str
+    qty: int
+
+
+class AuditLogger:
+    """File-based audit logger for order and chejan events."""
+
+    def __init__(self, log_dir: str = "logs", time_fn: Callable[[], float] = time.time) -> None:
+        self._log_dir = log_dir
+        self._time_fn = time_fn
+        self._lock = threading.RLock()
+        os.makedirs(self._log_dir, exist_ok=True)
+
+    def _log_path(self) -> str:
+        date_str = datetime.fromtimestamp(self._time_fn()).strftime("%Y%m%d")
+        return os.path.join(self._log_dir, f"kiwoom_audit_{date_str}.log")
+
+    @staticmethod
+    def _to_line(event: str, payload: Dict[str, Any]) -> str:
+        ts = datetime.now(UTC).isoformat(timespec="seconds")
+        fields = " ".join(f"{k}={payload[k]}" for k in sorted(payload))
+        return f"{ts} event={event} {fields}\n"
+
+    def write(self, event: str, payload: Dict[str, Any]) -> None:
+        line = self._to_line(event, payload)
+        with self._lock:
+            with open(self._log_path(), "a", encoding="utf-8") as fp:
+                fp.write(line)
+
+
+class DuplicateOrderGuard:
+    """Prevents duplicate order submissions in a short time window."""
+
+    def __init__(self, window_seconds: float = 5.0, time_fn: Callable[[], float] = time.time) -> None:
+        self._window_seconds = window_seconds
+        self._time_fn = time_fn
+        self._last_seen_by_signature: Dict[OrderSignature, float] = {}
+        self._sent_order_nos: Dict[str, float] = {}
+        self._lock = threading.RLock()
+
+    def _cleanup(self, now: float) -> None:
+        min_ts = now - self._window_seconds
+        stale_signatures = [sig for sig, ts in self._last_seen_by_signature.items() if ts < min_ts]
+        for sig in stale_signatures:
+            self._last_seen_by_signature.pop(sig, None)
+        stale_nos = [order_no for order_no, ts in self._sent_order_nos.items() if ts < min_ts]
+        for order_no in stale_nos:
+            self._sent_order_nos.pop(order_no, None)
+
+    def is_duplicate(self, signature: OrderSignature) -> bool:
+        now = self._time_fn()
+        with self._lock:
+            self._cleanup(now)
+            seen_at = self._last_seen_by_signature.get(signature)
+            return seen_at is not None and now - seen_at <= self._window_seconds
+
+    def mark_submitted(self, signature: OrderSignature, order_no: str = "") -> None:
+        now = self._time_fn()
+        with self._lock:
+            self._cleanup(now)
+            self._last_seen_by_signature[signature] = now
+            if order_no:
+                self._sent_order_nos[order_no] = now
+
+    def has_order_no(self, order_no: str) -> bool:
+        if not order_no:
+            return False
+        now = self._time_fn()
+        with self._lock:
+            self._cleanup(now)
+            return order_no in self._sent_order_nos
+
+
+class KillSwitch:
+    """Global kill switch to stop new orders in emergency situations."""
+
+    def __init__(self, cancel_open_orders_fn: Optional[Callable[[], int]] = None) -> None:
+        self._cancel_open_orders_fn = cancel_open_orders_fn
+        self._active = False
+        self._reason = ""
+        self._activated_at: Optional[float] = None
+        self._lock = threading.RLock()
+
+    @property
+    def is_active(self) -> bool:
+        with self._lock:
+            return self._active
+
+    @property
+    def reason(self) -> str:
+        with self._lock:
+            return self._reason
+
+    def activate(self, reason: str) -> int:
+        with self._lock:
+            if self._active:
+                return 0
+            self._active = True
+            self._reason = reason
+            self._activated_at = time.time()
+        if self._cancel_open_orders_fn is None:
+            return 0
+        try:
+            return int(self._cancel_open_orders_fn())
+        except Exception:
+            return 0
+
+
+class KiwoomSafetyManager:
+    """Coordinates kill-switch, audit logging, and duplicate prevention."""
+
+    def __init__(
+        self,
+        *,
+        duplicate_window_seconds: float = 5.0,
+        audit_logger: Optional[AuditLogger] = None,
+        allow_live_trading: bool = False,
+        cancel_open_orders_fn: Optional[Callable[[], int]] = None,
+        risk_validator: Optional[Callable[[Dict[str, Any]], Tuple[bool, str]]] = None,
+    ) -> None:
+        self._audit = audit_logger or AuditLogger()
+        self._dup = DuplicateOrderGuard(window_seconds=duplicate_window_seconds)
+        self._kill_switch = KillSwitch(cancel_open_orders_fn=cancel_open_orders_fn)
+        self._allow_live_trading = allow_live_trading
+        self._risk_validator = risk_validator
+
+    @property
+    def kill_switch(self) -> KillSwitch:
+        return self._kill_switch
+
+    def activate_kill_switch(self, reason: str) -> int:
+        cancelled = self._kill_switch.activate(reason)
+        self._audit.write("kill_switch", {"reason": reason, "cancelled": cancelled})
+        return cancelled
+
+    def validate_pre_order(
+        self,
+        *,
+        connection: Any,
+        order_type: int,
+        code: str,
+        qty: int,
+        price: int,
+        acc_no: str,
+        org_order_no: str,
+    ) -> Optional[OrderSignature]:
+        is_cancel_or_modify = order_type in {
+            int(OrderType.CANCEL_BUY),
+            int(OrderType.CANCEL_SELL),
+            int(OrderType.MODIFY_BUY),
+            int(OrderType.MODIFY_SELL),
+        }
+
+        if self._kill_switch.is_active and not is_cancel_or_modify:
+            raise SafetyViolation(f"kill switch is active: {self._kill_switch.reason}")
+
+        if connection is not None and hasattr(connection, "is_mock_trading"):
+            if (not self._allow_live_trading) and (not connection.is_mock_trading()):
+                raise SafetyViolation("live trading is blocked; enable explicit live trading setting")
+
+        if self._risk_validator is not None:
+            ok, reason = self._risk_validator(
+                {"order_type": order_type, "code": code, "qty": qty, "price": price, "acc_no": acc_no}
+            )
+            if not ok:
+                raise SafetyViolation(f"risk validation failed: {reason}")
+
+        if is_cancel_or_modify:
+            return None
+
+        side = "BUY" if order_type in {int(OrderType.NEW_BUY), int(OrderType.MODIFY_BUY)} else "SELL"
+        signature = OrderSignature(code=code, side=side, qty=qty)
+        if self._dup.is_duplicate(signature):
+            raise SafetyViolation("duplicate order blocked within guard window")
+        return signature
+
+    def on_order_submit(
+        self,
+        *,
+        rq_name: str,
+        api_rq_name: str,
+        acc_no: str,
+        order_type: int,
+        code: str,
+        qty: int,
+        price: int,
+        status: str,
+        order_no: str = "",
+        signature: Optional[OrderSignature] = None,
+        message: str = "",
+    ) -> None:
+        if signature is not None:
+            self._dup.mark_submitted(signature, order_no)
+        self._audit.write(
+            "send_order",
+            {
+                "rq_name": rq_name,
+                "api_rq_name": api_rq_name,
+                "acc_no": acc_no,
+                "order_type": order_type,
+                "code": code,
+                "qty": qty,
+                "price": price,
+                "status": status,
+                "order_no": order_no,
+                "message": message,
+            },
+        )
+
+    def on_chejan_event(self, payload: Dict[str, Any]) -> None:
+        self._audit.write("chejan", payload)

--- a/tests/test_kiwoom_p8_safety.py
+++ b/tests/test_kiwoom_p8_safety.py
@@ -1,0 +1,185 @@
+"""Tests for Kiwoom P8 safety features."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from kiwoom.chejan_handler import ChejanHandler
+from kiwoom.connection import KiwoomConnection
+from kiwoom.constants import FID, HogaType, OrderType
+from kiwoom.order import KiwoomOrderManager
+from kiwoom.safety import AuditLogger, KiwoomSafetyManager, SafetyViolation
+
+
+class _FakeOcx:
+    def __init__(self, return_value=0):
+        self.calls = []
+        self.return_value = return_value
+        self._callbacks = {}
+        self._chejan_values = {}
+
+    def dynamicCall(self, func_spec, *args):
+        self.calls.append((func_spec, args))
+        if "GetChejanData" in func_spec:
+            return self._chejan_values.get(args[0], "")
+        if "GetLoginInfo" in func_spec:
+            return "1"
+        if "SendOrder" in func_spec:
+            return self.return_value
+        return ""
+
+
+class _MockConnection:
+    def __init__(self, mock_trading: bool = True):
+        self._mock_trading = mock_trading
+
+    def is_mock_trading(self) -> bool:
+        return self._mock_trading
+
+
+def test_duplicate_order_prevention_blocks_fast_repeats(tmp_path: Path) -> None:
+    ocx = _FakeOcx(return_value=0)
+    safety = KiwoomSafetyManager(
+        duplicate_window_seconds=5.0,
+        audit_logger=AuditLogger(log_dir=str(tmp_path)),
+    )
+    manager = KiwoomOrderManager(
+        ocx,
+        throttle_seconds=0.0,
+        connection=_MockConnection(mock_trading=True),
+        safety_manager=safety,
+    )
+
+    _ = manager.send_order(
+        rq_name="dup",
+        screen_no="1001",
+        acc_no="8123456789",
+        order_type=int(OrderType.NEW_BUY),
+        code="005930",
+        qty=1,
+        price=70000,
+        hoga_type=HogaType.LIMIT.value,
+        org_order_no="",
+    )
+
+    try:
+        manager.send_order(
+            rq_name="dup2",
+            screen_no="1001",
+            acc_no="8123456789",
+            order_type=int(OrderType.NEW_BUY),
+            code="005930",
+            qty=1,
+            price=70000,
+            hoga_type=HogaType.LIMIT.value,
+            org_order_no="",
+        )
+        assert False, "duplicate order should have been blocked"
+    except SafetyViolation:
+        pass
+
+
+def test_kill_switch_blocks_new_orders_and_allows_cancel(tmp_path: Path) -> None:
+    ocx = _FakeOcx(return_value=0)
+    manager = KiwoomOrderManager(
+        ocx,
+        throttle_seconds=0.0,
+        connection=_MockConnection(mock_trading=True),
+    )
+    safety = KiwoomSafetyManager(
+        duplicate_window_seconds=5.0,
+        audit_logger=AuditLogger(log_dir=str(tmp_path)),
+        cancel_open_orders_fn=manager.cancel_open_orders,
+    )
+    manager._safety_manager = safety
+
+    order_no = manager.send_order(
+        rq_name="new_buy",
+        screen_no="1001",
+        acc_no="8123456789",
+        order_type=int(OrderType.NEW_BUY),
+        code="005930",
+        qty=1,
+        price=70000,
+        hoga_type=HogaType.LIMIT.value,
+        org_order_no="",
+    )
+    assert order_no
+
+    cancelled = safety.activate_kill_switch("manual emergency stop")
+    assert cancelled >= 1
+
+    try:
+        manager.send_order(
+            rq_name="blocked_buy",
+            screen_no="1001",
+            acc_no="8123456789",
+            order_type=int(OrderType.NEW_BUY),
+            code="005930",
+            qty=1,
+            price=70000,
+            hoga_type=HogaType.LIMIT.value,
+            org_order_no="",
+        )
+        assert False, "new order should be blocked when kill switch is active"
+    except SafetyViolation:
+        pass
+
+
+def test_audit_logging_writes_send_order_and_chejan(tmp_path: Path) -> None:
+    ocx = _FakeOcx(return_value=0)
+    safety = KiwoomSafetyManager(
+        duplicate_window_seconds=5.0,
+        audit_logger=AuditLogger(log_dir=str(tmp_path)),
+    )
+    manager = KiwoomOrderManager(
+        ocx,
+        throttle_seconds=0.0,
+        connection=_MockConnection(mock_trading=True),
+        safety_manager=safety,
+    )
+    handler = ChejanHandler(ocx, order_manager=manager, safety_manager=safety, async_notify=False)
+
+    order_no = manager.send_order(
+        rq_name="audit_order",
+        screen_no="1001",
+        acc_no="8123456789",
+        order_type=int(OrderType.NEW_BUY),
+        code="005930",
+        qty=1,
+        price=70000,
+        hoga_type=HogaType.LIMIT.value,
+        org_order_no="",
+    )
+
+    ocx._chejan_values = {
+        FID.ORDER_NO: order_no,
+        FID.CODE: "A005930",
+        FID.ORDER_STATUS: "체결",
+        FID.FILL_PRICE: "70000",
+        FID.FILL_QTY: "1",
+        FID.UNFILLED_QTY: "0",
+    }
+    handler.on_receive_chejan_data("0", 0, "")
+
+    log_files = list(tmp_path.glob("kiwoom_audit_*.log"))
+    assert log_files, "audit log file should exist"
+    content = log_files[0].read_text(encoding="utf-8")
+    assert "event=send_order" in content
+    assert "event=chejan" in content
+
+
+def test_connection_reconnect_failure_callback_triggered() -> None:
+    failures = []
+    conn = KiwoomConnection(
+        mock=True,
+        reconnect_attempts=1,
+        reconnect_interval=0.01,
+        on_reconnect_failure=lambda code: failures.append(code),
+    )
+    conn._connected = True
+    conn.login = lambda: False  # type: ignore[method-assign]
+    conn._on_event_connect(-101)
+    time.sleep(0.05)
+    assert failures


### PR DESCRIPTION
## Summary
- add `kiwoom/safety.py` with kill switch, duplicate-order guard, and file-based audit logging (`logs/kiwoom_audit_YYYYMMDD.log`)
- integrate safety checks into `KiwoomOrderManager` (pre-order validation, send-order audit trail, and emergency `cancel_open_orders()`)
- add connection monitoring hooks in `KiwoomConnection` for reconnect attempts and failure callbacks, and route chejan payloads to audit logging via `ChejanHandler`

## Test plan
- [x] `./venv/bin/python -m pytest tests/test_kiwoom_p4_order.py tests/test_kiwoom_p5_chejan.py tests/test_kiwoom_p8_safety.py`
- [x] validate P8 scenarios:
  - duplicate submission blocked within guard window
  - kill switch blocks new orders and triggers cancel flow
  - send_order/chejan events are written to audit log
  - reconnect failure callback executes after retries

## Notes
- This PR is stacked on #438 (`feat/issue-263-p4p5-performance`) because it extends recently modified Kiwoom order/chejan internals.
- closes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)