### PR TITLE
feat(api): add multi-market performance guardrails and metrics

### DIFF
--- a/api/services/screening_service.py
+++ b/api/services/screening_service.py
@@ -36,6 +36,8 @@ class ScreeningService:
     _universe_count_cache: Dict[str, tuple] = {}
     _universe_combo_count_cache: Dict[str, tuple] = {}
     _UNIVERSE_COUNT_TTL = 3600  # 1 hour
+    WARN_TICKERS_THRESHOLD = 2500
+    MAX_TICKERS_PER_RUN = 4000
 
     # Universe definitions
     UNIVERSES = {
@@ -412,10 +414,12 @@ class ScreeningService:
         Returns:
             Dict with results, total_count, matched_count, and resolved universes
         """
+        started_at = time.perf_counter()
         conditions = self._resolve_conditions(preset, params)
 
         requested_universes: Any = universes if universes is not None else universe
 
+        resolve_started_at = time.perf_counter()
         try:
             symbols_dict, resolved_universes, failed_errors = self._get_symbols_for_universes(
                 universe_input=requested_universes,
@@ -429,8 +433,23 @@ class ScreeningService:
                 details = ", ".join(f"{k}: {v}" for k, v in failed_errors.items())
                 raise ValueError(f"Failed to fetch all universes ({details})")
             raise ValueError("No tickers available for screening")
+        resolve_elapsed_ms = (time.perf_counter() - resolve_started_at) * 1000.0
 
         tickers = list(symbols_dict.keys())
+        total_count = len(tickers)
+        failed_count = len(failed_errors)
+        failure_rate = (failed_count / len(resolved_universes)) if resolved_universes else 0.0
+
+        if total_count > self.WARN_TICKERS_THRESHOLD:
+            logger.warning(
+                "screening.guardrail warning: universe_size=%d exceeds warn threshold=%d",
+                total_count,
+                self.WARN_TICKERS_THRESHOLD,
+            )
+        if total_count > self.MAX_TICKERS_PER_RUN:
+            raise ValueError(
+                f"Target universe too large ({total_count}). Maximum allowed per run is {self.MAX_TICKERS_PER_RUN}"
+            )
 
         # Create screener with pre-fetched stock names
         screener = StockScreener(
@@ -441,12 +460,13 @@ class ScreeningService:
             stock_names=symbols_dict,
         )
 
-        total_count = len(tickers)
-
         # Run screening (show_progress=False for API)
+        run_started_at = time.perf_counter()
         results = screener.run(tickers=tickers, show_progress=False)
+        run_elapsed_ms = (time.perf_counter() - run_started_at) * 1000.0
 
         # Convert to response format
+        convert_started_at = time.perf_counter()
         result_items = []
         for result in results:
             conditions_list = [
@@ -465,6 +485,26 @@ class ScreeningService:
                 matched=result.matched,
                 conditions=conditions_list
             ))
+        convert_elapsed_ms = (time.perf_counter() - convert_started_at) * 1000.0
+        total_elapsed_ms = (time.perf_counter() - started_at) * 1000.0
+
+        eval_throughput = (total_count / run_elapsed_ms * 1000.0) if run_elapsed_ms > 0 else float(total_count)
+        logger.info(
+            (
+                "screening.metrics universes=%s total_tickers=%d matched=%d "
+                "resolve_ms=%.1f run_ms=%.1f convert_ms=%.1f total_ms=%.1f "
+                "eval_tps=%.2f failed_universe_rate=%.2f"
+            ),
+            ",".join(resolved_universes),
+            total_count,
+            len(result_items),
+            resolve_elapsed_ms,
+            run_elapsed_ms,
+            convert_elapsed_ms,
+            total_elapsed_ms,
+            eval_throughput,
+            failure_rate,
+        )
 
         return {
             "results": result_items,

--- a/api/services/strategy_service.py
+++ b/api/services/strategy_service.py
@@ -6,6 +6,7 @@ Converts graph representations into screener conditions and executes them.
 """
 
 import logging
+import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timedelta
 from typing import Any, Callable, Dict, List, Optional, Type
@@ -31,6 +32,8 @@ logger = logging.getLogger(__name__)
 
 FUNDAMENTAL_TTL_SECONDS = 24 * 60 * 60
 _fundamental_cache = FundamentalCache()
+WARN_TICKERS_THRESHOLD = 2500
+MAX_TICKERS_PER_RUN = 4000
 
 # Auto-populated from @register_condition decorators
 CONDITION_CLASS_MAP: Dict[str, Type[BaseCondition]] = get_condition_class_map()
@@ -827,6 +830,8 @@ def execute_strategy(
     Returns:
         Dict with results, counts, universe, conditions used, and node_results
     """
+    started_at = time.perf_counter()
+
     # Validate sector nodes early (only 1 allowed, must be connected)
     sector_nodes = [n for n in graph.nodes if n.data.node_type == "sector"]
     if len(sector_nodes) > 1:
@@ -859,17 +864,33 @@ def execute_strategy(
         raise ValueError("No conditions found in graph")
 
     screening_service = ScreeningService()
+    resolve_started_at = time.perf_counter()
     resolved_universes, primary_universe = _resolve_execution_universes(
         graph=graph,
         screening_service=screening_service,
         universe_override=universe_override,
         universe_overrides=universe_overrides,
     )
+    resolve_elapsed_ms = (time.perf_counter() - resolve_started_at) * 1000.0
+
+    fetch_started_at = time.perf_counter()
     tickers = screening_service.get_tickers_for_universes(
         universe_input=resolved_universes,
         fail_fast=False,
     )
+    fetch_elapsed_ms = (time.perf_counter() - fetch_started_at) * 1000.0
     total_count = len(tickers)
+
+    if total_count > WARN_TICKERS_THRESHOLD:
+        logger.warning(
+            "strategy.guardrail warning: universe_size=%d exceeds warn threshold=%d",
+            total_count,
+            WARN_TICKERS_THRESHOLD,
+        )
+    if total_count > MAX_TICKERS_PER_RUN:
+        raise ValueError(
+            f"Target universe too large ({total_count}). Maximum allowed per run is {MAX_TICKERS_PER_RUN}"
+        )
 
     # Apply sector filtering (already validated above)
     if sector_nodes:
@@ -906,12 +927,14 @@ def execute_strategy(
         use_cache=True,
     )
 
+    eval_started_at = time.perf_counter()
     all_results = screener.run(
         tickers=tickers,
         show_progress=False,
         return_all=True,
         progress_callback=progress_callback,
     )
+    eval_elapsed_ms = (time.perf_counter() - eval_started_at) * 1000.0
 
     # Rebuild graph structures for survivor computation
     nodes_by_id: Dict[str, StrategyNode] = {n.id: n for n in graph.nodes}
@@ -996,6 +1019,24 @@ def execute_strategy(
         enrich_fundamentals(final_items)
 
     conditions_used = [type(c).__name__ for c in leaf_conditions]
+
+    total_elapsed_ms = (time.perf_counter() - started_at) * 1000.0
+    eval_throughput = (len(tickers) / eval_elapsed_ms * 1000.0) if eval_elapsed_ms > 0 else float(len(tickers))
+    logger.info(
+        (
+            "strategy.metrics universes=%s total_tickers=%d screened=%d matched=%d "
+            "resolve_ms=%.1f fetch_ms=%.1f eval_ms=%.1f total_ms=%.1f eval_tps=%.2f"
+        ),
+        ",".join(resolved_universes),
+        total_count,
+        len(tickers),
+        len(final_items),
+        resolve_elapsed_ms,
+        fetch_elapsed_ms,
+        eval_elapsed_ms,
+        total_elapsed_ms,
+        eval_throughput,
+    )
 
     return {
         "results": final_items,

--- a/api/tests/test_screening_service.py
+++ b/api/tests/test_screening_service.py
@@ -124,3 +124,22 @@ class TestRunScreening:
                 universes=["KOSPI"],
                 params=None,
             )
+
+    def test_run_screening_guardrail_rejects_oversized_universe(self, monkeypatch):
+        service = ScreeningService()
+        monkeypatch.setattr(service, "_resolve_conditions", lambda preset, params: [object()])
+
+        oversized_symbols = {f"T{i:04d}": f"Name{i}" for i in range(service.MAX_TICKERS_PER_RUN + 1)}
+        monkeypatch.setattr(
+            service,
+            "_get_symbols_for_universes",
+            lambda universe_input, fail_fast=False: (oversized_symbols, ["KOSPI"], {}),
+        )
+
+        with pytest.raises(ValueError, match="Target universe too large"):
+            service.run_screening(
+                preset="accumulation_basic",
+                universe="KOSPI",
+                universes=["KOSPI"],
+                params=None,
+            )

--- a/api/tests/test_strategy_service.py
+++ b/api/tests/test_strategy_service.py
@@ -498,6 +498,27 @@ class TestExecuteStrategyMultiUniverse:
         assert result["total_count"] == 2
         assert result["screened_count"] == 2
 
+    def test_execute_strategy_guardrail_rejects_oversized_universe(self, monkeypatch):
+        graph = self._make_graph(
+            nodes=[
+                {"id": "c1", "data": {"node_type": "condition", "condition_type": "min_price", "params": {"min_price": 10}}},
+                {"id": "o1", "data": {"node_type": "output"}},
+            ],
+            edges=[{"id": "e1", "source": "c1", "target": "o1"}],
+        )
+
+        oversized = [f"T{i:04d}" for i in range(4001)]
+        monkeypatch.setattr(
+            "api.services.strategy_service.ScreeningService.get_tickers_for_universes",
+            lambda self, universe_input, fail_fast=False: oversized,
+        )
+
+        with pytest.raises(ValueError, match="Target universe too large"):
+            execute_strategy(
+                graph=graph,
+                universe_overrides=["KOSPI", "KOSDAQ"],
+            )
+
 
 class TestExecuteStrategySectorPolicy:
     """Test sector behavior under mixed multi-market execution."""


### PR DESCRIPTION
## Summary
- Add performance guardrails for oversized multi-market runs in screening and strategy execution paths.
- Add stage-level observability logs (resolve/fetch/eval/convert/total timing and throughput).
- Add regression tests ensuring oversized ticker targets are blocked with clear errors.

## Changes
- `api/services/screening_service.py`
  - Added run guardrails (`WARN_TICKERS_THRESHOLD`, `MAX_TICKERS_PER_RUN`).
  - Added stage metrics logging and failure-rate logging for universe fetches.
  - Added fail-fast validation when ticker target exceeds max threshold.
- `api/services/strategy_service.py`
  - Added matching guardrails and stage metrics for strategy execution.
  - Added evaluation throughput logging.
- `api/tests/test_screening_service.py`
  - Added oversized universe guardrail test.
- `api/tests/test_strategy_service.py`
  - Added oversized strategy execution guardrail test.

## Test Plan
- [x] `venv/bin/python -m pytest -q api/tests/test_screening_service.py api/tests/test_strategy.py`
- [x] `venv/bin/python -m pytest -q api/tests/test_strategy_service.py -k \"TestExecuteStrategyMultiUniverse or TestExecuteStrategySectorPolicy or universe_node_multi_input_keeps_primary_for_compatibility\"`
- [ ] Full backend suite in CI

Closes #465

🤖 Generated with [Claude Code](https://claude.com/claude-code)