### PR TITLE
feat(api): add multi-universe resolver for screening service

### DIFF
--- a/api/routers/screening.py
+++ b/api/routers/screening.py
@@ -105,6 +105,7 @@ def run_screening(request: ScreeningRequest) -> ScreeningResponse:
         result = service.run_screening(
             preset=request.preset,
             universe=request.universe,
+            universes=request.universes,
             params=request.params
         )
 

--- a/api/services/screening_service.py
+++ b/api/services/screening_service.py
@@ -14,6 +14,7 @@ from api.schemas.screening import (
     ConditionResultItem,
     PresetInfo,
     UniverseInfo,
+    normalize_universe_values,
 )
 
 # Import screener module
@@ -33,6 +34,7 @@ class ScreeningService:
 
     # TTL cache for universe stock counts: {universe: (timestamp, count)}
     _universe_count_cache: Dict[str, tuple] = {}
+    _universe_combo_count_cache: Dict[str, tuple] = {}
     _UNIVERSE_COUNT_TTL = 3600  # 1 hour
 
     # Universe definitions
@@ -226,6 +228,25 @@ class ScreeningService:
         else:
             raise ValueError(f"Unknown universe: {universe}")
 
+    def resolve_universes(self, universe_input: Any) -> List[str]:
+        """
+        Resolve universe input to a validated, normalized list.
+
+        Rules:
+            - "KOSPI" -> ["KOSPI"]
+            - "KOSPI,KOSDAQ" -> ["KOSPI", "KOSDAQ"]
+            - []/None -> ["KOSPI"]
+            - stable order + dedupe
+        """
+        normalized = normalize_universe_values(universe_input)
+        if not normalized:
+            normalized = ["KOSPI"]
+
+        invalid = [u for u in normalized if u not in self.UNIVERSES]
+        if invalid:
+            raise ValueError(f"Unknown universe: {', '.join(invalid)}")
+        return normalized
+
     @staticmethod
     def _safe_name(entry: Dict, fallback_key: str = "symbol") -> str:
         """Return a sanitised stock name from a fetcher entry.
@@ -274,6 +295,79 @@ class ScreeningService:
         else:
             raise ValueError(f"Unknown universe: {universe}")
 
+    def _get_symbols_for_universes(
+        self,
+        universe_input: Any,
+        fail_fast: bool = False,
+    ) -> tuple[Dict[str, str], List[str], Dict[str, str]]:
+        """
+        Merge symbols across universes with stable-order dedupe.
+
+        Returns:
+            (merged_symbols, resolved_universes, failed_universe_errors)
+        """
+        resolved_universes = self.resolve_universes(universe_input)
+        merged_symbols: Dict[str, str] = {}
+        failed_errors: Dict[str, str] = {}
+
+        for universe in resolved_universes:
+            try:
+                symbols = self._get_universe_symbols(universe)
+            except Exception as e:
+                message = str(e)
+                failed_errors[universe] = message
+                logger.warning("Universe fetch failed for %s: %s", universe, message)
+                if fail_fast:
+                    raise ValueError(f"Failed to fetch universe {universe}: {message}")
+                continue
+
+            # Stable merge: first seen ticker wins.
+            for ticker, name in symbols.items():
+                if ticker not in merged_symbols:
+                    merged_symbols[ticker] = name
+
+        return merged_symbols, resolved_universes, failed_errors
+
+    def get_tickers_for_universes(
+        self,
+        universe_input: Any,
+        fail_fast: bool = False,
+    ) -> List[str]:
+        """Return deduplicated tickers across one or more universes."""
+        symbols, resolved_universes, failed_errors = self._get_symbols_for_universes(
+            universe_input=universe_input,
+            fail_fast=fail_fast,
+        )
+        if not symbols:
+            if failed_errors:
+                details = ", ".join(f"{k}: {v}" for k, v in failed_errors.items())
+                raise ValueError(f"Failed to fetch all universes ({details})")
+            raise ValueError(f"No tickers available for universes: {resolved_universes}")
+        return list(symbols.keys())
+
+    def _get_universe_stock_count_multi(self, universe_input: Any) -> int:
+        """
+        Get approximate stock count for one or more universes.
+
+        Single universe uses existing per-universe cache.
+        Multi-universe uses combo cache keyed by normalized list.
+        """
+        resolved_universes = self.resolve_universes(universe_input)
+        if len(resolved_universes) == 1:
+            return self._get_universe_stock_count(resolved_universes[0])
+
+        cache_key = "|".join(resolved_universes)
+        cached = self._universe_combo_count_cache.get(cache_key)
+        if cached:
+            ts, count = cached
+            if time.time() - ts < self._UNIVERSE_COUNT_TTL:
+                return count
+
+        symbols, _, _ = self._get_symbols_for_universes(resolved_universes, fail_fast=False)
+        count = len(symbols)
+        self._universe_combo_count_cache[cache_key] = (time.time(), count)
+        return count
+
     def _resolve_conditions(self, preset: str, params: Optional[Dict[str, Any]] = None) -> list:
         """Resolve conditions from a static preset or custom strategy."""
         if preset.startswith("custom:"):
@@ -302,27 +396,39 @@ class ScreeningService:
     def run_screening(
         self,
         preset: str,
-        universe: str,
-        params: Optional[Dict[str, Any]] = None
+        universe: Optional[str] = None,
+        params: Optional[Dict[str, Any]] = None,
+        universes: Optional[List[str]] = None,
     ) -> Dict[str, Any]:
         """
         Run stock screening with the given preset and universe.
 
         Args:
             preset: Preset name (static name or 'custom:{strategy_id}')
-            universe: Universe name
+            universe: Universe name (backward-compatible single value)
             params: Optional parameters to override preset defaults
+            universes: Universe list (preferred for multi-market)
 
         Returns:
-            Dict with results, total_count, and matched_count
+            Dict with results, total_count, matched_count, and resolved universes
         """
         conditions = self._resolve_conditions(preset, params)
 
-        # Get ticker-to-name mapping upfront to avoid N+1 yfinance calls
+        requested_universes: Any = universes if universes is not None else universe
+
         try:
-            symbols_dict = self._get_universe_symbols(universe)
+            symbols_dict, resolved_universes, failed_errors = self._get_symbols_for_universes(
+                universe_input=requested_universes,
+                fail_fast=False,
+            )
         except ValueError as e:
             raise ValueError(f"Invalid universe: {e}")
+
+        if not symbols_dict:
+            if failed_errors:
+                details = ", ".join(f"{k}: {v}" for k, v in failed_errors.items())
+                raise ValueError(f"Failed to fetch all universes ({details})")
+            raise ValueError("No tickers available for screening")
 
         tickers = list(symbols_dict.keys())
 
@@ -363,7 +469,9 @@ class ScreeningService:
         return {
             "results": result_items,
             "total_count": total_count,
-            "matched_count": len(result_items)
+            "matched_count": len(result_items),
+            "resolved_universes": resolved_universes,
+            "failed_universe_errors": failed_errors,
         }
 
     def check_single_stock(

--- a/api/tests/test_screening.py
+++ b/api/tests/test_screening.py
@@ -124,6 +124,7 @@ class TestRunScreening:
         mock_screening_service.run_screening.assert_called_once_with(
             preset="accumulation_basic",
             universe="KOSPI",
+            universes=["KOSPI"],
             params=None,
         )
 
@@ -198,6 +199,7 @@ class TestRunScreening:
         mock_screening_service.run_screening.assert_called_once_with(
             preset="accumulation_basic",
             universe="KOSPI",
+            universes=["KOSPI", "KOSDAQ"],
             params=None,
         )
 

--- a/api/tests/test_screening_service.py
+++ b/api/tests/test_screening_service.py
@@ -1,0 +1,126 @@
+"""Unit tests for ScreeningService multi-universe behavior."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from api.services.screening_service import ScreeningService
+
+
+class TestResolveUniverses:
+    def test_resolve_universes_normalizes_and_deduplicates(self):
+        service = ScreeningService()
+        assert service.resolve_universes("kospi, KOSDAQ, kospi") == ["KOSPI", "KOSDAQ"]
+
+    def test_resolve_universes_defaults_to_kospi(self):
+        service = ScreeningService()
+        assert service.resolve_universes(None) == ["KOSPI"]
+
+    def test_resolve_universes_rejects_unknown(self):
+        service = ScreeningService()
+        with pytest.raises(ValueError, match="Unknown universe"):
+            service.resolve_universes("KOSPI,INVALID")
+
+
+class TestTickerMerge:
+    def test_get_tickers_for_universes_dedupes_stable_order(self, monkeypatch):
+        service = ScreeningService()
+
+        def _mock_get_universe_symbols(universe: str):
+            if universe == "KOSPI":
+                return {"005930.KS": "Samsung", "000660.KS": "SK Hynix"}
+            if universe == "KOSDAQ":
+                return {"000660.KS": "SK Hynix", "035720.KQ": "Kakao"}
+            raise ValueError("unknown")
+
+        monkeypatch.setattr(service, "_get_universe_symbols", _mock_get_universe_symbols)
+
+        tickers = service.get_tickers_for_universes(["KOSPI", "KOSDAQ"])
+        assert tickers == ["005930.KS", "000660.KS", "035720.KQ"]
+
+    def test_get_tickers_for_universes_partial_failure_degrades(self, monkeypatch):
+        service = ScreeningService()
+
+        def _mock_get_universe_symbols(universe: str):
+            if universe == "KOSPI":
+                return {"005930.KS": "Samsung"}
+            raise RuntimeError("fetch failed")
+
+        monkeypatch.setattr(service, "_get_universe_symbols", _mock_get_universe_symbols)
+
+        tickers = service.get_tickers_for_universes(["KOSPI", "KOSDAQ"])
+        assert tickers == ["005930.KS"]
+
+    def test_get_tickers_for_universes_all_fail_raises(self, monkeypatch):
+        service = ScreeningService()
+
+        def _mock_get_universe_symbols(universe: str):
+            raise RuntimeError("fetch failed")
+
+        monkeypatch.setattr(service, "_get_universe_symbols", _mock_get_universe_symbols)
+
+        with pytest.raises(ValueError, match="Failed to fetch all universes"):
+            service.get_tickers_for_universes(["KOSPI", "KOSDAQ"])
+
+
+class TestRunScreening:
+    def test_run_screening_uses_multi_universe_symbols(self, monkeypatch):
+        service = ScreeningService()
+
+        monkeypatch.setattr(service, "_resolve_conditions", lambda preset, params: [object()])
+        monkeypatch.setattr(
+            service,
+            "_get_symbols_for_universes",
+            lambda universe_input, fail_fast=False: (
+                {"005930.KS": "Samsung", "AAPL": "Apple"},
+                ["KOSPI", "SP500"],
+                {},
+            ),
+        )
+
+        class _Result:
+            def __init__(self, ticker, name):
+                self.ticker = ticker
+                self.name = name
+                self.current_price = 100.0
+                self.matched = True
+                self.condition_results = []
+
+        mock_screener = MagicMock()
+        mock_screener.run.return_value = [_Result("005930.KS", "Samsung")]
+
+        def _mock_stock_screener(**kwargs):
+            assert sorted(kwargs["stock_names"].keys()) == ["005930.KS", "AAPL"]
+            return mock_screener
+
+        monkeypatch.setattr("api.services.screening_service.StockScreener", _mock_stock_screener)
+
+        result = service.run_screening(
+            preset="accumulation_basic",
+            universe="KOSPI",
+            universes=["KOSPI", "SP500"],
+            params=None,
+        )
+
+        assert result["total_count"] == 2
+        assert result["matched_count"] == 1
+        assert result["resolved_universes"] == ["KOSPI", "SP500"]
+        assert result["failed_universe_errors"] == {}
+
+    def test_run_screening_raises_when_all_universe_fetches_fail(self, monkeypatch):
+        service = ScreeningService()
+
+        monkeypatch.setattr(service, "_resolve_conditions", lambda preset, params: [object()])
+        monkeypatch.setattr(
+            service,
+            "_get_symbols_for_universes",
+            lambda universe_input, fail_fast=False: ({}, ["KOSPI"], {"KOSPI": "fetch failed"}),
+        )
+
+        with pytest.raises(ValueError, match="Failed to fetch all universes"):
+            service.run_screening(
+                preset="accumulation_basic",
+                universe="KOSPI",
+                universes=["KOSPI"],
+                params=None,
+            )


### PR DESCRIPTION
## Summary
- Implement a multi-universe resolution layer in `ScreeningService` with stable-order dedupe semantics.
- Add universe merge/fetch behavior that degrades on partial market fetch failure and fails when all markets fail.
- Preserve backward compatibility for existing single-universe callers while enabling `universes` input from API layer.

## Changes
- `api/services/screening_service.py`
  - Added `resolve_universes(input)` with normalize/dedupe/default behavior.
  - Added `_get_symbols_for_universes(...)` and `get_tickers_for_universes(...)`.
  - Added `_get_universe_stock_count_multi(...)` combo-count cache path.
  - Updated `run_screening(...)` to accept `universes` (preferred) and still support `universe`.
  - Added partial failure policy:
    - if at least one market succeeds, continue with merged tickers
    - if all markets fail, return `ValueError`
- `api/routers/screening.py`
  - Pass `request.universes` into `run_screening(...)`.
- Tests
  - Added `api/tests/test_screening_service.py` for resolver/merge/failure policy coverage.
  - Updated `api/tests/test_screening.py` call assertions for the new `universes` argument.

## Test Plan
- [x] `venv/bin/python -m pytest -q api/tests/test_screening_service.py`
- [x] `venv/bin/python -m pytest -q api/tests/test_screening.py api/tests/test_screening_schema.py`
- [ ] Full backend/API suite in CI

Closes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)