### PR TITLE
feat(pipeline): support multi-market inputs in CLI scripts

### DIFF
--- a/scripts/analysis/run_daily_analysis.py
+++ b/scripts/analysis/run_daily_analysis.py
@@ -16,6 +16,8 @@ Usage:
     # Single market
     python scripts/analysis/run_daily_analysis.py --market KOSPI
     python scripts/analysis/run_daily_analysis.py --market SP500
+    python scripts/analysis/run_daily_analysis.py --market KOSPI,SP500
+    python scripts/analysis/run_daily_analysis.py --markets KOSPI --markets SP500
 
     # Skip Claude analysis (enrichment only)
     python scripts/analysis/run_daily_analysis.py --enrich-only
@@ -59,6 +61,36 @@ logging.basicConfig(
     format='%(asctime)s - %(levelname)s - %(message)s'
 )
 logger = logging.getLogger(__name__)
+
+
+def parse_market_inputs(market: str, markets: Optional[List[str]] = None) -> List[str]:
+    """Parse single/csv/repeated market inputs with stable dedupe."""
+    tokens: List[str] = []
+    values = list(markets or [])
+    if market:
+        values.append(market)
+
+    for value in values:
+        for item in value.split(","):
+            token = item.strip().upper()
+            if token:
+                tokens.append(token)
+
+    normalized: List[str] = []
+    seen = set()
+    for token in tokens or ["ALL"]:
+        if token == "ALL":
+            for expanded in ("KOSPI", "SP500"):
+                if expanded not in seen:
+                    normalized.append(expanded)
+                    seen.add(expanded)
+            continue
+        if token not in ("KOSPI", "SP500"):
+            raise ValueError(f"Unsupported market: {token}")
+        if token not in seen:
+            normalized.append(token)
+            seen.add(token)
+    return normalized
 
 
 def screen_ma_touch(market: str, ma_period: int = 240, threshold: float = 0.02) -> List[Dict]:
@@ -342,6 +374,7 @@ def generate_report(
 
 def run_pipeline(
     market: str = "ALL",
+    markets: Optional[List[str]] = None,
     capital: float = 10000000,
     enrich_only: bool = False,
     claude_code: bool = False,
@@ -352,7 +385,8 @@ def run_pipeline(
     Run the full analysis pipeline.
 
     Args:
-        market: Market to analyze (ALL, KOSPI, SP500)
+        market: Market to analyze (single/csv, backward-compatible)
+        markets: Repeated market flags
         capital: Total capital for position sizing
         enrich_only: Only run screening and enrichment
         claude_code: Save JSON for Claude Code analysis instead of API
@@ -364,20 +398,19 @@ def run_pipeline(
     print("#" + "Daily Stock Analysis Pipeline".center(58) + "#")
     print("#" + " " * 58 + "#")
     print("#" * 60)
+    selected_markets = parse_market_inputs(market, markets)
+    market_tag = "_".join(selected_markets)
+
     print(f"\nDate: {datetime.now().strftime('%Y-%m-%d %H:%M')}")
-    print(f"Market: {market}")
+    print(f"Market: {', '.join(selected_markets)}")
     print(f"Capital: {capital:,.0f}")
 
     # 1. Screening
     candidates = []
 
-    if market in ['ALL', 'KOSPI']:
-        kospi_candidates = screen_ma_touch('KOSPI', ma_period, threshold)
-        candidates.extend(kospi_candidates)
-
-    if market in ['ALL', 'SP500']:
-        sp500_candidates = screen_ma_touch('SP500', ma_period, threshold)
-        candidates.extend(sp500_candidates)
+    for selected_market in selected_markets:
+        market_candidates = screen_ma_touch(selected_market, ma_period, threshold)
+        candidates.extend(market_candidates)
 
     if not candidates:
         print("\nNo candidates found. Exiting.")
@@ -389,7 +422,7 @@ def run_pipeline(
     enriched = enrich_stocks(candidates)
 
     # Save enriched data to JSON
-    json_path = save_enriched_json(enriched, market)
+    json_path = save_enriched_json(enriched, market_tag)
 
     if enrich_only:
         print("\n--enrich-only flag set. Skipping analysis.")
@@ -421,7 +454,7 @@ def run_pipeline(
         return enriched
 
     # 4. Report Generation
-    report = generate_report(results, capital, market)
+    report = generate_report(results, capital, market_tag)
 
     print("\n" + "=" * 60)
     print(" Pipeline Complete")
@@ -438,8 +471,13 @@ def main():
         '--market', '-m',
         type=str,
         default='ALL',
-        choices=['ALL', 'KOSPI', 'SP500'],
-        help='Market to analyze (default: ALL)'
+        help='Market single/CSV (ALL/KOSPI/SP500, default: ALL)'
+    )
+    parser.add_argument(
+        '--markets',
+        action='append',
+        default=[],
+        help='Repeated market flags (example: --markets KOSPI --markets SP500)'
     )
     parser.add_argument(
         '--capital', '-c',
@@ -474,6 +512,7 @@ def main():
 
     run_pipeline(
         market=args.market,
+        markets=args.markets,
         capital=args.capital,
         enrich_only=args.enrich_only,
         claude_code=args.claude_code,

--- a/scripts/cache_manager.py
+++ b/scripts/cache_manager.py
@@ -9,6 +9,8 @@ Usage:
 
     # KOSPI 전체 종목 프리페치
     python scripts/cache_manager.py prefetch --universe KOSPI
+    python scripts/cache_manager.py prefetch --universe KOSPI,KOSDAQ
+    python scripts/cache_manager.py prefetch --universes KOSPI --universes KOSDAQ
 
     # 특정 종목 갱신
     python scripts/cache_manager.py refresh --ticker 005930.KS
@@ -26,8 +28,56 @@ project_root = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(project_root))
 
 import argparse
+from typing import List
 from utils.data_cache import OHLCVCache, get_cache
 from screener.kospi_fetcher import KospiListFetcher
+
+
+def parse_universe_inputs(universe: str, universes: List[str] | None = None) -> List[str]:
+    """Parse single/csv/repeated universe inputs with stable dedupe."""
+    tokens: List[str] = []
+    values = list(universes or [])
+    if universe:
+        values.append(universe)
+    for value in values:
+        for item in value.split(","):
+            token = item.strip().upper()
+            if token:
+                tokens.append(token)
+
+    resolved: List[str] = []
+    seen = set()
+    for token in tokens or ["KOSPI"]:
+        if token not in seen:
+            resolved.append(token)
+            seen.add(token)
+    return resolved
+
+
+def resolve_symbols(fetcher: KospiListFetcher, universe: str, universes: List[str] | None = None):
+    """Resolve multi-universe inputs to merged symbol list."""
+    resolved = parse_universe_inputs(universe, universes)
+    merged = []
+    seen = set()
+
+    for selected in resolved:
+        if selected == "KOSPI":
+            symbols = fetcher.get_kospi_symbols()
+        elif selected == "KOSDAQ":
+            symbols = fetcher.get_kosdaq_symbols()
+        elif selected == "ALL":
+            symbols = fetcher.get_kospi_symbols() + fetcher.get_kosdaq_symbols()
+        else:
+            raise ValueError(f"Unknown universe: {selected}")
+
+        for row in symbols:
+            ticker = row["symbol"]
+            if ticker in seen:
+                continue
+            seen.add(ticker)
+            merged.append(row)
+
+    return resolved, merged
 
 
 def cmd_status(args):
@@ -41,16 +91,10 @@ def cmd_prefetch(args):
     cache = get_cache()
     fetcher = KospiListFetcher()
 
-    # 유니버스 종목 가져오기
-    universe = args.universe.upper()
-    if universe == "KOSPI":
-        symbols = fetcher.get_kospi_symbols()
-    elif universe == "KOSDAQ":
-        symbols = fetcher.get_kosdaq_symbols()
-    elif universe == "ALL":
-        symbols = fetcher.get_kospi_symbols() + fetcher.get_kosdaq_symbols()
-    else:
-        print(f"Unknown universe: {universe}")
+    try:
+        resolved_universes, symbols = resolve_symbols(fetcher, args.universe, args.universes)
+    except ValueError as e:
+        print(str(e))
         return
 
     tickers = [s['symbol'] for s in symbols]
@@ -58,7 +102,7 @@ def cmd_prefetch(args):
     print(f"\n{'='*60}")
     print(f"  OHLCV Data Prefetch")
     print(f"{'='*60}")
-    print(f"  유니버스: {universe}")
+    print(f"  유니버스: {', '.join(resolved_universes)}")
     print(f"  종목 수: {len(tickers)}")
     print(f"  캐시 기간: {args.days}일")
     print(f"{'='*60}\n")
@@ -88,20 +132,18 @@ def cmd_refresh(args):
     else:
         # 전체 갱신
         fetcher = KospiListFetcher()
-        universe = args.universe.upper()
-
-        if universe == "KOSPI":
-            symbols = fetcher.get_kospi_symbols()
-        elif universe == "KOSDAQ":
-            symbols = fetcher.get_kosdaq_symbols()
-        else:
-            symbols = fetcher.get_kospi_symbols() + fetcher.get_kosdaq_symbols()
+        try:
+            resolved_universes, symbols = resolve_symbols(fetcher, args.universe, args.universes)
+        except ValueError as e:
+            print(str(e))
+            return
 
         tickers = [s['symbol'] for s in symbols]
 
         print(f"\n{'='*60}")
         print(f"  캐시 전체 갱신")
         print(f"{'='*60}")
+        print(f"  유니버스: {', '.join(resolved_universes)}")
         print(f"  종목 수: {len(tickers)}")
         print(f"{'='*60}\n")
 
@@ -169,7 +211,11 @@ def main():
     parser_prefetch = subparsers.add_parser('prefetch', help='데이터 프리페치')
     parser_prefetch.add_argument(
         '--universe', type=str, default='KOSPI',
-        help='유니버스 (KOSPI/KOSDAQ/ALL)'
+        help='유니버스 단일/CSV (KOSPI/KOSDAQ/ALL)'
+    )
+    parser_prefetch.add_argument(
+        '--universes', action='append', default=[],
+        help='유니버스 반복 지정 (예: --universes KOSPI --universes KOSDAQ)'
     )
     parser_prefetch.add_argument(
         '--days', type=int, default=365,
@@ -185,7 +231,11 @@ def main():
     )
     parser_refresh.add_argument(
         '--universe', type=str, default='KOSPI',
-        help='전체 갱신 시 유니버스'
+        help='전체 갱신 시 유니버스 단일/CSV'
+    )
+    parser_refresh.add_argument(
+        '--universes', action='append', default=[],
+        help='전체 갱신 시 유니버스 반복 지정'
     )
     parser_refresh.set_defaults(func=cmd_refresh)
 

--- a/scripts/screening/accumulation_screen.py
+++ b/scripts/screening/accumulation_screen.py
@@ -48,6 +48,10 @@ Usage:
     # 유니버스 지정
     python scripts/screening/accumulation_screen.py --preset accumulation_basic --universe KOSDAQ
 
+    # 다중 유니버스 지정
+    python scripts/screening/accumulation_screen.py --preset accumulation_basic --universe KOSPI,KOSDAQ
+    python scripts/screening/accumulation_screen.py --preset accumulation_basic --universes KOSPI --universes KOSDAQ
+
 커스텀 파라미터:
     --bb-width 8.0     볼린저밴드 폭 8% 이하 (더 수축된 종목)
     --volume-mult 0.7  평균의 70% 이하 거래량 (더 조용한 종목)
@@ -63,6 +67,7 @@ project_root = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(project_root))
 
 import argparse
+from typing import List
 from screener import (
     StockScreener,
     get_preset,
@@ -80,16 +85,39 @@ from screener import (
 )
 
 
+def parse_universe_inputs(universe: str, universes: List[str] | None = None) -> List[str]:
+    """Parse single/csv/repeated universe inputs with stable dedupe."""
+    tokens: List[str] = []
+    values = list(universes or [])
+    if universe:
+        values.append(universe)
+    for value in values:
+        for item in value.split(","):
+            token = item.strip().upper()
+            if token:
+                tokens.append(token)
+
+    resolved: List[str] = []
+    seen = set()
+    for token in tokens or ["KOSPI"]:
+        if token not in seen:
+            resolved.append(token)
+            seen.add(token)
+    return resolved
+
+
 def run_preset(
     preset_name: str,
     universe: str = "KOSPI",
+    universes: List[str] | None = None,
     **kwargs
 ):
     """프리셋으로 스크리닝 실행"""
+    resolved_universes = parse_universe_inputs(universe, universes)
     print(f"\n{'='*60}")
     print(f"  Quiet Accumulation Zone Screening")
     print(f"  Preset: {preset_name}")
-    print(f"  Universe: {universe}")
+    print(f"  Universe: {', '.join(resolved_universes)}")
     print(f"{'='*60}\n")
 
     conditions = get_preset(preset_name, **kwargs)
@@ -99,8 +127,17 @@ def run_preset(
         print(f"  - {c}")
     print()
 
-    screener = StockScreener(conditions=conditions)
-    results = screener.run(universe=universe)
+    merged = []
+    seen_tickers = set()
+    for selected_universe in resolved_universes:
+        screener = StockScreener(conditions=conditions)
+        results = screener.run(universe=selected_universe)
+        for result in results:
+            if result.ticker in seen_tickers:
+                continue
+            seen_tickers.add(result.ticker)
+            merged.append(result)
+    results = merged
 
     if results:
         print(f"\nMatched Stocks ({len(results)}):\n")
@@ -218,7 +255,11 @@ Examples:
     )
     parser.add_argument(
         "--universe", type=str, default="KOSPI",
-        help="Universe (KOSPI/KOSDAQ/ALL, default: KOSPI)"
+        help="Universe single/CSV (default: KOSPI, example: KOSPI,KOSDAQ)"
+    )
+    parser.add_argument(
+        "--universes", action="append", default=[],
+        help="Universe repeated flags (example: --universes KOSPI --universes KOSDAQ)"
     )
     parser.add_argument(
         "--custom", action="store_true",
@@ -272,7 +313,7 @@ Examples:
     elif args.ticker:
         run_single_stock(args.ticker, args.preset, **preset_kwargs)
     else:
-        run_preset(args.preset, args.universe, **preset_kwargs)
+        run_preset(args.preset, args.universe, args.universes, **preset_kwargs)
 
 
 if __name__ == "__main__":

--- a/scripts/screening/run_screener.py
+++ b/scripts/screening/run_screener.py
@@ -11,6 +11,10 @@ Usage:
 
     # 커스텀 조건 (코드로)
     python scripts/screening/run_screener.py --custom
+
+    # 다중 유니버스
+    python scripts/screening/run_screener.py --preset ma_touch_160 --universe KOSPI,KOSDAQ
+    python scripts/screening/run_screener.py --preset ma_touch_160 --universes KOSPI --universes KOSDAQ
 """
 
 import sys
@@ -21,6 +25,7 @@ project_root = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(project_root))
 
 import argparse
+from typing import List
 from screener import (
     StockScreener,
     get_preset,
@@ -34,13 +39,45 @@ from screener import (
 )
 
 
-def run_preset(preset_name: str, universe: str = "KOSPI"):
+def parse_universe_inputs(universe: str, universes: List[str] | None = None) -> List[str]:
+    """Parse single/csv/repeated universe inputs with stable dedupe."""
+    tokens: List[str] = []
+    values = list(universes or [])
+    if universe:
+        values.append(universe)
+    for value in values:
+        for item in value.split(","):
+            token = item.strip().upper()
+            if token:
+                tokens.append(token)
+
+    resolved: List[str] = []
+    seen = set()
+    for token in tokens or ["KOSPI"]:
+        if token not in seen:
+            resolved.append(token)
+            seen.add(token)
+    return resolved
+
+
+def run_preset(preset_name: str, universe: str = "KOSPI", universes: List[str] | None = None):
     """프리셋으로 스크리닝 실행"""
+    resolved_universes = parse_universe_inputs(universe, universes)
     print(f"\n🎯 프리셋 '{preset_name}' 실행")
+    print(f"   Universes: {', '.join(resolved_universes)}")
 
     conditions = get_preset(preset_name)
-    screener = StockScreener(conditions=conditions)
-    results = screener.run(universe=universe)
+    merged = []
+    seen_tickers = set()
+    for selected_universe in resolved_universes:
+        screener = StockScreener(conditions=conditions)
+        results = screener.run(universe=selected_universe)
+        for result in results:
+            if result.ticker in seen_tickers:
+                continue
+            seen_tickers.add(result.ticker)
+            merged.append(result)
+    results = merged
 
     if results:
         print(f"\n📋 매칭 종목 ({len(results)}개):")
@@ -117,7 +154,8 @@ def main():
     parser.add_argument("--list-presets", action="store_true", help="프리셋 목록 표시")
     parser.add_argument("--custom", action="store_true", help="커스텀 조건 예제 실행")
     parser.add_argument("--ticker", type=str, help="단일 종목 검사 (예: 035420.KS)")
-    parser.add_argument("--universe", type=str, default="KOSPI", help="유니버스 (KOSPI/KOSDAQ/ALL)")
+    parser.add_argument("--universe", type=str, default="KOSPI", help="유니버스 단일/CSV (예: KOSPI,KOSDAQ)")
+    parser.add_argument("--universes", action="append", default=[], help="유니버스 반복 지정 (예: --universes KOSPI --universes KOSDAQ)")
 
     args = parser.parse_args()
 
@@ -128,14 +166,14 @@ def main():
         return
 
     if args.preset:
-        run_preset(args.preset, args.universe)
+        run_preset(args.preset, args.universe, args.universes)
     elif args.custom:
         run_custom_example()
     elif args.ticker:
         run_single_stock(args.ticker)
     else:
         # 기본: 160일선 터치 프리셋
-        run_preset("ma_touch_160", args.universe)
+        run_preset("ma_touch_160", args.universe, args.universes)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli_multi_market_inputs.py
+++ b/tests/test_cli_multi_market_inputs.py
@@ -1,0 +1,34 @@
+"""Smoke tests for multi-market CLI input parsers."""
+
+from scripts.analysis.run_daily_analysis import parse_market_inputs
+from scripts.cache_manager import parse_universe_inputs as parse_cache_universes
+from scripts.screening.accumulation_screen import parse_universe_inputs as parse_accum_universes
+from scripts.screening.run_screener import parse_universe_inputs as parse_screener_universes
+
+
+def test_screener_parser_supports_csv_and_repeated_flags():
+    resolved = parse_screener_universes("KOSPI,KOSDAQ", ["SP500"])
+    assert resolved == ["SP500", "KOSPI", "KOSDAQ"]
+
+
+def test_accumulation_parser_defaults_to_kospi():
+    resolved = parse_accum_universes("", [])
+    assert resolved == ["KOSPI"]
+
+
+def test_cache_parser_deduplicates_stably():
+    resolved = parse_cache_universes("KOSPI", ["KOSDAQ", "KOSPI,KOSDAQ"])
+    assert resolved == ["KOSDAQ", "KOSPI"]
+
+
+def test_daily_analysis_market_parser_expands_all():
+    resolved = parse_market_inputs("ALL", [])
+    assert resolved == ["KOSPI", "SP500"]
+
+
+def test_daily_analysis_market_parser_rejects_invalid():
+    try:
+        parse_market_inputs("NASDAQ100", [])
+        assert False, "expected ValueError for unsupported market"
+    except ValueError as exc:
+        assert "Unsupported market" in str(exc)


### PR DESCRIPTION
## Summary
- Add consistent multi-market input support for screening/batch scripts using both CSV and repeated flags.
- Preserve backward compatibility for existing single `--universe` / `--market` invocations.
- Add smoke tests to validate parser semantics and invalid input handling.

## Changes
- `scripts/screening/run_screener.py`
  - Added `parse_universe_inputs(...)`
  - Added `--universes` repeated flag and CSV parsing for `--universe`
  - Multi-universe execution merges results with stable ticker dedupe
- `scripts/screening/accumulation_screen.py`
  - Added same universe parsing and repeated flag support
  - Multi-universe execution merges results with stable ticker dedupe
- `scripts/cache_manager.py`
  - Added multi-universe parsing helpers
  - Extended `prefetch`/`refresh` to support repeated + CSV universes
  - Added merged symbol resolution with stable dedupe
- `scripts/analysis/run_daily_analysis.py`
  - Added `parse_market_inputs(...)`
  - Added `--markets` repeated flag and CSV parsing for `--market`
  - Unified multi-market loop execution and output tagging
- `tests/test_cli_multi_market_inputs.py`
  - Added smoke tests for parser behavior and unsupported market rejection

## Test Plan
- [x] `venv/bin/python -m pytest -q tests/test_cli_multi_market_inputs.py`
- [x] `venv/bin/python -m py_compile scripts/screening/run_screener.py scripts/screening/accumulation_screen.py scripts/cache_manager.py scripts/analysis/run_daily_analysis.py`
- [ ] End-to-end script smoke run in CI or dev environment

Closes #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)