### PR TITLE
fix: fallback for missing condition i18n keys

### DIFF
--- a/web/src/components/strategy/NodePalette.tsx
+++ b/web/src/components/strategy/NodePalette.tsx
@@ -27,6 +27,13 @@ const SPECIAL_NODES = [
   { type: 'output', labelKey: 'finalOutput', icon: Flag, color: 'text-orange-600 dark:text-orange-400' },
 ];
 
+function toTitleCaseFromKey(value: string): string {
+  return value
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
 function HelpTooltip({ targetRect, help }: { targetRect: DOMRect; help: string }) {
   const style: React.CSSProperties = {
     position: 'fixed',
@@ -127,6 +134,23 @@ export default function NodePalette({ nodeCount }: NodePaletteProps) {
   const [collapsedCategories, setCollapsedCategories] = useState<Set<string>>(new Set());
   const [searchQuery, setSearchQuery] = useState('');
   const conditionsByCategory = useMemo(() => getConditionsByCategory(), [getConditionsByCategory]);
+  const getCategoryLabel = (category: string): string => {
+    const key = `categories.${category}`;
+    return tCond.has(key) ? tCond(key) : toTitleCaseFromKey(category);
+  };
+  const getConditionLabel = (cond: StrategyConditionInfo): string => {
+    const key = `${cond.key}.label`;
+    return tCond.has(key) ? tCond(key) : (cond.label || toTitleCaseFromKey(cond.key));
+  };
+  const getConditionDesc = (cond: StrategyConditionInfo): string => {
+    const key = `${cond.key}.desc`;
+    return tCond.has(key) ? tCond(key) : (cond.description || '');
+  };
+  const getConditionHelp = (cond: StrategyConditionInfo): string | undefined => {
+    const key = `${cond.key}.help`;
+    if (tCond.has(key)) return tCond(key);
+    return cond.description || undefined;
+  };
 
   const toggleCategory = (cat: string) => {
     setCollapsedCategories((prev) => {
@@ -220,7 +244,7 @@ export default function NodePalette({ nodeCount }: NodePaletteProps) {
                     ) : (
                       <ChevronRight className="h-3 w-3" />
                     )}
-                    <span>{tCond('categories.' + category)}</span>
+                    <span>{getCategoryLabel(category)}</span>
                     <span className="ml-auto text-[10px] font-normal text-gray-400 dark:text-gray-500 bg-gray-100 dark:bg-gray-800 px-1.5 rounded-full">
                       {conditions.length}
                     </span>
@@ -230,9 +254,9 @@ export default function NodePalette({ nodeCount }: NodePaletteProps) {
                       <DraggableItem
                         key={cond.key}
                         type="condition"
-                        label={tCond(cond.key + '.label')}
-                        description={tCond(cond.key + '.desc')}
-                        help={tCond(cond.key + '.help')}
+                        label={getConditionLabel(cond)}
+                        description={getConditionDesc(cond)}
+                        help={getConditionHelp(cond)}
                         icon={Filter}
                         color="text-[#1313ec] dark:text-blue-400"
                         conditionKey={cond.key}

--- a/web/src/components/strategy/nodes/ConditionNode.tsx
+++ b/web/src/components/strategy/nodes/ConditionNode.tsx
@@ -17,6 +17,13 @@ import NodeEditPopup, {
   CategoryBadge,
 } from './NodeEditPopup';
 
+function toTitleCaseFromKey(value: string): string {
+  return value
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
 function ConditionNode({ data, selected }: NodeProps) {
   const t = useTranslations('strategy');
   const tCond = useTranslations('conditions');
@@ -27,16 +34,10 @@ function ConditionNode({ data, selected }: NodeProps) {
     : null;
 
   const condKey = nodeData.condition_type || '';
-  let label: string;
-  if (condKey) {
-    try {
-      label = tCond(`${condKey}.label`);
-    } catch {
-      label = meta?.label || nodeData.label || t('condition');
-    }
-  } else {
-    label = nodeData.label || t('condition');
-  }
+  const label =
+    condKey && tCond.has(`${condKey}.label`)
+      ? tCond(`${condKey}.label`)
+      : (meta?.label || nodeData.label || (condKey ? toTitleCaseFromKey(condKey) : t('condition')));
 
   const nodeId = useNodeId()!;
   const { getNode, getEdges, setNodes, updateNodeData, deleteElements } = useReactFlow();
@@ -195,7 +196,7 @@ function ConditionNode({ data, selected }: NodeProps) {
             <option value="">{t('selectCondition')}</option>
             {conditions.map((c) => (
               <option key={c.key} value={c.key}>
-                {tCond(c.key + '.label')}
+                {tCond.has(c.key + '.label') ? tCond(c.key + '.label') : (c.label || toTitleCaseFromKey(c.key))}
               </option>
             ))}
           </SelectInput>
@@ -219,7 +220,9 @@ function ConditionNode({ data, selected }: NodeProps) {
                 )}
 
                 <p className="text-xs text-gray-500 dark:text-gray-400 leading-relaxed">
-                  {tCond(currentMeta.key + '.desc')}
+                  {tCond.has(currentMeta.key + '.desc')
+                    ? tCond(currentMeta.key + '.desc')
+                    : (currentMeta.description || '')}
                 </p>
 
                 <div className="space-y-3">
@@ -229,8 +232,12 @@ function ConditionNode({ data, selected }: NodeProps) {
                       <div key={`pair-${suffix}`}>
                         <FieldLabel>
                           {t('range')}:{' '}
-                          {tCond(currentMeta.key + '.params.' + minP.name)} /{' '}
-                          {tCond(currentMeta.key + '.params.' + maxP.name)}
+                          {tCond.has(currentMeta.key + '.params.' + minP.name)
+                            ? tCond(currentMeta.key + '.params.' + minP.name)
+                            : toTitleCaseFromKey(minP.name)} /{' '}
+                          {tCond.has(currentMeta.key + '.params.' + maxP.name)
+                            ? tCond(currentMeta.key + '.params.' + maxP.name)
+                            : toTitleCaseFromKey(maxP.name)}
                         </FieldLabel>
                         <div className="flex items-center gap-2">
                           <InlineNumberInput
@@ -275,7 +282,9 @@ function ConditionNode({ data, selected }: NodeProps) {
                     </span>
                   </div>
                   <p className="text-xs text-gray-600 dark:text-gray-300 leading-relaxed">
-                    {tCond(currentMeta.key + '.help')}
+                    {tCond.has(currentMeta.key + '.help')
+                      ? tCond(currentMeta.key + '.help')
+                      : (currentMeta.description || '')}
                   </p>
                 </div>
               </>

--- a/web/src/components/strategy/nodes/NodeEditPopup.tsx
+++ b/web/src/components/strategy/nodes/NodeEditPopup.tsx
@@ -6,6 +6,13 @@ import { Trash2 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import type { ConditionParam } from '@/lib/strategy/conditionRegistry';
 
+function toTitleCaseFromKey(value: string): string {
+  return value
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
 /* ------------------------------------------------------------------ */
 /*  Shared form primitives (extracted from PropertiesPanel)            */
 /* ------------------------------------------------------------------ */
@@ -55,7 +62,8 @@ export function ParamInput({
   const tCond = useTranslations('conditions');
   const tCommon = useTranslations('common');
 
-  const paramLabel = tCond(conditionKey + '.params.' + param.name);
+  const paramKey = conditionKey + '.params.' + param.name;
+  const paramLabel = tCond.has(paramKey) ? tCond(paramKey) : toTitleCaseFromKey(param.name);
 
   if (param.type === 'bool') {
     return (
@@ -258,9 +266,10 @@ export function groupParams(params: ConditionParam[]) {
 
 export function CategoryBadge({ category }: { category: string }) {
   const tCond = useTranslations('conditions');
+  const key = `categories.${category}`;
   return (
     <span className="inline-block text-[10px] font-semibold uppercase tracking-wider px-2 py-0.5 rounded-full bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 border border-gray-200 dark:border-gray-700">
-      {tCond(`categories.${category}`)}
+      {tCond.has(key) ? tCond(key) : toTitleCaseFromKey(category)}
     </span>
   );
 }


### PR DESCRIPTION
## Summary
- add frontend fallback rendering when condition i18n keys are missing
- prevent raw keys like `conditions.categories.momentum` and `conditions.<key>.label` from being shown
- apply fallback in palette, condition node editor, and category badge

## Details
- use translated text when available (`tCond.has(...)`)
- fallback order for condition label/desc/help:
  1. locale message
  2. backend metadata (`label`, `description`)
  3. humanized key (`snake_case`/`camelCase` -> title case)

Closes #449

## Validation
- `npm -C web run lint -- src/components/strategy/NodePalette.tsx src/components/strategy/nodes/NodeEditPopup.tsx src/components/strategy/nodes/ConditionNode.tsx`
- lint warnings observed are existing unrelated warnings in `ConditionNode.tsx` (`intermediateResult`, `resultCount` unused)