### PR TITLE
feat(api): enforce multi-universe strategy execution semantics

### DIFF
--- a/api/routers/strategy.py
+++ b/api/routers/strategy.py
@@ -220,8 +220,9 @@ async def run_strategy(request: StrategyExecuteRequest) -> StrategyExecuteRespon
         result = execute_strategy(
             graph=request.graph,
             universe_override=request.universe_override,
+            universe_overrides=request.universe_overrides,
         )
-        response_universes = request.universe_overrides or [result["universe"]]
+        response_universes = result.get("universes") or request.universe_overrides or [result["universe"]]
         return StrategyExecuteResponse(**result, universes=response_universes)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
@@ -277,10 +278,11 @@ async def run_strategy_stream(request: StrategyExecuteRequest):
             result = execute_strategy_with_progress(
                 graph=request.graph,
                 universe_override=request.universe_override,
+                universe_overrides=request.universe_overrides,
                 progress_callback=_progress_cb,
                 skip_enrich=True,
             )
-            result["universes"] = request.universe_overrides or [result["universe"]]
+            result["universes"] = result.get("universes") or request.universe_overrides or [result["universe"]]
             if cancel_event.is_set():
                 return
             screened = result.get("screened_count", result["total_count"])

--- a/api/services/strategy_service.py
+++ b/api/services/strategy_service.py
@@ -314,6 +314,42 @@ def _coerce_param(value: Any, param_type: str) -> Any:
     return value
 
 
+def _resolve_execution_universes(
+    graph: StrategyGraph,
+    screening_service: ScreeningService,
+    universe_override: Optional[str] = None,
+    universe_overrides: Optional[List[str]] = None,
+) -> tuple[List[str], str]:
+    """
+    Resolve strategy execution universes with deterministic priority.
+
+    Priority:
+    1) request-level `universe_overrides` (multi)
+    2) request-level `universe_override` (single)
+    3) graph universe node values (`universes` then `universe`)
+    4) default `KOSPI`
+    """
+    if universe_overrides:
+        resolved = screening_service.resolve_universes(universe_overrides)
+        return resolved, resolved[0]
+
+    if universe_override:
+        resolved = screening_service.resolve_universes(universe_override)
+        return resolved, resolved[0]
+
+    for node in graph.nodes:
+        if node.data.node_type != "universe":
+            continue
+        graph_values: Any = node.data.universes or node.data.universe
+        if graph_values:
+            resolved = screening_service.resolve_universes(graph_values)
+            return resolved, resolved[0]
+        break
+
+    resolved = screening_service.resolve_universes(None)
+    return resolved, resolved[0]
+
+
 def _build_condition(condition_type: str, params: Dict[str, Any]) -> BaseCondition:
     """Instantiate a single condition from type key and params."""
     cls = CONDITION_CLASS_MAP.get(condition_type)
@@ -755,6 +791,7 @@ def _compute_node_survivors(
 def execute_strategy_with_progress(
     graph: StrategyGraph,
     universe_override: Optional[str] = None,
+    universe_overrides: Optional[List[str]] = None,
     progress_callback: Optional[Callable[[int, int, int], None]] = None,
     skip_enrich: bool = False,
 ) -> Dict[str, Any]:
@@ -766,6 +803,7 @@ def execute_strategy_with_progress(
     return execute_strategy(
         graph=graph,
         universe_override=universe_override,
+        universe_overrides=universe_overrides,
         progress_callback=progress_callback,
         skip_enrich=skip_enrich,
     )
@@ -774,6 +812,7 @@ def execute_strategy_with_progress(
 def execute_strategy(
     graph: StrategyGraph,
     universe_override: Optional[str] = None,
+    universe_overrides: Optional[List[str]] = None,
     progress_callback: Optional[Callable[[int, int, int], None]] = None,
     skip_enrich: bool = False,
 ) -> Dict[str, Any]:
@@ -783,6 +822,7 @@ def execute_strategy(
     Args:
         graph: The strategy graph
         universe_override: Override the universe from graph
+        universe_overrides: Multi-universe overrides (priority over universe_override)
 
     Returns:
         Dict with results, counts, universe, conditions used, and node_results
@@ -813,27 +853,36 @@ def execute_strategy(
         if sector_nodes[0].id not in reachable:
             sector_nodes = []  # Disconnected sector node — ignore
 
-    leaf_conditions, graph_universe, node_meta = build_flat_conditions_from_graph(graph)
+    leaf_conditions, _, node_meta = build_flat_conditions_from_graph(graph)
 
     if not leaf_conditions:
         raise ValueError("No conditions found in graph")
 
-    universe = universe_override or graph_universe
-
-    # Get tickers from universe
     screening_service = ScreeningService()
-    tickers = screening_service._get_universe_tickers(universe)
+    resolved_universes, primary_universe = _resolve_execution_universes(
+        graph=graph,
+        screening_service=screening_service,
+        universe_override=universe_override,
+        universe_overrides=universe_overrides,
+    )
+    tickers = screening_service.get_tickers_for_universes(
+        universe_input=resolved_universes,
+        fail_fast=False,
+    )
     total_count = len(tickers)
 
     # Apply sector filtering (already validated above)
     if sector_nodes:
         sector_name = (sector_nodes[0].data.sector or "").strip()
         fetcher = get_sector_fetcher()
-        sector_tickers = set(fetcher.get_sector_tickers(universe, sector_name))
+        sector_tickers = set(fetcher.get_sector_tickers(primary_universe, sector_name))
         tickers = [t for t in tickers if t in sector_tickers]
         logger.info(
-            "Sector filter '%s': %d -> %d tickers",
-            sector_name, total_count, len(tickers),
+            "Sector filter '%s' on %s: %d -> %d tickers",
+            sector_name,
+            primary_universe,
+            total_count,
+            len(tickers),
         )
 
     # Create screener with flat leaf conditions and run with return_all=True
@@ -940,7 +989,8 @@ def execute_strategy(
         "total_count": total_count,
         "screened_count": len(tickers),
         "matched_count": len(final_items),
-        "universe": universe,
+        "universe": primary_universe,
+        "universes": resolved_universes,
         "conditions_used": conditions_used,
         "node_results": node_results,
     }

--- a/api/tests/test_strategy_service.py
+++ b/api/tests/test_strategy_service.py
@@ -16,6 +16,8 @@ from api.services.strategy_service import (
     CONDITION_CLASS_MAP,
     CONDITION_METADATA,
     _build_condition,
+    execute_strategy,
+    execute_strategy_with_progress,
 )
 from screener.conditions import (
     AndCondition,
@@ -361,3 +363,137 @@ class TestGetAvailableConditions:
         assert "RSI" in categories
         assert "Accumulation" in categories
         assert "Breakout" in categories
+
+
+class TestExecuteStrategyMultiUniverse:
+    """Test multi-universe execution semantics and precedence."""
+
+    def _make_graph(self, nodes, edges):
+        return StrategyGraph(
+            nodes=[StrategyNode(id=n["id"], data=StrategyNodeData(**n["data"])) for n in nodes],
+            edges=[StrategyEdge(**e) for e in edges],
+        )
+
+    def test_request_override_has_priority_over_graph_universe(self, monkeypatch):
+        graph = self._make_graph(
+            nodes=[
+                {"id": "u1", "data": {"node_type": "universe", "universe": "SP500"}},
+                {"id": "c1", "data": {"node_type": "condition", "condition_type": "min_price", "params": {"min_price": 1000}}},
+                {"id": "o1", "data": {"node_type": "output"}},
+            ],
+            edges=[
+                {"id": "e1", "source": "u1", "target": "c1"},
+                {"id": "e2", "source": "c1", "target": "o1"},
+            ],
+        )
+
+        captured = {"universe_input": None}
+
+        def _mock_get_tickers_for_universes(self, universe_input, fail_fast=False):
+            captured["universe_input"] = universe_input
+            return ["005930.KS", "000660.KS"]
+
+        class _MockScreener:
+            def run(self, tickers, show_progress, return_all, progress_callback=None):
+                return []
+
+        monkeypatch.setattr(
+            "api.services.strategy_service.ScreeningService.get_tickers_for_universes",
+            _mock_get_tickers_for_universes,
+        )
+        monkeypatch.setattr(
+            "api.services.strategy_service.StockScreener",
+            lambda **kwargs: _MockScreener(),
+        )
+
+        result = execute_strategy(
+            graph=graph,
+            universe_override="KOSPI",
+            universe_overrides=["KOSPI", "KOSDAQ"],
+        )
+
+        assert captured["universe_input"] == ["KOSPI", "KOSDAQ"]
+        assert result["universe"] == "KOSPI"
+        assert result["universes"] == ["KOSPI", "KOSDAQ"]
+        assert result["total_count"] == 2
+        assert result["screened_count"] == 2
+
+    def test_graph_multi_universe_used_when_no_override(self, monkeypatch):
+        graph = self._make_graph(
+            nodes=[
+                {"id": "u1", "data": {"node_type": "universe", "universe": "SP500,NASDAQ100"}},
+                {"id": "c1", "data": {"node_type": "condition", "condition_type": "min_price", "params": {"min_price": 10}}},
+                {"id": "o1", "data": {"node_type": "output"}},
+            ],
+            edges=[
+                {"id": "e1", "source": "u1", "target": "c1"},
+                {"id": "e2", "source": "c1", "target": "o1"},
+            ],
+        )
+
+        captured = {"universe_input": None}
+
+        def _mock_get_tickers_for_universes(self, universe_input, fail_fast=False):
+            captured["universe_input"] = universe_input
+            return ["AAPL", "MSFT", "NVDA"]
+
+        class _MockScreener:
+            def run(self, tickers, show_progress, return_all, progress_callback=None):
+                return []
+
+        monkeypatch.setattr(
+            "api.services.strategy_service.ScreeningService.get_tickers_for_universes",
+            _mock_get_tickers_for_universes,
+        )
+        monkeypatch.setattr(
+            "api.services.strategy_service.StockScreener",
+            lambda **kwargs: _MockScreener(),
+        )
+
+        result = execute_strategy(graph=graph)
+        assert captured["universe_input"] == ["SP500", "NASDAQ100"]
+        assert result["universe"] == "SP500"
+        assert result["universes"] == ["SP500", "NASDAQ100"]
+        assert result["total_count"] == 3
+        assert result["screened_count"] == 3
+
+    def test_progress_total_matches_merged_ticker_count(self, monkeypatch):
+        graph = self._make_graph(
+            nodes=[
+                {"id": "c1", "data": {"node_type": "condition", "condition_type": "min_price", "params": {"min_price": 10}}},
+                {"id": "o1", "data": {"node_type": "output"}},
+            ],
+            edges=[{"id": "e1", "source": "c1", "target": "o1"}],
+        )
+
+        progress_events = []
+
+        def _mock_get_tickers_for_universes(self, universe_input, fail_fast=False):
+            return ["005930.KS", "AAPL"]
+
+        class _MockScreener:
+            def run(self, tickers, show_progress, return_all, progress_callback=None):
+                if progress_callback is not None:
+                    progress_callback(1, len(tickers), 0)
+                    progress_callback(len(tickers), len(tickers), 0)
+                return []
+
+        monkeypatch.setattr(
+            "api.services.strategy_service.ScreeningService.get_tickers_for_universes",
+            _mock_get_tickers_for_universes,
+        )
+        monkeypatch.setattr(
+            "api.services.strategy_service.StockScreener",
+            lambda **kwargs: _MockScreener(),
+        )
+
+        result = execute_strategy_with_progress(
+            graph=graph,
+            universe_overrides=["KOSPI", "SP500"],
+            progress_callback=lambda p, t, m: progress_events.append((p, t, m)),
+        )
+
+        assert progress_events
+        assert progress_events[-1][1] == 2
+        assert result["total_count"] == 2
+        assert result["screened_count"] == 2


### PR DESCRIPTION
## Summary
- Add deterministic universe resolution priority for strategy execution: `universe_overrides` > `universe_override` > graph universe node > default `KOSPI`.
- Execute strategy on merged multi-universe ticker sets via `ScreeningService.get_tickers_for_universes`.
- Align API response and stream payload with resolved execution universes and ensure progress totals reflect actual merged execution scope.

## Changes
- `api/services/strategy_service.py`
  - Added `_resolve_execution_universes(...)` helper.
  - Extended `execute_strategy(...)` and `execute_strategy_with_progress(...)` with `universe_overrides`.
  - Switched ticker source from single universe fetch to multi-universe merged ticker resolver.
  - Returned `universes` in strategy execution result payload.
- `api/routers/strategy.py`
  - Pass `universe_overrides` to strategy service.
  - Preserve compatibility fallback for `universes` response field.
- `api/tests/test_strategy_service.py`
  - Added regression tests for precedence, graph multi-universe fallback, and progress total alignment.

## Test Plan
- [x] `venv/bin/python -m pytest -q api/tests/test_strategy.py`
- [x] `venv/bin/python -m pytest -q api/tests/test_strategy_service.py -k \"TestExecuteStrategyMultiUniverse or universe_node_multi_input_keeps_primary_for_compatibility\"`
- [ ] Full API/backend suite in CI

Closes #462

🤖 Generated with [Claude Code](https://claude.com/claude-code)