### PR TITLE
fix: localize strategy filter condition strings

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -954,6 +954,264 @@
         "max_roic": "Max ROIC %"
       },
       "help": "Return on Invested Capital — how well the company uses all its capital."
+    },
+    "analyst_revision_1m": {
+      "label": "Analyst Revision 1M",
+      "desc": "Analyst Revision 1M filter",
+      "params": {
+        "min_revision_pct": "Minimum Revision %"
+      },
+      "help": "Filters stocks based on Analyst Revision 1M threshold settings."
+    },
+    "analyst_revision_3m": {
+      "label": "Analyst Revision 3M",
+      "desc": "Analyst Revision 3M filter",
+      "params": {
+        "min_revision_pct": "Minimum Revision %"
+      },
+      "help": "Filters stocks based on Analyst Revision 3M threshold settings."
+    },
+    "asset_turnover_ratio": {
+      "label": "Asset Turnover Ratio",
+      "desc": "Asset Turnover Ratio filter",
+      "params": {
+        "min_ratio": "Minimum Ratio"
+      },
+      "help": "Filters stocks based on Asset Turnover Ratio threshold settings."
+    },
+    "book_to_market_ratio": {
+      "label": "Book to Market Ratio",
+      "desc": "Book to Market Ratio filter",
+      "params": {
+        "min_ratio": "Minimum Ratio"
+      },
+      "help": "Filters stocks based on Book to Market Ratio threshold settings."
+    },
+    "buyback_yield_filter": {
+      "label": "Buyback Yield Filter",
+      "desc": "Buyback Yield Filter filter",
+      "params": {
+        "min_yield_pct": "Minimum Yield %"
+      },
+      "help": "Filters stocks based on Buyback Yield Filter threshold settings."
+    },
+    "cash_conversion_ratio": {
+      "label": "Cash Conversion Ratio",
+      "desc": "Cash Conversion Ratio filter",
+      "params": {
+        "min_ratio": "Minimum Ratio"
+      },
+      "help": "Filters stocks based on Cash Conversion Ratio threshold settings."
+    },
+    "cashflow_to_debt_ratio": {
+      "label": "Cashflow to Debt Ratio",
+      "desc": "Cashflow to Debt Ratio filter",
+      "params": {
+        "min_ratio": "Minimum Ratio"
+      },
+      "help": "Filters stocks based on Cashflow to Debt Ratio threshold settings."
+    },
+    "debt_service_coverage_ratio": {
+      "label": "Debt Service Coverage Ratio",
+      "desc": "Debt Service Coverage Ratio filter",
+      "params": {
+        "min_ratio": "Minimum Ratio"
+      },
+      "help": "Filters stocks based on Debt Service Coverage Ratio threshold settings."
+    },
+    "dividend_growth_5y": {
+      "label": "Dividend Growth 5Y",
+      "desc": "Dividend Growth 5Y filter",
+      "params": {
+        "min_growth_pct": "Minimum Growth %"
+      },
+      "help": "Filters stocks based on Dividend Growth 5Y threshold settings."
+    },
+    "earnings_stability_score": {
+      "label": "Earnings Stability Score",
+      "desc": "Earnings Stability Score filter",
+      "params": {
+        "lookback_years": "Lookback Years",
+        "max_cv": "Maximum CV"
+      },
+      "help": "Filters stocks based on Earnings Stability Score threshold settings."
+    },
+    "eps_cagr_3y": {
+      "label": "EPS CAGR 3Y",
+      "desc": "EPS CAGR 3Y filter",
+      "params": {
+        "min_cagr_pct": "Minimum CAGR %"
+      },
+      "help": "Filters stocks based on EPS CAGR 3Y threshold settings."
+    },
+    "eps_growth_yoy": {
+      "label": "EPS Growth YoY",
+      "desc": "EPS Growth YoY filter",
+      "params": {
+        "min_growth_pct": "Minimum Growth %"
+      },
+      "help": "Filters stocks based on EPS Growth YoY threshold settings."
+    },
+    "ev_to_ebitda_ratio": {
+      "label": "EV to EBITDA Ratio",
+      "desc": "EV to EBITDA Ratio filter",
+      "params": {
+        "max_ratio": "Maximum Ratio"
+      },
+      "help": "Filters stocks based on EV to EBITDA Ratio threshold settings."
+    },
+    "ev_to_sales_ratio": {
+      "label": "EV to Sales Ratio",
+      "desc": "EV to Sales Ratio filter",
+      "params": {
+        "max_ratio": "Maximum Ratio"
+      },
+      "help": "Filters stocks based on EV to Sales Ratio threshold settings."
+    },
+    "free_cash_flow_margin": {
+      "label": "Free Cash Flow Margin",
+      "desc": "Free Cash Flow Margin filter",
+      "params": {
+        "min_margin_pct": "Minimum Margin %"
+      },
+      "help": "Filters stocks based on Free Cash Flow Margin threshold settings."
+    },
+    "gross_margin": {
+      "label": "Gross Margin",
+      "desc": "Gross Margin filter",
+      "params": {
+        "min_margin_pct": "Minimum Margin %"
+      },
+      "help": "Filters stocks based on Gross Margin threshold settings."
+    },
+    "gross_profitability": {
+      "label": "Gross Profitability",
+      "desc": "Gross Profitability filter",
+      "params": {
+        "min_ratio": "Minimum Ratio"
+      },
+      "help": "Filters stocks based on Gross Profitability threshold settings."
+    },
+    "interest_coverage_ratio": {
+      "label": "Interest Coverage Ratio",
+      "desc": "Interest Coverage Ratio filter",
+      "params": {
+        "min_ratio": "Minimum Ratio"
+      },
+      "help": "Filters stocks based on Interest Coverage Ratio threshold settings."
+    },
+    "inventory_turnover_ratio": {
+      "label": "Inventory Turnover Ratio",
+      "desc": "Inventory Turnover Ratio filter",
+      "params": {
+        "min_ratio": "Minimum Ratio"
+      },
+      "help": "Filters stocks based on Inventory Turnover Ratio threshold settings."
+    },
+    "net_debt_to_ebitda": {
+      "label": "Net Debt to EBITDA",
+      "desc": "Net Debt to EBITDA filter",
+      "params": {
+        "max_ratio": "Maximum Ratio"
+      },
+      "help": "Filters stocks based on Net Debt to EBITDA threshold settings."
+    },
+    "net_margin": {
+      "label": "Net Margin",
+      "desc": "Net Margin filter",
+      "params": {
+        "min_margin_pct": "Minimum Margin %"
+      },
+      "help": "Filters stocks based on Net Margin threshold settings."
+    },
+    "operating_margin": {
+      "label": "Operating Margin",
+      "desc": "Operating Margin filter",
+      "params": {
+        "min_margin_pct": "Minimum Margin %"
+      },
+      "help": "Filters stocks based on Operating Margin threshold settings."
+    },
+    "payout_ratio_filter": {
+      "label": "Payout Ratio Filter",
+      "desc": "Payout Ratio Filter filter",
+      "params": {
+        "max_payout_pct": "Maximum Payout %"
+      },
+      "help": "Filters stocks based on Payout Ratio Filter threshold settings."
+    },
+    "price_to_tangible_book": {
+      "label": "Price to Tangible Book",
+      "desc": "Price to Tangible Book filter",
+      "params": {
+        "max_ratio": "Maximum Ratio"
+      },
+      "help": "Filters stocks based on Price to Tangible Book threshold settings."
+    },
+    "quality_score": {
+      "label": "Quality Score",
+      "desc": "Quality Score filter",
+      "params": {
+        "min_score": "Minimum Score"
+      },
+      "help": "Filters stocks based on Quality Score threshold settings."
+    },
+    "receivables_turnover_ratio": {
+      "label": "Receivables Turnover Ratio",
+      "desc": "Receivables Turnover Ratio filter",
+      "params": {
+        "min_ratio": "Minimum Ratio"
+      },
+      "help": "Filters stocks based on Receivables Turnover Ratio threshold settings."
+    },
+    "revenue_cagr_3y": {
+      "label": "Revenue CAGR 3Y",
+      "desc": "Revenue CAGR 3Y filter",
+      "params": {
+        "min_cagr_pct": "Minimum CAGR %"
+      },
+      "help": "Filters stocks based on Revenue CAGR 3Y threshold settings."
+    },
+    "revenue_growth_yoy": {
+      "label": "Revenue Growth YoY",
+      "desc": "Revenue Growth YoY filter",
+      "params": {
+        "min_growth_pct": "Minimum Growth %"
+      },
+      "help": "Filters stocks based on Revenue Growth YoY threshold settings."
+    },
+    "revenue_stability_score": {
+      "label": "Revenue Stability Score",
+      "desc": "Revenue Stability Score filter",
+      "params": {
+        "lookback_years": "Lookback Years",
+        "max_cv": "Maximum CV"
+      },
+      "help": "Filters stocks based on Revenue Stability Score threshold settings."
+    },
+    "shareholder_yield_filter": {
+      "label": "Shareholder Yield Filter",
+      "desc": "Shareholder Yield Filter filter",
+      "params": {
+        "min_yield_pct": "Minimum Yield %"
+      },
+      "help": "Filters stocks based on Shareholder Yield Filter threshold settings."
+    },
+    "roce_filter": {
+      "label": "ROCE Filter",
+      "desc": "ROCE Filter filter",
+      "params": {
+        "min_roce_pct": "Minimum ROCE %"
+      },
+      "help": "Filters stocks based on ROCE Filter threshold settings."
+    },
+    "roa_filter": {
+      "label": "ROA Filter",
+      "desc": "ROA Filter filter",
+      "params": {
+        "min_roa_pct": "Minimum ROA %"
+      },
+      "help": "Filters stocks based on ROA Filter threshold settings."
     }
   },
   "settings": {

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -954,6 +954,264 @@
         "max_roic": "최대 ROIC %"
       },
       "help": "투하자본수익률 — 회사가 전체 자본을 얼마나 잘 활용하는지 보여줍니다."
+    },
+    "analyst_revision_1m": {
+      "label": "애널리스트 추정치 1개월 수정률",
+      "desc": "애널리스트 추정치 1개월 수정률 조건으로 종목을 필터링합니다.",
+      "params": {
+        "min_revision_pct": "최소 수정률 %"
+      },
+      "help": "애널리스트 추정치 1개월 수정률 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "analyst_revision_3m": {
+      "label": "애널리스트 추정치 3개월 수정률",
+      "desc": "애널리스트 추정치 3개월 수정률 조건으로 종목을 필터링합니다.",
+      "params": {
+        "min_revision_pct": "최소 수정률 %"
+      },
+      "help": "애널리스트 추정치 3개월 수정률 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "asset_turnover_ratio": {
+      "label": "총자산회전율",
+      "desc": "총자산회전율 조건으로 종목을 필터링합니다.",
+      "params": {
+        "min_ratio": "최소 비율"
+      },
+      "help": "총자산회전율 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "book_to_market_ratio": {
+      "label": "장부가치 대비 시가총액 비율",
+      "desc": "장부가치 대비 시가총액 비율 조건으로 종목을 필터링합니다.",
+      "params": {
+        "min_ratio": "최소 비율"
+      },
+      "help": "장부가치 대비 시가총액 비율 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "buyback_yield_filter": {
+      "label": "자사주 매입 수익률",
+      "desc": "자사주 매입 수익률 조건으로 종목을 필터링합니다.",
+      "params": {
+        "min_yield_pct": "최소 수익률 %"
+      },
+      "help": "자사주 매입 수익률 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "cash_conversion_ratio": {
+      "label": "현금전환비율",
+      "desc": "현금전환비율 조건으로 종목을 필터링합니다.",
+      "params": {
+        "min_ratio": "최소 비율"
+      },
+      "help": "현금전환비율 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "cashflow_to_debt_ratio": {
+      "label": "영업현금흐름 대비 부채비율",
+      "desc": "영업현금흐름 대비 부채비율 조건으로 종목을 필터링합니다.",
+      "params": {
+        "min_ratio": "최소 비율"
+      },
+      "help": "영업현금흐름 대비 부채비율 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "debt_service_coverage_ratio": {
+      "label": "채무상환커버리지비율",
+      "desc": "채무상환커버리지비율 조건으로 종목을 필터링합니다.",
+      "params": {
+        "min_ratio": "최소 비율"
+      },
+      "help": "채무상환커버리지비율 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "dividend_growth_5y": {
+      "label": "5년 배당 성장률",
+      "desc": "5년 배당 성장률 조건으로 종목을 필터링합니다.",
+      "params": {
+        "min_growth_pct": "최소 성장률 %"
+      },
+      "help": "5년 배당 성장률 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "earnings_stability_score": {
+      "label": "이익 안정성 점수",
+      "desc": "이익 안정성 점수 조건으로 종목을 필터링합니다.",
+      "params": {
+        "lookback_years": "조회 연수",
+        "max_cv": "최대 변동계수"
+      },
+      "help": "이익 안정성 점수 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "eps_cagr_3y": {
+      "label": "EPS 3년 CAGR",
+      "desc": "EPS 3년 CAGR 조건으로 종목을 필터링합니다.",
+      "params": {
+        "min_cagr_pct": "최소 CAGR %"
+      },
+      "help": "EPS 3년 CAGR 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "eps_growth_yoy": {
+      "label": "EPS 전년 대비 성장률",
+      "desc": "EPS 전년 대비 성장률 조건으로 종목을 필터링합니다.",
+      "params": {
+        "min_growth_pct": "최소 성장률 %"
+      },
+      "help": "EPS 전년 대비 성장률 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "ev_to_ebitda_ratio": {
+      "label": "EV/EBITDA 비율",
+      "desc": "EV/EBITDA 비율 조건으로 종목을 필터링합니다.",
+      "params": {
+        "max_ratio": "최대 비율"
+      },
+      "help": "EV/EBITDA 비율 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "ev_to_sales_ratio": {
+      "label": "EV/매출 비율",
+      "desc": "EV/매출 비율 조건으로 종목을 필터링합니다.",
+      "params": {
+        "max_ratio": "최대 비율"
+      },
+      "help": "EV/매출 비율 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "free_cash_flow_margin": {
+      "label": "잉여현금흐름 마진",
+      "desc": "잉여현금흐름 마진 조건으로 종목을 필터링합니다.",
+      "params": {
+        "min_margin_pct": "최소 마진 %"
+      },
+      "help": "잉여현금흐름 마진 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "gross_margin": {
+      "label": "매출총이익률",
+      "desc": "매출총이익률 조건으로 종목을 필터링합니다.",
+      "params": {
+        "min_margin_pct": "최소 마진 %"
+      },
+      "help": "매출총이익률 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "gross_profitability": {
+      "label": "총이익 수익성",
+      "desc": "총이익 수익성 조건으로 종목을 필터링합니다.",
+      "params": {
+        "min_ratio": "최소 비율"
+      },
+      "help": "총이익 수익성 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "interest_coverage_ratio": {
+      "label": "이자보상배율",
+      "desc": "이자보상배율 조건으로 종목을 필터링합니다.",
+      "params": {
+        "min_ratio": "최소 비율"
+      },
+      "help": "이자보상배율 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "inventory_turnover_ratio": {
+      "label": "재고회전율",
+      "desc": "재고회전율 조건으로 종목을 필터링합니다.",
+      "params": {
+        "min_ratio": "최소 비율"
+      },
+      "help": "재고회전율 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "net_debt_to_ebitda": {
+      "label": "순부채/EBITDA",
+      "desc": "순부채/EBITDA 조건으로 종목을 필터링합니다.",
+      "params": {
+        "max_ratio": "최대 비율"
+      },
+      "help": "순부채/EBITDA 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "net_margin": {
+      "label": "순이익률",
+      "desc": "순이익률 조건으로 종목을 필터링합니다.",
+      "params": {
+        "min_margin_pct": "최소 마진 %"
+      },
+      "help": "순이익률 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "operating_margin": {
+      "label": "영업이익률",
+      "desc": "영업이익률 조건으로 종목을 필터링합니다.",
+      "params": {
+        "min_margin_pct": "최소 마진 %"
+      },
+      "help": "영업이익률 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "payout_ratio_filter": {
+      "label": "배당성향 필터",
+      "desc": "배당성향 필터 조건으로 종목을 필터링합니다.",
+      "params": {
+        "max_payout_pct": "최대 배당성향 %"
+      },
+      "help": "배당성향 필터 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "price_to_tangible_book": {
+      "label": "주가/유형순자산비율",
+      "desc": "주가/유형순자산비율 조건으로 종목을 필터링합니다.",
+      "params": {
+        "max_ratio": "최대 비율"
+      },
+      "help": "주가/유형순자산비율 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "quality_score": {
+      "label": "퀄리티 점수",
+      "desc": "퀄리티 점수 조건으로 종목을 필터링합니다.",
+      "params": {
+        "min_score": "최소 점수"
+      },
+      "help": "퀄리티 점수 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "receivables_turnover_ratio": {
+      "label": "매출채권회전율",
+      "desc": "매출채권회전율 조건으로 종목을 필터링합니다.",
+      "params": {
+        "min_ratio": "최소 비율"
+      },
+      "help": "매출채권회전율 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "revenue_cagr_3y": {
+      "label": "매출 3년 CAGR",
+      "desc": "매출 3년 CAGR 조건으로 종목을 필터링합니다.",
+      "params": {
+        "min_cagr_pct": "최소 CAGR %"
+      },
+      "help": "매출 3년 CAGR 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "revenue_growth_yoy": {
+      "label": "매출 전년 대비 성장률",
+      "desc": "매출 전년 대비 성장률 조건으로 종목을 필터링합니다.",
+      "params": {
+        "min_growth_pct": "최소 성장률 %"
+      },
+      "help": "매출 전년 대비 성장률 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "revenue_stability_score": {
+      "label": "매출 안정성 점수",
+      "desc": "매출 안정성 점수 조건으로 종목을 필터링합니다.",
+      "params": {
+        "lookback_years": "조회 연수",
+        "max_cv": "최대 변동계수"
+      },
+      "help": "매출 안정성 점수 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "shareholder_yield_filter": {
+      "label": "주주환원 수익률",
+      "desc": "주주환원 수익률 조건으로 종목을 필터링합니다.",
+      "params": {
+        "min_yield_pct": "최소 수익률 %"
+      },
+      "help": "주주환원 수익률 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "roce_filter": {
+      "label": "ROCE 필터",
+      "desc": "ROCE 필터 조건으로 종목을 필터링합니다.",
+      "params": {
+        "min_roce_pct": "최소 ROCE %"
+      },
+      "help": "ROCE 필터 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "roa_filter": {
+      "label": "ROA 필터",
+      "desc": "ROA 필터 조건으로 종목을 필터링합니다.",
+      "params": {
+        "min_roa_pct": "최소 ROA %"
+      },
+      "help": "ROA 필터 기준값을 만족하는 종목만 통과시킵니다."
     }
   },
   "settings": {

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -953,6 +953,264 @@
         "max_roic": "最大 ROIC %"
       },
       "help": "投入资本回报率——衡量公司使用全部资本的效率。"
+    },
+    "analyst_revision_1m": {
+      "label": "分析师预期1个月修正率",
+      "desc": "按分析师预期1个月修正率条件筛选股票。",
+      "params": {
+        "min_revision_pct": "最小修正率 %"
+      },
+      "help": "仅保留满足分析师预期1个月修正率阈值的股票。"
+    },
+    "analyst_revision_3m": {
+      "label": "分析师预期3个月修正率",
+      "desc": "按分析师预期3个月修正率条件筛选股票。",
+      "params": {
+        "min_revision_pct": "最小修正率 %"
+      },
+      "help": "仅保留满足分析师预期3个月修正率阈值的股票。"
+    },
+    "asset_turnover_ratio": {
+      "label": "总资产周转率",
+      "desc": "按总资产周转率条件筛选股票。",
+      "params": {
+        "min_ratio": "最小比率"
+      },
+      "help": "仅保留满足总资产周转率阈值的股票。"
+    },
+    "book_to_market_ratio": {
+      "label": "账面价值比率",
+      "desc": "按账面价值比率条件筛选股票。",
+      "params": {
+        "min_ratio": "最小比率"
+      },
+      "help": "仅保留满足账面价值比率阈值的股票。"
+    },
+    "buyback_yield_filter": {
+      "label": "回购收益率筛选",
+      "desc": "按回购收益率筛选条件筛选股票。",
+      "params": {
+        "min_yield_pct": "最小收益率 %"
+      },
+      "help": "仅保留满足回购收益率筛选阈值的股票。"
+    },
+    "cash_conversion_ratio": {
+      "label": "现金转换比率",
+      "desc": "按现金转换比率条件筛选股票。",
+      "params": {
+        "min_ratio": "最小比率"
+      },
+      "help": "仅保留满足现金转换比率阈值的股票。"
+    },
+    "cashflow_to_debt_ratio": {
+      "label": "现金流负债比",
+      "desc": "按现金流负债比条件筛选股票。",
+      "params": {
+        "min_ratio": "最小比率"
+      },
+      "help": "仅保留满足现金流负债比阈值的股票。"
+    },
+    "debt_service_coverage_ratio": {
+      "label": "偿债覆盖率",
+      "desc": "按偿债覆盖率条件筛选股票。",
+      "params": {
+        "min_ratio": "最小比率"
+      },
+      "help": "仅保留满足偿债覆盖率阈值的股票。"
+    },
+    "dividend_growth_5y": {
+      "label": "5年股息增长率",
+      "desc": "按5年股息增长率条件筛选股票。",
+      "params": {
+        "min_growth_pct": "最小增长率 %"
+      },
+      "help": "仅保留满足5年股息增长率阈值的股票。"
+    },
+    "earnings_stability_score": {
+      "label": "盈利稳定性评分",
+      "desc": "按盈利稳定性评分条件筛选股票。",
+      "params": {
+        "lookback_years": "回溯年数",
+        "max_cv": "最大变异系数"
+      },
+      "help": "仅保留满足盈利稳定性评分阈值的股票。"
+    },
+    "eps_cagr_3y": {
+      "label": "EPS 3年复合增长率",
+      "desc": "按EPS 3年复合增长率条件筛选股票。",
+      "params": {
+        "min_cagr_pct": "最小 CAGR %"
+      },
+      "help": "仅保留满足EPS 3年复合增长率阈值的股票。"
+    },
+    "eps_growth_yoy": {
+      "label": "EPS同比增长率",
+      "desc": "按EPS同比增长率条件筛选股票。",
+      "params": {
+        "min_growth_pct": "最小增长率 %"
+      },
+      "help": "仅保留满足EPS同比增长率阈值的股票。"
+    },
+    "ev_to_ebitda_ratio": {
+      "label": "EV/EBITDA比率",
+      "desc": "按EV/EBITDA比率条件筛选股票。",
+      "params": {
+        "max_ratio": "最大比率"
+      },
+      "help": "仅保留满足EV/EBITDA比率阈值的股票。"
+    },
+    "ev_to_sales_ratio": {
+      "label": "EV/销售比率",
+      "desc": "按EV/销售比率条件筛选股票。",
+      "params": {
+        "max_ratio": "最大比率"
+      },
+      "help": "仅保留满足EV/销售比率阈值的股票。"
+    },
+    "free_cash_flow_margin": {
+      "label": "自由现金流利润率",
+      "desc": "按自由现金流利润率条件筛选股票。",
+      "params": {
+        "min_margin_pct": "最小利润率 %"
+      },
+      "help": "仅保留满足自由现金流利润率阈值的股票。"
+    },
+    "gross_margin": {
+      "label": "毛利率",
+      "desc": "按毛利率条件筛选股票。",
+      "params": {
+        "min_margin_pct": "最小利润率 %"
+      },
+      "help": "仅保留满足毛利率阈值的股票。"
+    },
+    "gross_profitability": {
+      "label": "毛利盈利能力",
+      "desc": "按毛利盈利能力条件筛选股票。",
+      "params": {
+        "min_ratio": "最小比率"
+      },
+      "help": "仅保留满足毛利盈利能力阈值的股票。"
+    },
+    "interest_coverage_ratio": {
+      "label": "利息保障倍数",
+      "desc": "按利息保障倍数条件筛选股票。",
+      "params": {
+        "min_ratio": "最小比率"
+      },
+      "help": "仅保留满足利息保障倍数阈值的股票。"
+    },
+    "inventory_turnover_ratio": {
+      "label": "存货周转率",
+      "desc": "按存货周转率条件筛选股票。",
+      "params": {
+        "min_ratio": "最小比率"
+      },
+      "help": "仅保留满足存货周转率阈值的股票。"
+    },
+    "net_debt_to_ebitda": {
+      "label": "净债务/EBITDA",
+      "desc": "按净债务/EBITDA条件筛选股票。",
+      "params": {
+        "max_ratio": "最大比率"
+      },
+      "help": "仅保留满足净债务/EBITDA阈值的股票。"
+    },
+    "net_margin": {
+      "label": "净利率",
+      "desc": "按净利率条件筛选股票。",
+      "params": {
+        "min_margin_pct": "最小利润率 %"
+      },
+      "help": "仅保留满足净利率阈值的股票。"
+    },
+    "operating_margin": {
+      "label": "营业利润率",
+      "desc": "按营业利润率条件筛选股票。",
+      "params": {
+        "min_margin_pct": "最小利润率 %"
+      },
+      "help": "仅保留满足营业利润率阈值的股票。"
+    },
+    "payout_ratio_filter": {
+      "label": "派息率筛选",
+      "desc": "按派息率筛选条件筛选股票。",
+      "params": {
+        "max_payout_pct": "最大派息率 %"
+      },
+      "help": "仅保留满足派息率筛选阈值的股票。"
+    },
+    "price_to_tangible_book": {
+      "label": "市价/有形账面价值比",
+      "desc": "按市价/有形账面价值比条件筛选股票。",
+      "params": {
+        "max_ratio": "最大比率"
+      },
+      "help": "仅保留满足市价/有形账面价值比阈值的股票。"
+    },
+    "quality_score": {
+      "label": "质量评分",
+      "desc": "按质量评分条件筛选股票。",
+      "params": {
+        "min_score": "最小评分"
+      },
+      "help": "仅保留满足质量评分阈值的股票。"
+    },
+    "receivables_turnover_ratio": {
+      "label": "应收账款周转率",
+      "desc": "按应收账款周转率条件筛选股票。",
+      "params": {
+        "min_ratio": "最小比率"
+      },
+      "help": "仅保留满足应收账款周转率阈值的股票。"
+    },
+    "revenue_cagr_3y": {
+      "label": "营收3年复合增长率",
+      "desc": "按营收3年复合增长率条件筛选股票。",
+      "params": {
+        "min_cagr_pct": "最小 CAGR %"
+      },
+      "help": "仅保留满足营收3年复合增长率阈值的股票。"
+    },
+    "revenue_growth_yoy": {
+      "label": "营收同比增长率",
+      "desc": "按营收同比增长率条件筛选股票。",
+      "params": {
+        "min_growth_pct": "最小增长率 %"
+      },
+      "help": "仅保留满足营收同比增长率阈值的股票。"
+    },
+    "revenue_stability_score": {
+      "label": "营收稳定性评分",
+      "desc": "按营收稳定性评分条件筛选股票。",
+      "params": {
+        "lookback_years": "回溯年数",
+        "max_cv": "最大变异系数"
+      },
+      "help": "仅保留满足营收稳定性评分阈值的股票。"
+    },
+    "shareholder_yield_filter": {
+      "label": "股东收益率筛选",
+      "desc": "按股东收益率筛选条件筛选股票。",
+      "params": {
+        "min_yield_pct": "最小收益率 %"
+      },
+      "help": "仅保留满足股东收益率筛选阈值的股票。"
+    },
+    "roce_filter": {
+      "label": "ROCE筛选",
+      "desc": "按ROCE筛选条件筛选股票。",
+      "params": {
+        "min_roce_pct": "最小 ROCE %"
+      },
+      "help": "仅保留满足ROCE筛选阈值的股票。"
+    },
+    "roa_filter": {
+      "label": "ROA筛选",
+      "desc": "按ROA筛选条件筛选股票。",
+      "params": {
+        "min_roa_pct": "最小 ROA %"
+      },
+      "help": "仅保留满足ROA筛选阈值的股票。"
     }
   },
   "settings": {

--- a/web/src/components/strategy/NodePalette.tsx
+++ b/web/src/components/strategy/NodePalette.tsx
@@ -224,7 +224,7 @@ export default function NodePalette({ nodeCount }: NodePaletteProps) {
           {isLoading ? (
             <div className="flex items-center justify-center py-8 text-gray-400">
               <Loader2 className="h-4 w-4 animate-spin mr-2" />
-              <span className="text-xs">Loading conditions...</span>
+              <span className="text-xs">{t('loadingConditions')}</span>
             </div>
           ) : (
             categories.map((category) => {


### PR DESCRIPTION
## Summary
- replace hardcoded filter-node loading copy with `strategy.loadingConditions`
- add missing `conditions.*` translations for en/ko/zh used by strategy filter nodes
- eliminate English fallback for the reported condition keys in non-English locales

## Test plan
- [x] `npm --prefix web run lint` (existing warnings only)
- [x] `npm --prefix web run build`

## Manual QA checklist
- [x] KO locale: filter list labels render in Korean (no English fallback for covered keys)
- [x] KO locale: condition detail panel (`desc/help/params`) renders translated strings
- [x] EN/KO/ZH locale message keys stay in sync for `conditions.*`
- [x] loading copy in node palette uses i18n key (no hardcoded English)

Closes #474

🤖 Generated with [Claude Code](https://claude.com/claude-code)