### PR TITLE
Integrate multi-market strategy semantics in frontend

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -304,6 +304,7 @@
     "sectorSelection": "Sector / Industry",
     "sectorStockCount": "{count} stocks in sector",
     "sectorInstruction": "Click to select a sector",
+    "sectorUnavailableForUniverse": "Sector filtering currently supports only a single Korean market (KOSPI or KOSDAQ). Current selection: {universe}",
     "loadingSectors": "Loading sectors...",
     "marketSelection": "Market Selection",
     "composite": "{universe} Composite",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -304,6 +304,7 @@
     "sectorSelection": "업종 / 산업",
     "sectorStockCount": "업종 내 {count}개 종목",
     "sectorInstruction": "클릭하여 업종을 선택하세요",
+    "sectorUnavailableForUniverse": "업종 필터는 현재 한국 단일 시장(KOSPI 또는 KOSDAQ)에서만 지원됩니다. 현재 선택: {universe}",
     "loadingSectors": "업종 목록 로딩 중...",
     "marketSelection": "시장 선택",
     "composite": "{universe} 종합",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -304,6 +304,7 @@
     "sectorSelection": "行业 / 产业",
     "sectorStockCount": "行业内 {count} 只股票",
     "sectorInstruction": "点击选择行业",
+    "sectorUnavailableForUniverse": "行业筛选目前仅支持单一韩国市场（KOSPI 或 KOSDAQ）。当前选择：{universe}",
     "loadingSectors": "正在加载行业列表...",
     "marketSelection": "市场选择",
     "composite": "{universe} 综合",

--- a/web/src/components/strategy/nodes/SectorNode.tsx
+++ b/web/src/components/strategy/nodes/SectorNode.tsx
@@ -1,11 +1,15 @@
 'use client';
 
-import { memo, useCallback, useState, useEffect } from 'react';
-import { Handle, Position, useNodeId, useReactFlow } from '@xyflow/react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { Handle, Position, useNodeId, useReactFlow, useStore } from '@xyflow/react';
 import type { NodeProps } from '@xyflow/react';
-import { Building2, Loader2 } from 'lucide-react';
+import { Building2 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
-import type { StrategyNodeData } from '@/lib/strategy/graphSerializer';
+import {
+  parseUniverseSelection,
+  resolveSectorMarket,
+  type StrategyNodeData,
+} from '@/lib/strategy/graphSerializer';
 import { getSectors, type SectorInfo } from '@/lib/api';
 import NodeEditPopup, { FieldLabel, SelectInput } from './NodeEditPopup';
 
@@ -14,23 +18,44 @@ function SectorNode({ data, selected }: NodeProps) {
   const nodeData = data as unknown as StrategyNodeData;
   const nodeId = useNodeId()!;
   const { updateNodeData, deleteElements } = useReactFlow();
+  const nodes = useStore((state) => state.nodes);
 
   const [sectors, setSectors] = useState<SectorInfo[]>([]);
-  const [loading, setLoading] = useState(true);
 
-  // Fetch sectors for the current market (KOSPI/KOSDAQ)
+  const selectedUniverses = useMemo(() => {
+    const universeNode = nodes.find((n) => {
+      const d = n.data as unknown as StrategyNodeData;
+      return d.node_type === 'universe';
+    });
+    const universeData = (universeNode?.data as StrategyNodeData | undefined)?.universe;
+    return parseUniverseSelection(universeData);
+  }, [nodes]);
+
+  const sectorMarket = useMemo(
+    () => resolveSectorMarket(selectedUniverses),
+    [selectedUniverses]
+  );
+  const isSectorSupported = sectorMarket !== null;
+
+  // Fetch sectors based on current universe selection.
   useEffect(() => {
     let cancelled = false;
-    getSectors('KOSPI')
+    if (!sectorMarket) return () => { cancelled = true; };
+    getSectors(sectorMarket)
       .then((res) => {
         if (!cancelled) setSectors(res.sectors);
       })
-      .catch(() => {})
-      .finally(() => {
-        if (!cancelled) setLoading(false);
+      .catch(() => {
+        if (!cancelled) setSectors([]);
       });
     return () => { cancelled = true; };
-  }, []);
+  }, [sectorMarket]);
+
+  useEffect(() => {
+    if (!sectorMarket && nodeData.sector) {
+      updateNodeData(nodeId, { sector: '' });
+    }
+  }, [nodeData.sector, nodeId, sectorMarket, updateNodeData]);
 
   const handleSectorChange = useCallback(
     (value: string) => {
@@ -73,7 +98,9 @@ function SectorNode({ data, selected }: NodeProps) {
         )}
         {!selectedSector && (
           <div className="text-xs text-slate-400 dark:text-slate-500 mt-1">
-            {t('sectorInstruction')}
+            {sectorMarket
+              ? t('sectorInstruction')
+              : t('sectorUnavailableForUniverse', { universe: selectedUniverses.join(' + ') })}
           </div>
         )}
       </div>
@@ -93,10 +120,9 @@ function SectorNode({ data, selected }: NodeProps) {
       <NodeEditPopup selected={!!selected} onDelete={handleDelete}>
         <div>
           <FieldLabel>{t('sectorSelection')}</FieldLabel>
-          {loading ? (
-            <div className="flex items-center gap-2 py-2 text-xs text-gray-400">
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              {t('loadingSectors')}
+          {!isSectorSupported ? (
+            <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:border-amber-900/60 dark:bg-amber-900/20 dark:text-amber-200">
+              {t('sectorUnavailableForUniverse', { universe: selectedUniverses.join(' + ') })}
             </div>
           ) : (
             <SelectInput

--- a/web/src/components/strategy/nodes/UniverseNode.tsx
+++ b/web/src/components/strategy/nodes/UniverseNode.tsx
@@ -5,39 +5,28 @@ import { Handle, Position, useNodeId, useReactFlow } from '@xyflow/react';
 import type { NodeProps } from '@xyflow/react';
 import { Globe } from 'lucide-react';
 import { useTranslations } from 'next-intl';
-import type { StrategyNodeData } from '@/lib/strategy/graphSerializer';
+import {
+  SUPPORTED_UNIVERSES,
+  parseUniverseSelection,
+  serializeUniverseSelection,
+  type SupportedUniverse,
+  type StrategyNodeData,
+} from '@/lib/strategy/graphSerializer';
 import NodeEditPopup, { FieldLabel } from './NodeEditPopup';
-
-const UNIVERSES = ['KOSPI', 'KOSDAQ', 'SP500', 'NASDAQ100'] as const;
-
-function parseUniverses(value?: string): string[] {
-  if (!value) return ['KOSPI'];
-  const parsed = value
-    .split(',')
-    .map((item) => item.trim())
-    .filter((item): item is (typeof UNIVERSES)[number] =>
-      (UNIVERSES as readonly string[]).includes(item)
-    );
-  return parsed.length > 0 ? parsed : ['KOSPI'];
-}
-
-function toUniverseValue(values: string[]): string {
-  return values.join(',');
-}
 
 function UniverseNode({ data, selected }: NodeProps) {
   const t = useTranslations('strategy');
   const nodeData = data as unknown as StrategyNodeData;
   const nodeId = useNodeId()!;
   const { updateNodeData, deleteElements } = useReactFlow();
-  const selectedUniverses = parseUniverses(nodeData.universe);
+  const selectedUniverses = parseUniverseSelection(nodeData.universe);
 
   const handleUniverseToggle = useCallback(
-    (value: string) => {
-      const current = parseUniverses(nodeData.universe);
+    (value: SupportedUniverse) => {
+      const current = parseUniverseSelection(nodeData.universe);
       const exists = current.includes(value);
 
-      let next: string[];
+      let next: SupportedUniverse[];
       if (exists) {
         if (current.length === 1) return;
         next = current.filter((item) => item !== value);
@@ -45,7 +34,7 @@ function UniverseNode({ data, selected }: NodeProps) {
         next = [...current, value];
       }
 
-      updateNodeData(nodeId, { universe: toUniverseValue(next) });
+      updateNodeData(nodeId, { universe: serializeUniverseSelection(next) });
     },
     [nodeData.universe, nodeId, updateNodeData]
   );
@@ -89,7 +78,7 @@ function UniverseNode({ data, selected }: NodeProps) {
         <div>
           <FieldLabel>{t('stockUniverse')}</FieldLabel>
           <div className="space-y-2">
-            {UNIVERSES.map((universe) => (
+            {SUPPORTED_UNIVERSES.map((universe) => (
               <label
                 key={universe}
                 className="flex items-center gap-2.5 rounded-md border border-[#e1e3e5] dark:border-[#2e2e30] bg-white dark:bg-[#1e1e1f] px-3 py-2 text-sm text-gray-700 dark:text-gray-200"

--- a/web/src/lib/strategy/graphSerializer.ts
+++ b/web/src/lib/strategy/graphSerializer.ts
@@ -1,5 +1,8 @@
 import type { Node, Edge } from '@xyflow/react';
 
+export const SUPPORTED_UNIVERSES = ['KOSPI', 'KOSDAQ', 'SP500', 'NASDAQ100'] as const;
+export type SupportedUniverse = (typeof SUPPORTED_UNIVERSES)[number];
+
 export interface StrategyNodeData extends Record<string, unknown> {
   node_type: 'universe' | 'condition' | 'logic' | 'output' | 'sector';
   condition_type?: string;
@@ -11,6 +14,36 @@ export interface StrategyNodeData extends Record<string, unknown> {
   resultCount?: number;
   child_node_ids?: string[];
   intermediateResult?: import('@/lib/api').NodeIntermediateResult;
+}
+
+export function parseUniverseSelection(value?: string): SupportedUniverse[] {
+  if (!value) return ['KOSPI'];
+  const parsed = value
+    .split(',')
+    .map((item) => item.trim())
+    .filter(
+      (item): item is SupportedUniverse =>
+        (SUPPORTED_UNIVERSES as readonly string[]).includes(item)
+    );
+  return parsed.length > 0 ? Array.from(new Set(parsed)) : ['KOSPI'];
+}
+
+export function serializeUniverseSelection(values: string[]): string {
+  return values.join(',');
+}
+
+export function resolveSectorMarket(
+  universes: readonly string[]
+): 'KOSPI' | 'KOSDAQ' | null {
+  if (universes.length === 0) return 'KOSPI';
+  const selected = new Set(universes);
+  const hasKorean = selected.has('KOSPI') || selected.has('KOSDAQ');
+  const hasUS = selected.has('SP500') || selected.has('NASDAQ100');
+  if (hasUS) return null;
+  if (selected.has('KOSPI') && selected.has('KOSDAQ')) return null;
+  if (selected.has('KOSDAQ')) return 'KOSDAQ';
+  if (hasKorean) return 'KOSPI';
+  return null;
 }
 
 export interface StrategyNode {

--- a/web/src/lib/strategy/graphValidator.ts
+++ b/web/src/lib/strategy/graphValidator.ts
@@ -1,5 +1,9 @@
 import type { Node, Edge } from '@xyflow/react';
-import type { StrategyNodeData } from './graphSerializer';
+import {
+  parseUniverseSelection,
+  resolveSectorMarket,
+  type StrategyNodeData,
+} from './graphSerializer';
 
 export interface ValidationResult {
   valid: boolean;
@@ -33,8 +37,15 @@ export function validateGraph(
 
   // Check sector node (max 1, must not be inside group, must have sector selected)
   const sectorNodes = nodes.filter((n) => n.data.node_type === 'sector');
+  const universeNode = universeNodes[0];
+  const selectedUniverses = parseUniverseSelection(universeNode?.data.universe);
   if (sectorNodes.length > 1) {
     errors.push('Only one Sector node is allowed per strategy graph.');
+  }
+  if (sectorNodes.length > 0 && resolveSectorMarket(selectedUniverses) === null) {
+    errors.push(
+      `Sector node requires a single Korean market universe (KOSPI or KOSDAQ). Current selection: ${selectedUniverses.join(', ')}`
+    );
   }
   for (const sn of sectorNodes) {
     if (sn.parentId) {


### PR DESCRIPTION
## Summary
- centralize universe selection parsing/serialization for strategy nodes
- make sector node fetch/select behavior depend on valid single Korean market universe
- add graph validation error for unsupported sector + multi-market combinations
- add locale copy for the sector availability guidance (en/ko/zh)

## Test plan
- [x] `npm --prefix web run lint`
- [x] `npm --prefix web run build`

Closes #470

🤖 Generated with [Claude Code](https://claude.com/claude-code)