### PR TITLE
feat(api): clarify sector behavior in mixed multi-market runs

### DIFF
--- a/api/services/strategy_service.py
+++ b/api/services/strategy_service.py
@@ -874,13 +874,26 @@ def execute_strategy(
     # Apply sector filtering (already validated above)
     if sector_nodes:
         sector_name = (sector_nodes[0].data.sector or "").strip()
+        kr_universes = [u for u in resolved_universes if u in ("KOSPI", "KOSDAQ")]
+        if not kr_universes:
+            raise ValueError(
+                "Sector filtering is supported only when KR universes (KOSPI/KOSDAQ) are included"
+            )
+
         fetcher = get_sector_fetcher()
-        sector_tickers = set(fetcher.get_sector_tickers(primary_universe, sector_name))
-        tickers = [t for t in tickers if t in sector_tickers]
+        sector_tickers: set[str] = set()
+        for market in kr_universes:
+            sector_tickers.update(fetcher.get_sector_tickers(market, sector_name))
+
+        # Policy: apply sector filter only to KR tickers; keep non-KR tickers unchanged.
+        tickers = [
+            ticker for ticker in tickers
+            if (not _is_korean_ticker(ticker)) or (ticker in sector_tickers)
+        ]
         logger.info(
-            "Sector filter '%s' on %s: %d -> %d tickers",
+            "Sector filter '%s' on KR universes %s: %d -> %d tickers",
             sector_name,
-            primary_universe,
+            ",".join(kr_universes),
             total_count,
             len(tickers),
         )

--- a/api/tests/test_strategy_service.py
+++ b/api/tests/test_strategy_service.py
@@ -497,3 +497,88 @@ class TestExecuteStrategyMultiUniverse:
         assert progress_events[-1][1] == 2
         assert result["total_count"] == 2
         assert result["screened_count"] == 2
+
+
+class TestExecuteStrategySectorPolicy:
+    """Test sector behavior under mixed multi-market execution."""
+
+    def _make_graph(self, nodes, edges):
+        return StrategyGraph(
+            nodes=[StrategyNode(id=n["id"], data=StrategyNodeData(**n["data"])) for n in nodes],
+            edges=[StrategyEdge(**e) for e in edges],
+        )
+
+    def test_sector_filters_only_kr_tickers_in_mixed_universes(self, monkeypatch):
+        graph = self._make_graph(
+            nodes=[
+                {"id": "u1", "data": {"node_type": "universe", "universe": "KOSPI"}},
+                {"id": "s1", "data": {"node_type": "sector", "sector": "전기전자"}},
+                {"id": "c1", "data": {"node_type": "condition", "condition_type": "min_price", "params": {"min_price": 10}}},
+                {"id": "o1", "data": {"node_type": "output"}},
+            ],
+            edges=[
+                {"id": "e1", "source": "u1", "target": "c1"},
+                {"id": "e2", "source": "s1", "target": "c1"},
+                {"id": "e3", "source": "c1", "target": "o1"},
+            ],
+        )
+
+        captured = {"tickers": None}
+
+        def _mock_get_tickers_for_universes(self, universe_input, fail_fast=False):
+            return ["005930.KS", "000660.KS", "AAPL"]
+
+        class _MockSectorFetcher:
+            def get_sector_tickers(self, market: str, sector: str):
+                return ["005930.KS"]
+
+        class _MockScreener:
+            def run(self, tickers, show_progress, return_all, progress_callback=None):
+                captured["tickers"] = tickers
+                return []
+
+        monkeypatch.setattr(
+            "api.services.strategy_service.ScreeningService.get_tickers_for_universes",
+            _mock_get_tickers_for_universes,
+        )
+        monkeypatch.setattr(
+            "api.services.strategy_service.get_sector_fetcher",
+            lambda: _MockSectorFetcher(),
+        )
+        monkeypatch.setattr(
+            "api.services.strategy_service.StockScreener",
+            lambda **kwargs: _MockScreener(),
+        )
+
+        result = execute_strategy(
+            graph=graph,
+            universe_overrides=["KOSPI", "SP500"],
+        )
+
+        assert captured["tickers"] == ["005930.KS", "AAPL"]
+        assert result["total_count"] == 3
+        assert result["screened_count"] == 2
+
+    def test_sector_with_non_kr_universe_fails_fast(self, monkeypatch):
+        graph = self._make_graph(
+            nodes=[
+                {"id": "s1", "data": {"node_type": "sector", "sector": "전기전자"}},
+                {"id": "c1", "data": {"node_type": "condition", "condition_type": "min_price", "params": {"min_price": 10}}},
+                {"id": "o1", "data": {"node_type": "output"}},
+            ],
+            edges=[
+                {"id": "e1", "source": "s1", "target": "c1"},
+                {"id": "e2", "source": "c1", "target": "o1"},
+            ],
+        )
+
+        monkeypatch.setattr(
+            "api.services.strategy_service.ScreeningService.get_tickers_for_universes",
+            lambda self, universe_input, fail_fast=False: ["AAPL", "MSFT"],
+        )
+
+        with pytest.raises(ValueError, match="Sector filtering is supported only when KR universes"):
+            execute_strategy(
+                graph=graph,
+                universe_overrides=["SP500"],
+            )


### PR DESCRIPTION
## Summary
- Define and implement sector node semantics for multi-market execution.
- Policy: sector filtering applies only to KR tickers (`.KS`, `.KQ`) while non-KR tickers are bypassed in mixed KR/US runs.
- Fail fast with a clear 400 error when sector nodes are used without KR universes.

## Changes
- `api/services/strategy_service.py`
  - Updated sector filtering path in `execute_strategy(...)`.
  - Added KR-universe presence validation for sector node usage.
  - Kept non-KR tickers intact under mixed universes.
- `api/tests/test_strategy_service.py`
  - Added tests for mixed KR/US partial-apply behavior.
  - Added tests for non-KR-only fail-fast behavior.

## Test Plan
- [x] `venv/bin/python -m pytest -q api/tests/test_strategy.py`
- [x] `venv/bin/python -m pytest -q api/tests/test_strategy_service.py -k \"TestExecuteStrategyMultiUniverse or TestExecuteStrategySectorPolicy or universe_node_multi_input_keeps_primary_for_compatibility\"`
- [ ] Full backend suite in CI

Closes #463

🤖 Generated with [Claude Code](https://claude.com/claude-code)