### PR TITLE
feat: add team:quant fundamental conditions batch 8

### DIFF
--- a/screener/conditions/__init__.py
+++ b/screener/conditions/__init__.py
@@ -154,6 +154,19 @@ from .quant_statistical import (
     AnalystRevision3MCondition,
 )
 
+from .quant_fundamental_batch8 import (
+    ReceivablesTurnoverRatioCondition,
+    InventoryTurnoverRatioCondition,
+    AssetTurnoverRatioCondition,
+    CashflowToDebtRatioCondition,
+    PriceToTangibleBookCondition,
+    EVToSalesRatioCondition,
+    EVToEbitdaRatioCondition,
+    BookToMarketRatioCondition,
+    EPSCAGR3YCondition,
+    EPSGrowthYoYCondition,
+)
+
 from .composite import (
     AndCondition,
     OrCondition,
@@ -271,6 +284,13 @@ __all__ = [
     'BetaToBenchmarkCondition', 'CorrelationToBenchmarkCondition',
     'SupportRetestSignalCondition', 'ResistanceRetestSignalCondition',
     'AnalystRevision1MCondition', 'AnalystRevision3MCondition',
+
+    # Quant Fundamental Batch 8
+    'ReceivablesTurnoverRatioCondition', 'InventoryTurnoverRatioCondition',
+    'AssetTurnoverRatioCondition', 'CashflowToDebtRatioCondition',
+    'PriceToTangibleBookCondition', 'EVToSalesRatioCondition',
+    'EVToEbitdaRatioCondition', 'BookToMarketRatioCondition',
+    'EPSCAGR3YCondition', 'EPSGrowthYoYCondition',
 
     # Composite
     'AndCondition', 'OrCondition', 'NotCondition',

--- a/screener/conditions/quant_fundamental_batch8.py
+++ b/screener/conditions/quant_fundamental_batch8.py
@@ -1,0 +1,329 @@
+"""
+Quant Fundamental Conditions Batch 8
+team:quant 재무/가치 지표 조건
+"""
+
+from __future__ import annotations
+
+import math
+
+import pandas as pd
+
+from .base import BaseCondition, ConditionResult
+from .registry import register_condition
+
+
+def _insufficient(name: str) -> ConditionResult:
+    return ConditionResult(matched=False, condition_name=name, details={"error": "Insufficient data"})
+
+
+def _last_value(data: pd.DataFrame, col: str) -> float | None:
+    if col not in data.columns or len(data) < 1:
+        return None
+    v = data[col].iloc[-1]
+    if pd.isna(v):
+        return None
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return None
+
+
+@register_condition(
+    key="receivables_turnover_ratio",
+    label="Receivables Turnover Ratio",
+    description="Revenue to receivables turnover ratio",
+    category="fundamental",
+    params=[
+        {"name": "min_ratio", "type": "float", "default": 4.0, "description": "Minimum receivables turnover"},
+    ],
+)
+class ReceivablesTurnoverRatioCondition(BaseCondition):
+    def __init__(self, min_ratio: float = 4.0):
+        self.min_ratio = min_ratio
+
+    @property
+    def name(self) -> str:
+        return "receivables_turnover_ratio"
+
+    @property
+    def required_days(self) -> int:
+        return 1
+
+    def evaluate(self, ticker: str, data: pd.DataFrame) -> ConditionResult:
+        revenue = _last_value(data, "revenue_ttm")
+        receivables = _last_value(data, "receivables")
+        if revenue is None or receivables in (None, 0.0):
+            return _insufficient(self.name)
+        ratio = revenue / receivables
+        return ConditionResult(matched=ratio >= self.min_ratio, condition_name=self.name, details={"ratio": ratio})
+
+
+@register_condition(
+    key="inventory_turnover_ratio",
+    label="Inventory Turnover Ratio",
+    description="COGS to inventory turnover ratio",
+    category="fundamental",
+    params=[
+        {"name": "min_ratio", "type": "float", "default": 3.0, "description": "Minimum inventory turnover"},
+    ],
+)
+class InventoryTurnoverRatioCondition(BaseCondition):
+    def __init__(self, min_ratio: float = 3.0):
+        self.min_ratio = min_ratio
+
+    @property
+    def name(self) -> str:
+        return "inventory_turnover_ratio"
+
+    @property
+    def required_days(self) -> int:
+        return 1
+
+    def evaluate(self, ticker: str, data: pd.DataFrame) -> ConditionResult:
+        cogs = _last_value(data, "cogs_ttm")
+        inventory = _last_value(data, "inventory")
+        if cogs is None or inventory in (None, 0.0):
+            return _insufficient(self.name)
+        ratio = cogs / inventory
+        return ConditionResult(matched=ratio >= self.min_ratio, condition_name=self.name, details={"ratio": ratio})
+
+
+@register_condition(
+    key="asset_turnover_ratio",
+    label="Asset Turnover Ratio",
+    description="Revenue to total assets turnover ratio",
+    category="fundamental",
+    params=[
+        {"name": "min_ratio", "type": "float", "default": 0.5, "description": "Minimum asset turnover"},
+    ],
+)
+class AssetTurnoverRatioCondition(BaseCondition):
+    def __init__(self, min_ratio: float = 0.5):
+        self.min_ratio = min_ratio
+
+    @property
+    def name(self) -> str:
+        return "asset_turnover_ratio"
+
+    @property
+    def required_days(self) -> int:
+        return 1
+
+    def evaluate(self, ticker: str, data: pd.DataFrame) -> ConditionResult:
+        revenue = _last_value(data, "revenue_ttm")
+        assets = _last_value(data, "total_assets")
+        if revenue is None or assets in (None, 0.0):
+            return _insufficient(self.name)
+        ratio = revenue / assets
+        return ConditionResult(matched=ratio >= self.min_ratio, condition_name=self.name, details={"ratio": ratio})
+
+
+@register_condition(
+    key="cashflow_to_debt_ratio",
+    label="Cashflow to Debt Ratio",
+    description="Operating cash flow to debt ratio",
+    category="fundamental",
+    params=[
+        {"name": "min_ratio", "type": "float", "default": 0.2, "description": "Minimum cashflow/debt ratio"},
+    ],
+)
+class CashflowToDebtRatioCondition(BaseCondition):
+    def __init__(self, min_ratio: float = 0.2):
+        self.min_ratio = min_ratio
+
+    @property
+    def name(self) -> str:
+        return "cashflow_to_debt_ratio"
+
+    @property
+    def required_days(self) -> int:
+        return 1
+
+    def evaluate(self, ticker: str, data: pd.DataFrame) -> ConditionResult:
+        cfo = _last_value(data, "operating_cash_flow_ttm")
+        debt = _last_value(data, "total_debt")
+        if cfo is None or debt in (None, 0.0):
+            return _insufficient(self.name)
+        ratio = cfo / debt
+        return ConditionResult(matched=ratio >= self.min_ratio, condition_name=self.name, details={"ratio": ratio})
+
+
+@register_condition(
+    key="price_to_tangible_book",
+    label="Price to Tangible Book",
+    description="Market cap to tangible book ratio",
+    category="fundamental",
+    params=[
+        {"name": "max_ratio", "type": "float", "default": 3.0, "description": "Maximum P/TB"},
+    ],
+)
+class PriceToTangibleBookCondition(BaseCondition):
+    def __init__(self, max_ratio: float = 3.0):
+        self.max_ratio = max_ratio
+
+    @property
+    def name(self) -> str:
+        return "price_to_tangible_book"
+
+    @property
+    def required_days(self) -> int:
+        return 1
+
+    def evaluate(self, ticker: str, data: pd.DataFrame) -> ConditionResult:
+        market_cap = _last_value(data, "market_cap")
+        tangible_book = _last_value(data, "tangible_book_value")
+        if market_cap is None or tangible_book in (None, 0.0):
+            return _insufficient(self.name)
+        ratio = market_cap / tangible_book
+        return ConditionResult(matched=ratio <= self.max_ratio, condition_name=self.name, details={"ratio": ratio})
+
+
+@register_condition(
+    key="ev_to_sales_ratio",
+    label="EV to Sales Ratio",
+    description="Enterprise value to sales ratio",
+    category="fundamental",
+    params=[
+        {"name": "max_ratio", "type": "float", "default": 4.0, "description": "Maximum EV/Sales"},
+    ],
+)
+class EVToSalesRatioCondition(BaseCondition):
+    def __init__(self, max_ratio: float = 4.0):
+        self.max_ratio = max_ratio
+
+    @property
+    def name(self) -> str:
+        return "ev_to_sales_ratio"
+
+    @property
+    def required_days(self) -> int:
+        return 1
+
+    def evaluate(self, ticker: str, data: pd.DataFrame) -> ConditionResult:
+        ev = _last_value(data, "enterprise_value")
+        sales = _last_value(data, "revenue_ttm")
+        if ev is None or sales in (None, 0.0):
+            return _insufficient(self.name)
+        ratio = ev / sales
+        return ConditionResult(matched=ratio <= self.max_ratio, condition_name=self.name, details={"ratio": ratio})
+
+
+@register_condition(
+    key="ev_to_ebitda_ratio",
+    label="EV to EBITDA Ratio",
+    description="Enterprise value to EBITDA ratio",
+    category="fundamental",
+    params=[
+        {"name": "max_ratio", "type": "float", "default": 12.0, "description": "Maximum EV/EBITDA"},
+    ],
+)
+class EVToEbitdaRatioCondition(BaseCondition):
+    def __init__(self, max_ratio: float = 12.0):
+        self.max_ratio = max_ratio
+
+    @property
+    def name(self) -> str:
+        return "ev_to_ebitda_ratio"
+
+    @property
+    def required_days(self) -> int:
+        return 1
+
+    def evaluate(self, ticker: str, data: pd.DataFrame) -> ConditionResult:
+        ev = _last_value(data, "enterprise_value")
+        ebitda = _last_value(data, "ebitda_ttm")
+        if ev is None or ebitda in (None, 0.0):
+            return _insufficient(self.name)
+        ratio = ev / ebitda
+        return ConditionResult(matched=ratio <= self.max_ratio, condition_name=self.name, details={"ratio": ratio})
+
+
+@register_condition(
+    key="book_to_market_ratio",
+    label="Book to Market Ratio",
+    description="Book value divided by market cap",
+    category="fundamental",
+    params=[
+        {"name": "min_ratio", "type": "float", "default": 0.3, "description": "Minimum B/M ratio"},
+    ],
+)
+class BookToMarketRatioCondition(BaseCondition):
+    def __init__(self, min_ratio: float = 0.3):
+        self.min_ratio = min_ratio
+
+    @property
+    def name(self) -> str:
+        return "book_to_market_ratio"
+
+    @property
+    def required_days(self) -> int:
+        return 1
+
+    def evaluate(self, ticker: str, data: pd.DataFrame) -> ConditionResult:
+        book = _last_value(data, "book_value")
+        market_cap = _last_value(data, "market_cap")
+        if book is None or market_cap in (None, 0.0):
+            return _insufficient(self.name)
+        ratio = book / market_cap
+        return ConditionResult(matched=ratio >= self.min_ratio, condition_name=self.name, details={"ratio": ratio})
+
+
+@register_condition(
+    key="eps_cagr_3y",
+    label="EPS CAGR 3Y",
+    description="3-year EPS CAGR",
+    category="fundamental",
+    params=[
+        {"name": "min_cagr_pct", "type": "float", "default": 5.0, "description": "Minimum CAGR %"},
+    ],
+)
+class EPSCAGR3YCondition(BaseCondition):
+    def __init__(self, min_cagr_pct: float = 5.0):
+        self.min_cagr_pct = min_cagr_pct
+
+    @property
+    def name(self) -> str:
+        return "eps_cagr_3y"
+
+    @property
+    def required_days(self) -> int:
+        return 1
+
+    def evaluate(self, ticker: str, data: pd.DataFrame) -> ConditionResult:
+        eps_now = _last_value(data, "eps_ttm")
+        eps_3y_ago = _last_value(data, "eps_3y_ago")
+        if eps_now is None or eps_3y_ago is None or eps_3y_ago <= 0 or eps_now <= 0:
+            return _insufficient(self.name)
+        cagr = (math.pow(eps_now / eps_3y_ago, 1.0 / 3.0) - 1.0) * 100.0
+        return ConditionResult(matched=cagr >= self.min_cagr_pct, condition_name=self.name, details={"cagr_pct": cagr})
+
+
+@register_condition(
+    key="eps_growth_yoy",
+    label="EPS Growth YoY",
+    description="Year-over-year EPS growth",
+    category="fundamental",
+    params=[
+        {"name": "min_growth_pct", "type": "float", "default": 5.0, "description": "Minimum YoY growth %"},
+    ],
+)
+class EPSGrowthYoYCondition(BaseCondition):
+    def __init__(self, min_growth_pct: float = 5.0):
+        self.min_growth_pct = min_growth_pct
+
+    @property
+    def name(self) -> str:
+        return "eps_growth_yoy"
+
+    @property
+    def required_days(self) -> int:
+        return 1
+
+    def evaluate(self, ticker: str, data: pd.DataFrame) -> ConditionResult:
+        eps_now = _last_value(data, "eps_ttm")
+        eps_prev = _last_value(data, "eps_prev_year")
+        if eps_now is None or eps_prev is None or eps_prev == 0:
+            return _insufficient(self.name)
+        growth = ((eps_now - eps_prev) / abs(eps_prev)) * 100.0
+        return ConditionResult(matched=growth >= self.min_growth_pct, condition_name=self.name, details={"growth_pct": growth})

--- a/tests/test_quant_fundamental_batch8.py
+++ b/tests/test_quant_fundamental_batch8.py
@@ -1,0 +1,84 @@
+import numpy as np
+import pandas as pd
+
+from screener.conditions.quant_fundamental_batch8 import (
+    ReceivablesTurnoverRatioCondition,
+    InventoryTurnoverRatioCondition,
+    AssetTurnoverRatioCondition,
+    CashflowToDebtRatioCondition,
+    PriceToTangibleBookCondition,
+    EVToSalesRatioCondition,
+    EVToEbitdaRatioCondition,
+    BookToMarketRatioCondition,
+    EPSCAGR3YCondition,
+    EPSGrowthYoYCondition,
+)
+from screener.conditions.registry import get_condition_metadata
+
+
+def _df(n=80):
+    idx = pd.bdate_range("2025-01-02", periods=n)
+    base = pd.Series(np.linspace(100, 130, n), index=idx)
+    return pd.DataFrame(
+        {
+            "open": base * 0.99,
+            "high": base * 1.01,
+            "low": base * 0.98,
+            "close": base,
+            "volume": np.linspace(1_000_000, 1_500_000, n),
+            "revenue_ttm": np.full(n, 10_000_000.0),
+            "receivables": np.full(n, 1_500_000.0),
+            "cogs_ttm": np.full(n, 6_000_000.0),
+            "inventory": np.full(n, 1_000_000.0),
+            "total_assets": np.full(n, 15_000_000.0),
+            "operating_cash_flow_ttm": np.full(n, 2_500_000.0),
+            "total_debt": np.full(n, 5_000_000.0),
+            "market_cap": np.full(n, 20_000_000.0),
+            "tangible_book_value": np.full(n, 8_000_000.0),
+            "enterprise_value": np.full(n, 22_000_000.0),
+            "ebitda_ttm": np.full(n, 3_000_000.0),
+            "book_value": np.full(n, 9_000_000.0),
+            "eps_ttm": np.full(n, 4.0),
+            "eps_3y_ago": np.full(n, 2.5),
+            "eps_prev_year": np.full(n, 3.2),
+        },
+        index=idx,
+    )
+
+
+def test_quant_fundamental_batch8_keys_registered():
+    keys = set(get_condition_metadata().keys())
+    expected = {
+        "receivables_turnover_ratio",
+        "inventory_turnover_ratio",
+        "asset_turnover_ratio",
+        "cashflow_to_debt_ratio",
+        "price_to_tangible_book",
+        "ev_to_sales_ratio",
+        "ev_to_ebitda_ratio",
+        "book_to_market_ratio",
+        "eps_cagr_3y",
+        "eps_growth_yoy",
+    }
+    assert expected.issubset(keys)
+
+
+def test_quant_fundamental_batch8_conditions_compute():
+    data = _df()
+    assert "ratio" in ReceivablesTurnoverRatioCondition(min_ratio=0).evaluate("T", data).details
+    assert "ratio" in InventoryTurnoverRatioCondition(min_ratio=0).evaluate("T", data).details
+    assert "ratio" in AssetTurnoverRatioCondition(min_ratio=0).evaluate("T", data).details
+    assert "ratio" in CashflowToDebtRatioCondition(min_ratio=0).evaluate("T", data).details
+    assert "ratio" in PriceToTangibleBookCondition(max_ratio=100).evaluate("T", data).details
+    assert "ratio" in EVToSalesRatioCondition(max_ratio=100).evaluate("T", data).details
+    assert "ratio" in EVToEbitdaRatioCondition(max_ratio=100).evaluate("T", data).details
+    assert "ratio" in BookToMarketRatioCondition(min_ratio=0).evaluate("T", data).details
+    assert "cagr_pct" in EPSCAGR3YCondition(min_cagr_pct=-100).evaluate("T", data).details
+    assert "growth_pct" in EPSGrowthYoYCondition(min_growth_pct=-100).evaluate("T", data).details
+
+
+def test_missing_fundamental_columns_failsafe():
+    data = _df().drop(columns=["enterprise_value"])
+    result = EVToSalesRatioCondition().evaluate("T", data)
+    assert result.matched is False
+    assert result.details.get("error") == "Insufficient data"


### PR DESCRIPTION
## Summary
- add 10 new `team:quant` fundamental conditions for batch 8
- cover turnover, EV multiples, book-to-market, and EPS growth metrics
- wire exports and add tests for registration/computation/failsafe

## Included conditions
- `receivables_turnover_ratio` (#424)
- `inventory_turnover_ratio` (#422)
- `asset_turnover_ratio` (#420)
- `cashflow_to_debt_ratio` (#418)
- `price_to_tangible_book` (#417)
- `ev_to_sales_ratio` (#415)
- `ev_to_ebitda_ratio` (#413)
- `book_to_market_ratio` (#412)
- `eps_cagr_3y` (#410)
- `eps_growth_yoy` (#408)

## Validation
- `python -m py_compile screener/conditions/quant_fundamental_batch8.py screener/conditions/__init__.py tests/test_quant_fundamental_batch8.py`