### PR TITLE
fix: close strategy condition i18n gaps with CI contract check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,3 +32,6 @@ jobs:
 
       - name: Run ESLint
         run: npm run lint
+
+      - name: Verify condition i18n contract
+        run: npm run check:condition-i18n

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1212,6 +1212,722 @@
         "min_roa_pct": "Minimum ROA %"
       },
       "help": "Filters stocks based on ROA Filter threshold settings."
+    },
+    "overnight_return_filter": {
+      "label": "Overnight Return",
+      "desc": "Previous close to current open return filter",
+      "params": {
+        "min_overnight_return_pct": "Minimum Overnight Return %"
+      },
+      "help": "Filters stocks based on Overnight Return threshold settings."
+    },
+    "distance_from_52w_low": {
+      "label": "Distance From 52W Low",
+      "desc": "Distance from 252-day low",
+      "params": {
+        "lookback_days": "Lookback Days",
+        "max_distance_pct": "Maximum Distance %"
+      },
+      "help": "Filters stocks based on Distance From 52W Low threshold settings."
+    },
+    "distance_from_200d_high": {
+      "label": "Distance From 200D High",
+      "desc": "Distance below 200-day high",
+      "params": {
+        "lookback_days": "Lookback Days",
+        "max_distance_pct": "Maximum Distance %"
+      },
+      "help": "Filters stocks based on Distance From 200D High threshold settings."
+    },
+    "gap_up_breakaway": {
+      "label": "Gap Up Breakaway",
+      "desc": "Gap-up breakout using previous high",
+      "params": {
+        "min_gap_pct": "Minimum Gap %"
+      },
+      "help": "Filters stocks based on Gap Up Breakaway threshold settings."
+    },
+    "gap_down_exhaustion": {
+      "label": "Gap Down Exhaustion",
+      "desc": "Large down-gap exhaustion signal",
+      "params": {
+        "min_gap_down_pct": "Minimum Gap Down %"
+      },
+      "help": "Filters stocks based on Gap Down Exhaustion threshold settings."
+    },
+    "opening_range_breakout": {
+      "label": "Opening Range Breakout",
+      "desc": "Close breaks previous day range",
+      "params": {
+        "direction": "Direction"
+      },
+      "help": "Filters stocks based on Opening Range Breakout threshold settings."
+    },
+    "pivot_point_breakout": {
+      "label": "Pivot Point Breakout",
+      "desc": "Breakout above/below classic pivot",
+      "params": {
+        "direction": "Direction"
+      },
+      "help": "Filters stocks based on Pivot Point Breakout threshold settings."
+    },
+    "month_of_year_seasonality": {
+      "label": "Month Of Year Seasonality",
+      "desc": "Average return for target month",
+      "params": {
+        "min_avg_return_pct": "Minimum Avg Return %",
+        "target_month": "Target Month"
+      },
+      "help": "Filters stocks based on Month Of Year Seasonality threshold settings."
+    },
+    "turn_of_month_effect": {
+      "label": "Turn Of Month",
+      "desc": "Turn-of-month return effect",
+      "params": {
+        "min_avg_return_pct": "Minimum Avg Return %",
+        "window_days": "Window Days"
+      },
+      "help": "Filters stocks based on Turn Of Month threshold settings."
+    },
+    "day_of_week_seasonality": {
+      "label": "Day Of Week",
+      "desc": "Average weekday return effect",
+      "params": {
+        "min_avg_return_pct": "Minimum Avg Return %",
+        "target_weekday": "Target Weekday"
+      },
+      "help": "Filters stocks based on Day Of Week threshold settings."
+    },
+    "net_share_issuance_filter": {
+      "label": "Net Share Issuance Filter",
+      "desc": "Limit net share issuance",
+      "params": {
+        "max_issuance_pct": "Maximum Issuance %"
+      },
+      "help": "Filters stocks based on Net Share Issuance Filter threshold settings."
+    },
+    "insider_net_buying": {
+      "label": "Insider Net Buying",
+      "desc": "Insider net buying ratio",
+      "params": {
+        "min_net_buying_pct": "Minimum Net Buying %"
+      },
+      "help": "Filters stocks based on Insider Net Buying threshold settings."
+    },
+    "short_float_pct_filter": {
+      "label": "Short Float % Filter",
+      "desc": "Short float percentage threshold",
+      "params": {
+        "max_short_float_pct": "Maximum Short Float %"
+      },
+      "help": "Filters stocks based on Short Float % Filter threshold settings."
+    },
+    "short_interest_ratio_filter": {
+      "label": "Short Interest Ratio Filter",
+      "desc": "Days-to-cover threshold",
+      "params": {
+        "max_ratio": "Maximum Ratio"
+      },
+      "help": "Filters stocks based on Short Interest Ratio Filter threshold settings."
+    },
+    "earnings_surprise_filter": {
+      "label": "Earnings Surprise Filter",
+      "desc": "Quarterly earnings surprise threshold",
+      "params": {
+        "min_surprise_pct": "Minimum Surprise %"
+      },
+      "help": "Filters stocks based on Earnings Surprise Filter threshold settings."
+    },
+    "post_earnings_drift": {
+      "label": "Post Earnings Drift",
+      "desc": "Post-earnings drift threshold",
+      "params": {
+        "min_return_pct": "Minimum Return %"
+      },
+      "help": "Filters stocks based on Post Earnings Drift threshold settings."
+    },
+    "pre_earnings_drift": {
+      "label": "Pre Earnings Drift",
+      "desc": "Pre-earnings drift threshold",
+      "params": {
+        "min_return_pct": "Minimum Return %"
+      },
+      "help": "Filters stocks based on Pre Earnings Drift threshold settings."
+    },
+    "accruals_ratio": {
+      "label": "Accruals Ratio",
+      "desc": "Accruals ratio from income and cash flow",
+      "params": {
+        "max_ratio": "Maximum Ratio"
+      },
+      "help": "Filters stocks based on Accruals Ratio threshold settings."
+    },
+    "asset_growth_rate": {
+      "label": "Asset Growth Rate",
+      "desc": "Total asset growth rate",
+      "params": {
+        "max_growth_pct": "Maximum Growth %"
+      },
+      "help": "Filters stocks based on Asset Growth Rate threshold settings."
+    },
+    "momentum_12_1": {
+      "label": "Momentum 12-1",
+      "desc": "12-month momentum excluding recent 1 month",
+      "params": {
+        "lookback_months": "Lookback Months",
+        "min_return_pct": "Minimum Return %",
+        "skip_recent_months": "Skip Recent Months"
+      },
+      "help": "Filters stocks based on Momentum 12-1 threshold settings."
+    },
+    "volatility_n_day": {
+      "label": "Volatility N Day",
+      "desc": "Annualized N-day volatility filter",
+      "params": {
+        "lookback_days": "Lookback Days",
+        "max_annualized_vol_pct": "Maximum Annualized Vol %"
+      },
+      "help": "Filters stocks based on Volatility N Day threshold settings."
+    },
+    "distance_from_52w_high": {
+      "label": "Distance From 52W High",
+      "desc": "Distance below 52-week high",
+      "params": {
+        "lookback_days": "Lookback Days",
+        "max_distance_pct": "Maximum Distance %"
+      },
+      "help": "Filters stocks based on Distance From 52W High threshold settings."
+    },
+    "relative_strength_vs_benchmark": {
+      "label": "Relative Strength Vs Benchmark",
+      "desc": "Stock return minus benchmark return",
+      "params": {
+        "lookback_days": "Lookback Days",
+        "min_excess_return_pct": "Minimum Excess Return %"
+      },
+      "help": "Filters stocks based on Relative Strength Vs Benchmark threshold settings."
+    },
+    "adx_trend_strength": {
+      "label": "ADX Trend Strength",
+      "desc": "ADX trend strength filter",
+      "params": {
+        "di_direction": "Di Direction",
+        "min_adx": "Minimum ADX",
+        "period": "Period"
+      },
+      "help": "Filters stocks based on ADX Trend Strength threshold settings."
+    },
+    "ma_ribbon_alignment": {
+      "label": "MA Ribbon Alignment",
+      "desc": "Short>Mid>Long MA alignment",
+      "params": {
+        "long_period": "Long Period",
+        "mid_period": "Mid Period",
+        "short_period": "Short Period"
+      },
+      "help": "Filters stocks based on MA Ribbon Alignment threshold settings."
+    },
+    "golden_cross_50_200": {
+      "label": "Golden Cross 50/200",
+      "desc": "50MA crossing above 200MA",
+      "params": {
+        "lookback_days": "Lookback Days"
+      },
+      "help": "Filters stocks based on Golden Cross 50/200 threshold settings."
+    },
+    "death_cross_50_200": {
+      "label": "Death Cross 50/200",
+      "desc": "50MA crossing below 200MA",
+      "params": {
+        "lookback_days": "Lookback Days"
+      },
+      "help": "Filters stocks based on Death Cross 50/200 threshold settings."
+    },
+    "donchian_channel_breakout": {
+      "label": "Donchian Channel Breakout",
+      "desc": "Breakout above Donchian upper band",
+      "params": {
+        "lookback_days": "Lookback Days"
+      },
+      "help": "Filters stocks based on Donchian Channel Breakout threshold settings."
+    },
+    "keltner_channel_breakout": {
+      "label": "Keltner Channel Breakout",
+      "desc": "Breakout above EMA + ATR band",
+      "params": {
+        "atr_multiplier": "ATR Multiplier",
+        "atr_period": "ATR Period",
+        "ema_period": "Ema Period"
+      },
+      "help": "Filters stocks based on Keltner Channel Breakout threshold settings."
+    },
+    "parabolic_sar_flip": {
+      "label": "Parabolic SAR Flip",
+      "desc": "Bullish SAR flip within lookback",
+      "params": {
+        "af_max": "Af Maximum",
+        "af_step": "Af Step",
+        "lookback_days": "Lookback Days"
+      },
+      "help": "Filters stocks based on Parabolic SAR Flip threshold settings."
+    },
+    "linear_regression_slope_filter": {
+      "label": "Linear Regression Slope",
+      "desc": "Linear regression slope threshold",
+      "params": {
+        "lookback_days": "Lookback Days",
+        "min_slope": "Minimum Slope"
+      },
+      "help": "Filters stocks based on Linear Regression Slope threshold settings."
+    },
+    "linear_regression_angle_filter": {
+      "label": "Linear Regression Angle",
+      "desc": "Linear regression angle threshold",
+      "params": {
+        "lookback_days": "Lookback Days",
+        "min_angle_deg": "Minimum Angle Deg"
+      },
+      "help": "Filters stocks based on Linear Regression Angle threshold settings."
+    },
+    "linear_regression_r2_filter": {
+      "label": "Linear Regression R2",
+      "desc": "Linear regression R2 threshold",
+      "params": {
+        "lookback_days": "Lookback Days",
+        "min_r2": "Minimum R2"
+      },
+      "help": "Filters stocks based on Linear Regression R2 threshold settings."
+    },
+    "beta_to_benchmark": {
+      "label": "Beta to Benchmark",
+      "desc": "Rolling beta versus benchmark",
+      "params": {
+        "lookback_days": "Lookback Days",
+        "max_beta": "Maximum Beta"
+      },
+      "help": "Filters stocks based on Beta to Benchmark threshold settings."
+    },
+    "correlation_to_benchmark": {
+      "label": "Correlation to Benchmark",
+      "desc": "Rolling correlation versus benchmark",
+      "params": {
+        "lookback_days": "Lookback Days",
+        "max_corr": "Maximum Corr"
+      },
+      "help": "Filters stocks based on Correlation to Benchmark threshold settings."
+    },
+    "support_retest_signal": {
+      "label": "Support Retest Signal",
+      "desc": "Price retests support and closes above",
+      "params": {
+        "support_lookback": "Support Lookback",
+        "tolerance_pct": "Tolerance %"
+      },
+      "help": "Filters stocks based on Support Retest Signal threshold settings."
+    },
+    "resistance_retest_signal": {
+      "label": "Resistance Retest Signal",
+      "desc": "Price retests resistance and closes below",
+      "params": {
+        "resistance_lookback": "Resistance Lookback",
+        "tolerance_pct": "Tolerance %"
+      },
+      "help": "Filters stocks based on Resistance Retest Signal threshold settings."
+    },
+    "downside_volatility_filter": {
+      "label": "Downside Volatility",
+      "desc": "Annualized downside volatility filter",
+      "params": {
+        "lookback_days": "Lookback Days",
+        "max_downside_vol_pct": "Maximum Downside Vol %"
+      },
+      "help": "Filters stocks based on Downside Volatility threshold settings."
+    },
+    "semivariance_filter": {
+      "label": "Semivariance",
+      "desc": "Downside semivariance filter",
+      "params": {
+        "lookback_days": "Lookback Days",
+        "max_semivariance": "Maximum Semivariance"
+      },
+      "help": "Filters stocks based on Semivariance threshold settings."
+    },
+    "rolling_sharpe_filter": {
+      "label": "Rolling Sharpe",
+      "desc": "Rolling Sharpe ratio filter",
+      "params": {
+        "lookback_days": "Lookback Days",
+        "min_sharpe": "Minimum Sharpe"
+      },
+      "help": "Filters stocks based on Rolling Sharpe threshold settings."
+    },
+    "rolling_sortino_filter": {
+      "label": "Rolling Sortino",
+      "desc": "Rolling Sortino ratio filter",
+      "params": {
+        "lookback_days": "Lookback Days",
+        "min_sortino": "Minimum Sortino"
+      },
+      "help": "Filters stocks based on Rolling Sortino threshold settings."
+    },
+    "ulcer_index_filter": {
+      "label": "Ulcer Index",
+      "desc": "Ulcer index filter",
+      "params": {
+        "lookback_days": "Lookback Days",
+        "max_ulcer_index": "Maximum Ulcer Index"
+      },
+      "help": "Filters stocks based on Ulcer Index threshold settings."
+    },
+    "calmar_ratio_filter": {
+      "label": "Calmar Ratio",
+      "desc": "Calmar ratio filter",
+      "params": {
+        "lookback_days": "Lookback Days",
+        "min_calmar": "Minimum Calmar"
+      },
+      "help": "Filters stocks based on Calmar Ratio threshold settings."
+    },
+    "max_drawdown_window_filter": {
+      "label": "Max Drawdown Window",
+      "desc": "Window max drawdown filter",
+      "params": {
+        "lookback_days": "Lookback Days",
+        "max_drawdown_pct": "Maximum Drawdown %"
+      },
+      "help": "Filters stocks based on Max Drawdown Window threshold settings."
+    },
+    "return_skewness_filter": {
+      "label": "Return Skewness",
+      "desc": "Return skewness filter",
+      "params": {
+        "lookback_days": "Lookback Days",
+        "min_skewness": "Minimum Skewness"
+      },
+      "help": "Filters stocks based on Return Skewness threshold settings."
+    },
+    "return_kurtosis_filter": {
+      "label": "Return Kurtosis",
+      "desc": "Return kurtosis filter",
+      "params": {
+        "lookback_days": "Lookback Days",
+        "max_kurtosis": "Maximum Kurtosis"
+      },
+      "help": "Filters stocks based on Return Kurtosis threshold settings."
+    },
+    "intraday_return_filter": {
+      "label": "Intraday Return",
+      "desc": "Intraday return filter",
+      "params": {
+        "min_intraday_return_pct": "Minimum Intraday Return %"
+      },
+      "help": "Filters stocks based on Intraday Return threshold settings."
+    },
+    "dso_trend_filter": {
+      "label": "DSO Trend Filter",
+      "desc": "Days Sales Outstanding deterioration trend filter",
+      "params": {
+        "lookback_years": "Lookback Years",
+        "min_dso_increase_pct": "Minimum Dso Increase %"
+      },
+      "help": "Filters stocks based on DSO Trend Filter threshold settings."
+    },
+    "ema_cross": {
+      "label": "EMA Cross",
+      "desc": "EMA cross signal",
+      "params": {
+        "direction": "Direction",
+        "fast_period": "Fast Period",
+        "lookback_days": "Lookback Days",
+        "slow_period": "Slow Period"
+      },
+      "help": "Filters stocks based on EMA Cross threshold settings."
+    },
+    "ema_slope": {
+      "label": "EMA Slope",
+      "desc": "EMA slope over lookback",
+      "params": {
+        "lookback_days": "Lookback Days",
+        "min_slope_pct": "Minimum Slope %",
+        "period": "Period"
+      },
+      "help": "Filters stocks based on EMA Slope threshold settings."
+    },
+    "sma_slope": {
+      "label": "SMA Slope",
+      "desc": "SMA slope over lookback",
+      "params": {
+        "lookback_days": "Lookback Days",
+        "min_slope_pct": "Minimum Slope %",
+        "period": "Period"
+      },
+      "help": "Filters stocks based on SMA Slope threshold settings."
+    },
+    "macd_signal_cross": {
+      "label": "MACD Signal Cross",
+      "desc": "MACD line crossing signal line",
+      "params": {
+        "direction": "Direction",
+        "fast_period": "Fast Period",
+        "lookback_days": "Lookback Days",
+        "signal_period": "Signal Period",
+        "slow_period": "Slow Period"
+      },
+      "help": "Filters stocks based on MACD Signal Cross threshold settings."
+    },
+    "macd_histogram_slope": {
+      "label": "MACD Histogram Slope",
+      "desc": "MACD histogram slope",
+      "params": {
+        "fast_period": "Fast Period",
+        "lookback_days": "Lookback Days",
+        "min_slope": "Minimum Slope",
+        "signal_period": "Signal Period",
+        "slow_period": "Slow Period"
+      },
+      "help": "Filters stocks based on MACD Histogram Slope threshold settings."
+    },
+    "cci_overbought_oversold": {
+      "label": "CCI Overbought/Oversold",
+      "desc": "CCI threshold filter",
+      "params": {
+        "mode": "Mode",
+        "period": "Period",
+        "threshold": "Threshold"
+      },
+      "help": "Filters stocks based on CCI Overbought/Oversold threshold settings."
+    },
+    "williams_r_reversal": {
+      "label": "Williams %R Reversal",
+      "desc": "Williams %R reversal signal",
+      "params": {
+        "direction": "Direction",
+        "overbought": "Overbought",
+        "oversold": "Oversold",
+        "period": "Period"
+      },
+      "help": "Filters stocks based on Williams %R Reversal threshold settings."
+    },
+    "trix_cross": {
+      "label": "TRIX Cross",
+      "desc": "TRIX crossing signal line",
+      "params": {
+        "direction": "Direction",
+        "lookback_days": "Lookback Days",
+        "period": "Period",
+        "signal_period": "Signal Period"
+      },
+      "help": "Filters stocks based on TRIX Cross threshold settings."
+    },
+    "aroon_trend_signal": {
+      "label": "Aroon Trend Signal",
+      "desc": "Aroon trend strength signal",
+      "params": {
+        "direction": "Direction",
+        "min_aroon": "Minimum Aroon",
+        "period": "Period"
+      },
+      "help": "Filters stocks based on Aroon Trend Signal threshold settings."
+    },
+    "money_flow_index_signal": {
+      "label": "Money Flow Index",
+      "desc": "MFI threshold signal",
+      "params": {
+        "mode": "Mode",
+        "overbought": "Overbought",
+        "oversold": "Oversold",
+        "period": "Period"
+      },
+      "help": "Filters stocks based on Money Flow Index threshold settings."
+    },
+    "vwap_cross_signal": {
+      "label": "VWAP Cross Signal",
+      "desc": "Close crossing above VWAP",
+      "params": {
+        "lookback_days": "Lookback Days",
+        "period": "Period"
+      },
+      "help": "Filters stocks based on VWAP Cross Signal threshold settings."
+    },
+    "vwap_distance_pct": {
+      "label": "VWAP Distance %",
+      "desc": "Distance between close and VWAP",
+      "params": {
+        "max_distance_pct": "Maximum Distance %",
+        "period": "Period"
+      },
+      "help": "Filters stocks based on VWAP Distance % threshold settings."
+    },
+    "relative_volume_percentile": {
+      "label": "Relative Volume Percentile",
+      "desc": "Current volume percentile within lookback",
+      "params": {
+        "lookback_days": "Lookback Days",
+        "min_percentile": "Minimum Percentile"
+      },
+      "help": "Filters stocks based on Relative Volume Percentile threshold settings."
+    },
+    "turnover_ratio_min": {
+      "label": "Turnover Ratio Min",
+      "desc": "Minimum turnover ratio",
+      "params": {
+        "min_turnover_ratio": "Minimum Turnover Ratio"
+      },
+      "help": "Filters stocks based on Turnover Ratio Min threshold settings."
+    },
+    "atr_percentile_filter": {
+      "label": "ATR Percentile",
+      "desc": "ATR percentile within lookback",
+      "params": {
+        "atr_period": "ATR Period",
+        "lookback_days": "Lookback Days",
+        "max_percentile": "Maximum Percentile"
+      },
+      "help": "Filters stocks based on ATR Percentile threshold settings."
+    },
+    "atr_expansion_breakout": {
+      "label": "ATR Expansion Breakout",
+      "desc": "ATR expansion and price breakout",
+      "params": {
+        "atr_multiplier": "ATR Multiplier",
+        "atr_period": "ATR Period",
+        "breakout_lookback": "Breakout Lookback"
+      },
+      "help": "Filters stocks based on ATR Expansion Breakout threshold settings."
+    },
+    "natr_filter": {
+      "label": "NATR Filter",
+      "desc": "Normalized ATR filter",
+      "params": {
+        "max_natr_pct": "Maximum Natr %",
+        "period": "Period"
+      },
+      "help": "Filters stocks based on NATR Filter threshold settings."
+    },
+    "dmi_directional_cross": {
+      "label": "DMI Directional Cross",
+      "desc": "+DI crosses above -DI",
+      "params": {
+        "lookback_days": "Lookback Days",
+        "period": "Period"
+      },
+      "help": "Filters stocks based on DMI Directional Cross threshold settings."
+    },
+    "ichimoku_cloud_breakout": {
+      "label": "Ichimoku Cloud Breakout",
+      "desc": "Close above cloud upper",
+      "params": {
+        "base_period": "Base Period",
+        "conversion_period": "Conversion Period",
+        "span_b_period": "Span B Period"
+      },
+      "help": "Filters stocks based on Ichimoku Cloud Breakout threshold settings."
+    },
+    "ichimoku_tenkan_kijun_cross": {
+      "label": "Ichimoku Tenkan/Kijun Cross",
+      "desc": "Tenkan crosses above Kijun",
+      "params": {
+        "base_period": "Base Period",
+        "conversion_period": "Conversion Period",
+        "lookback_days": "Lookback Days"
+      },
+      "help": "Filters stocks based on Ichimoku Tenkan/Kijun Cross threshold settings."
+    },
+    "bollinger_squeeze_breakout": {
+      "label": "Bollinger Squeeze Breakout",
+      "desc": "Low BB width followed by upper band breakout",
+      "params": {
+        "max_width_pct": "Maximum Width %",
+        "period": "Period",
+        "std_mult": "Std Mult"
+      },
+      "help": "Filters stocks based on Bollinger Squeeze Breakout threshold settings."
+    },
+    "bollinger_percent_b": {
+      "label": "Bollinger Percent B",
+      "desc": "Price position within Bollinger bands",
+      "params": {
+        "max_percent_b": "Maximum Percent B",
+        "min_percent_b": "Minimum Percent B",
+        "period": "Period",
+        "std_mult": "Std Mult"
+      },
+      "help": "Filters stocks based on Bollinger Percent B threshold settings."
+    },
+    "ppo_signal_cross": {
+      "label": "PPO Signal Cross",
+      "desc": "PPO line crossing signal line",
+      "params": {
+        "fast_period": "Fast Period",
+        "lookback_days": "Lookback Days",
+        "signal_period": "Signal Period",
+        "slow_period": "Slow Period"
+      },
+      "help": "Filters stocks based on PPO Signal Cross threshold settings."
+    },
+    "stochastic_cross_signal": {
+      "label": "Stochastic Cross Signal",
+      "desc": "%K crossing above %D",
+      "params": {
+        "d_period": "D Period",
+        "k_period": "K Period",
+        "lookback_days": "Lookback Days"
+      },
+      "help": "Filters stocks based on Stochastic Cross Signal threshold settings."
+    },
+    "stochrsi_signal": {
+      "label": "StochRSI Signal",
+      "desc": "StochRSI threshold signal",
+      "params": {
+        "mode": "Mode",
+        "rsi_period": "RSI Period",
+        "stoch_period": "Stoch Period"
+      },
+      "help": "Filters stocks based on StochRSI Signal threshold settings."
+    },
+    "aroon_oscillator_signal": {
+      "label": "Aroon Oscillator Signal",
+      "desc": "Aroon up-down oscillator filter",
+      "params": {
+        "min_oscillator": "Minimum Oscillator",
+        "period": "Period"
+      },
+      "help": "Filters stocks based on Aroon Oscillator Signal threshold settings."
+    },
+    "ultimate_oscillator_signal": {
+      "label": "Ultimate Oscillator Signal",
+      "desc": "Ultimate oscillator threshold",
+      "params": {
+        "min_value": "Minimum Value"
+      },
+      "help": "Filters stocks based on Ultimate Oscillator Signal threshold settings."
+    },
+    "chaikin_money_flow_signal": {
+      "label": "Chaikin Money Flow",
+      "desc": "CMF threshold signal",
+      "params": {
+        "min_cmf": "Minimum Cmf",
+        "period": "Period"
+      },
+      "help": "Filters stocks based on Chaikin Money Flow threshold settings."
+    },
+    "chaikin_oscillator_signal": {
+      "label": "Chaikin Oscillator",
+      "desc": "Chaikin oscillator above threshold",
+      "params": {
+        "fast_period": "Fast Period",
+        "min_value": "Minimum Value",
+        "slow_period": "Slow Period"
+      },
+      "help": "Filters stocks based on Chaikin Oscillator threshold settings."
+    },
+    "ad_line_trend": {
+      "label": "A/D Line Trend",
+      "desc": "Accumulation/distribution line trend",
+      "params": {
+        "lookback_days": "Lookback Days"
+      },
+      "help": "Filters stocks based on A/D Line Trend threshold settings."
     }
   },
   "settings": {

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -1212,6 +1212,722 @@
         "min_roa_pct": "최소 ROA %"
       },
       "help": "ROA 필터 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "overnight_return_filter": {
+      "label": "오버나이트 수익률 필터",
+      "desc": "오버나이트 수익률 필터 조건으로 종목을 필터링합니다.",
+      "params": {
+        "min_overnight_return_pct": "최소 오버나이트 수익률 비율 %"
+      },
+      "help": "오버나이트 수익률 필터 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "distance_from_52w_low": {
+      "label": "괴리 From 52w 저점",
+      "desc": "괴리 From 52w 저점 조건으로 종목을 필터링합니다.",
+      "params": {
+        "lookback_days": "조회기간 일수",
+        "max_distance_pct": "최대 괴리 비율 %"
+      },
+      "help": "괴리 From 52w 저점 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "distance_from_200d_high": {
+      "label": "괴리 From 200d 고점",
+      "desc": "괴리 From 200d 고점 조건으로 종목을 필터링합니다.",
+      "params": {
+        "lookback_days": "조회기간 일수",
+        "max_distance_pct": "최대 괴리 비율 %"
+      },
+      "help": "괴리 From 200d 고점 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "gap_up_breakaway": {
+      "label": "Gap Up Breakaway",
+      "desc": "Gap Up Breakaway 조건으로 종목을 필터링합니다.",
+      "params": {
+        "min_gap_pct": "최소 gap 비율 %"
+      },
+      "help": "Gap Up Breakaway 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "gap_down_exhaustion": {
+      "label": "Gap Down Exhaustion",
+      "desc": "Gap Down Exhaustion 조건으로 종목을 필터링합니다.",
+      "params": {
+        "min_gap_down_pct": "최소 gap down 비율 %"
+      },
+      "help": "Gap Down Exhaustion 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "opening_range_breakout": {
+      "label": "Opening Range 돌파",
+      "desc": "Opening Range 돌파 조건으로 종목을 필터링합니다.",
+      "params": {
+        "direction": "direction"
+      },
+      "help": "Opening Range 돌파 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "pivot_point_breakout": {
+      "label": "Pivot Point 돌파",
+      "desc": "Pivot Point 돌파 조건으로 종목을 필터링합니다.",
+      "params": {
+        "direction": "direction"
+      },
+      "help": "Pivot Point 돌파 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "month_of_year_seasonality": {
+      "label": "월 Of 년 Seasonality",
+      "desc": "월 Of 년 Seasonality 조건으로 종목을 필터링합니다.",
+      "params": {
+        "min_avg_return_pct": "최소 avg 수익률 비율 %",
+        "target_month": "target 월"
+      },
+      "help": "월 Of 년 Seasonality 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "turn_of_month_effect": {
+      "label": "Turn Of 월 Effect",
+      "desc": "Turn Of 월 Effect 조건으로 종목을 필터링합니다.",
+      "params": {
+        "min_avg_return_pct": "최소 avg 수익률 비율 %",
+        "window_days": "윈도우 일수"
+      },
+      "help": "Turn Of 월 Effect 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "day_of_week_seasonality": {
+      "label": "일 Of 주 Seasonality",
+      "desc": "일 Of 주 Seasonality 조건으로 종목을 필터링합니다.",
+      "params": {
+        "min_avg_return_pct": "최소 avg 수익률 비율 %",
+        "target_weekday": "target weekday"
+      },
+      "help": "일 Of 주 Seasonality 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "net_share_issuance_filter": {
+      "label": "순 주식 발행 필터",
+      "desc": "순 주식 발행 필터 조건으로 종목을 필터링합니다.",
+      "params": {
+        "max_issuance_pct": "최대 발행 비율 %"
+      },
+      "help": "순 주식 발행 필터 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "insider_net_buying": {
+      "label": "Insider 순 Buying",
+      "desc": "Insider 순 Buying 조건으로 종목을 필터링합니다.",
+      "params": {
+        "min_net_buying_pct": "최소 순 buying 비율 %"
+      },
+      "help": "Insider 순 Buying 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "short_float_pct_filter": {
+      "label": "Short Float Pct 필터",
+      "desc": "Short Float Pct 필터 조건으로 종목을 필터링합니다.",
+      "params": {
+        "max_short_float_pct": "최대 short float 비율 %"
+      },
+      "help": "Short Float Pct 필터 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "short_interest_ratio_filter": {
+      "label": "Short 이자 비율 필터",
+      "desc": "Short 이자 비율 필터 조건으로 종목을 필터링합니다.",
+      "params": {
+        "max_ratio": "최대 비율"
+      },
+      "help": "Short 이자 비율 필터 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "earnings_surprise_filter": {
+      "label": "실적 서프라이즈 필터",
+      "desc": "실적 서프라이즈 필터 조건으로 종목을 필터링합니다.",
+      "params": {
+        "min_surprise_pct": "최소 서프라이즈 비율 %"
+      },
+      "help": "실적 서프라이즈 필터 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "post_earnings_drift": {
+      "label": "사후 실적 Drift",
+      "desc": "사후 실적 Drift 조건으로 종목을 필터링합니다.",
+      "params": {
+        "min_return_pct": "최소 수익률 비율 %"
+      },
+      "help": "사후 실적 Drift 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "pre_earnings_drift": {
+      "label": "사전 실적 Drift",
+      "desc": "사전 실적 Drift 조건으로 종목을 필터링합니다.",
+      "params": {
+        "min_return_pct": "최소 수익률 비율 %"
+      },
+      "help": "사전 실적 Drift 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "accruals_ratio": {
+      "label": "Accruals 비율",
+      "desc": "Accruals 비율 조건으로 종목을 필터링합니다.",
+      "params": {
+        "max_ratio": "최대 비율"
+      },
+      "help": "Accruals 비율 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "asset_growth_rate": {
+      "label": "자산 성장률 Rate",
+      "desc": "자산 성장률 Rate 조건으로 종목을 필터링합니다.",
+      "params": {
+        "max_growth_pct": "최대 성장률 비율 %"
+      },
+      "help": "자산 성장률 Rate 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "momentum_12_1": {
+      "label": "모멘텀 12 1",
+      "desc": "모멘텀 12 1 조건으로 종목을 필터링합니다.",
+      "params": {
+        "lookback_months": "조회기간 개월",
+        "min_return_pct": "최소 수익률 비율 %",
+        "skip_recent_months": "skip recent 개월"
+      },
+      "help": "모멘텀 12 1 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "volatility_n_day": {
+      "label": "변동성 N 일",
+      "desc": "변동성 N 일 조건으로 종목을 필터링합니다.",
+      "params": {
+        "lookback_days": "조회기간 일수",
+        "max_annualized_vol_pct": "최대 annualized vol 비율 %"
+      },
+      "help": "변동성 N 일 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "distance_from_52w_high": {
+      "label": "괴리 From 52w 고점",
+      "desc": "괴리 From 52w 고점 조건으로 종목을 필터링합니다.",
+      "params": {
+        "lookback_days": "조회기간 일수",
+        "max_distance_pct": "최대 괴리 비율 %"
+      },
+      "help": "괴리 From 52w 고점 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "relative_strength_vs_benchmark": {
+      "label": "Relative Strength Vs Benchmark",
+      "desc": "Relative Strength Vs Benchmark 조건으로 종목을 필터링합니다.",
+      "params": {
+        "lookback_days": "조회기간 일수",
+        "min_excess_return_pct": "최소 excess 수익률 비율 %"
+      },
+      "help": "Relative Strength Vs Benchmark 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "adx_trend_strength": {
+      "label": "ADX 추세 Strength",
+      "desc": "ADX 추세 Strength 조건으로 종목을 필터링합니다.",
+      "params": {
+        "di_direction": "di direction",
+        "min_adx": "최소 ADX",
+        "period": "기간"
+      },
+      "help": "ADX 추세 Strength 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "ma_ribbon_alignment": {
+      "label": "Ma Ribbon Alignment",
+      "desc": "Ma Ribbon Alignment 조건으로 종목을 필터링합니다.",
+      "params": {
+        "long_period": "long 기간",
+        "mid_period": "mid 기간",
+        "short_period": "short 기간"
+      },
+      "help": "Ma Ribbon Alignment 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "golden_cross_50_200": {
+      "label": "Golden Cross 50 200",
+      "desc": "Golden Cross 50 200 조건으로 종목을 필터링합니다.",
+      "params": {
+        "lookback_days": "조회기간 일수"
+      },
+      "help": "Golden Cross 50 200 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "death_cross_50_200": {
+      "label": "Death Cross 50 200",
+      "desc": "Death Cross 50 200 조건으로 종목을 필터링합니다.",
+      "params": {
+        "lookback_days": "조회기간 일수"
+      },
+      "help": "Death Cross 50 200 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "donchian_channel_breakout": {
+      "label": "Donchian Channel 돌파",
+      "desc": "Donchian Channel 돌파 조건으로 종목을 필터링합니다.",
+      "params": {
+        "lookback_days": "조회기간 일수"
+      },
+      "help": "Donchian Channel 돌파 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "keltner_channel_breakout": {
+      "label": "Keltner Channel 돌파",
+      "desc": "Keltner Channel 돌파 조건으로 종목을 필터링합니다.",
+      "params": {
+        "atr_multiplier": "ATR multiplier",
+        "atr_period": "ATR 기간",
+        "ema_period": "ema 기간"
+      },
+      "help": "Keltner Channel 돌파 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "parabolic_sar_flip": {
+      "label": "Parabolic Sar Flip",
+      "desc": "Parabolic Sar Flip 조건으로 종목을 필터링합니다.",
+      "params": {
+        "af_max": "af max",
+        "af_step": "af step",
+        "lookback_days": "조회기간 일수"
+      },
+      "help": "Parabolic Sar Flip 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "linear_regression_slope_filter": {
+      "label": "Linear Regression Slope 필터",
+      "desc": "Linear Regression Slope 필터 조건으로 종목을 필터링합니다.",
+      "params": {
+        "lookback_days": "조회기간 일수",
+        "min_slope": "최소 slope"
+      },
+      "help": "Linear Regression Slope 필터 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "linear_regression_angle_filter": {
+      "label": "Linear Regression Angle 필터",
+      "desc": "Linear Regression Angle 필터 조건으로 종목을 필터링합니다.",
+      "params": {
+        "lookback_days": "조회기간 일수",
+        "min_angle_deg": "최소 angle deg"
+      },
+      "help": "Linear Regression Angle 필터 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "linear_regression_r2_filter": {
+      "label": "Linear Regression R2 필터",
+      "desc": "Linear Regression R2 필터 조건으로 종목을 필터링합니다.",
+      "params": {
+        "lookback_days": "조회기간 일수",
+        "min_r2": "최소 r2"
+      },
+      "help": "Linear Regression R2 필터 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "beta_to_benchmark": {
+      "label": "Beta To Benchmark",
+      "desc": "Beta To Benchmark 조건으로 종목을 필터링합니다.",
+      "params": {
+        "lookback_days": "조회기간 일수",
+        "max_beta": "최대 beta"
+      },
+      "help": "Beta To Benchmark 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "correlation_to_benchmark": {
+      "label": "Correlation To Benchmark",
+      "desc": "Correlation To Benchmark 조건으로 종목을 필터링합니다.",
+      "params": {
+        "lookback_days": "조회기간 일수",
+        "max_corr": "최대 corr"
+      },
+      "help": "Correlation To Benchmark 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "support_retest_signal": {
+      "label": "Support Retest 신호",
+      "desc": "Support Retest 신호 조건으로 종목을 필터링합니다.",
+      "params": {
+        "support_lookback": "support 조회기간",
+        "tolerance_pct": "tolerance 비율 %"
+      },
+      "help": "Support Retest 신호 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "resistance_retest_signal": {
+      "label": "Resistance Retest 신호",
+      "desc": "Resistance Retest 신호 조건으로 종목을 필터링합니다.",
+      "params": {
+        "resistance_lookback": "resistance 조회기간",
+        "tolerance_pct": "tolerance 비율 %"
+      },
+      "help": "Resistance Retest 신호 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "downside_volatility_filter": {
+      "label": "Downside 변동성 필터",
+      "desc": "Downside 변동성 필터 조건으로 종목을 필터링합니다.",
+      "params": {
+        "lookback_days": "조회기간 일수",
+        "max_downside_vol_pct": "최대 downside vol 비율 %"
+      },
+      "help": "Downside 변동성 필터 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "semivariance_filter": {
+      "label": "Semivariance 필터",
+      "desc": "Semivariance 필터 조건으로 종목을 필터링합니다.",
+      "params": {
+        "lookback_days": "조회기간 일수",
+        "max_semivariance": "최대 semivariance"
+      },
+      "help": "Semivariance 필터 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "rolling_sharpe_filter": {
+      "label": "Rolling Sharpe 필터",
+      "desc": "Rolling Sharpe 필터 조건으로 종목을 필터링합니다.",
+      "params": {
+        "lookback_days": "조회기간 일수",
+        "min_sharpe": "최소 sharpe"
+      },
+      "help": "Rolling Sharpe 필터 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "rolling_sortino_filter": {
+      "label": "Rolling Sortino 필터",
+      "desc": "Rolling Sortino 필터 조건으로 종목을 필터링합니다.",
+      "params": {
+        "lookback_days": "조회기간 일수",
+        "min_sortino": "최소 sortino"
+      },
+      "help": "Rolling Sortino 필터 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "ulcer_index_filter": {
+      "label": "Ulcer Index 필터",
+      "desc": "Ulcer Index 필터 조건으로 종목을 필터링합니다.",
+      "params": {
+        "lookback_days": "조회기간 일수",
+        "max_ulcer_index": "최대 ulcer index"
+      },
+      "help": "Ulcer Index 필터 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "calmar_ratio_filter": {
+      "label": "Calmar 비율 필터",
+      "desc": "Calmar 비율 필터 조건으로 종목을 필터링합니다.",
+      "params": {
+        "lookback_days": "조회기간 일수",
+        "min_calmar": "최소 calmar"
+      },
+      "help": "Calmar 비율 필터 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "max_drawdown_window_filter": {
+      "label": "Max Drawdown Window 필터",
+      "desc": "Max Drawdown Window 필터 조건으로 종목을 필터링합니다.",
+      "params": {
+        "lookback_days": "조회기간 일수",
+        "max_drawdown_pct": "최대 drawdown 비율 %"
+      },
+      "help": "Max Drawdown Window 필터 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "return_skewness_filter": {
+      "label": "수익률 Skewness 필터",
+      "desc": "수익률 Skewness 필터 조건으로 종목을 필터링합니다.",
+      "params": {
+        "lookback_days": "조회기간 일수",
+        "min_skewness": "최소 skewness"
+      },
+      "help": "수익률 Skewness 필터 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "return_kurtosis_filter": {
+      "label": "수익률 Kurtosis 필터",
+      "desc": "수익률 Kurtosis 필터 조건으로 종목을 필터링합니다.",
+      "params": {
+        "lookback_days": "조회기간 일수",
+        "max_kurtosis": "최대 kurtosis"
+      },
+      "help": "수익률 Kurtosis 필터 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "intraday_return_filter": {
+      "label": "Intraday 수익률 필터",
+      "desc": "Intraday 수익률 필터 조건으로 종목을 필터링합니다.",
+      "params": {
+        "min_intraday_return_pct": "최소 intraday 수익률 비율 %"
+      },
+      "help": "Intraday 수익률 필터 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "dso_trend_filter": {
+      "label": "Dso 추세 필터",
+      "desc": "Dso 추세 필터 조건으로 종목을 필터링합니다.",
+      "params": {
+        "lookback_years": "조회기간 연수",
+        "min_dso_increase_pct": "최소 dso increase 비율 %"
+      },
+      "help": "Dso 추세 필터 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "ema_cross": {
+      "label": "Ema Cross",
+      "desc": "Ema Cross 조건으로 종목을 필터링합니다.",
+      "params": {
+        "direction": "direction",
+        "fast_period": "fast 기간",
+        "lookback_days": "조회기간 일수",
+        "slow_period": "slow 기간"
+      },
+      "help": "Ema Cross 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "ema_slope": {
+      "label": "Ema Slope",
+      "desc": "Ema Slope 조건으로 종목을 필터링합니다.",
+      "params": {
+        "lookback_days": "조회기간 일수",
+        "min_slope_pct": "최소 slope 비율 %",
+        "period": "기간"
+      },
+      "help": "Ema Slope 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "sma_slope": {
+      "label": "Sma Slope",
+      "desc": "Sma Slope 조건으로 종목을 필터링합니다.",
+      "params": {
+        "lookback_days": "조회기간 일수",
+        "min_slope_pct": "최소 slope 비율 %",
+        "period": "기간"
+      },
+      "help": "Sma Slope 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "macd_signal_cross": {
+      "label": "MACD 신호 Cross",
+      "desc": "MACD 신호 Cross 조건으로 종목을 필터링합니다.",
+      "params": {
+        "direction": "direction",
+        "fast_period": "fast 기간",
+        "lookback_days": "조회기간 일수",
+        "signal_period": "신호 기간",
+        "slow_period": "slow 기간"
+      },
+      "help": "MACD 신호 Cross 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "macd_histogram_slope": {
+      "label": "MACD Histogram Slope",
+      "desc": "MACD Histogram Slope 조건으로 종목을 필터링합니다.",
+      "params": {
+        "fast_period": "fast 기간",
+        "lookback_days": "조회기간 일수",
+        "min_slope": "최소 slope",
+        "signal_period": "신호 기간",
+        "slow_period": "slow 기간"
+      },
+      "help": "MACD Histogram Slope 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "cci_overbought_oversold": {
+      "label": "CCI Overbought Oversold",
+      "desc": "CCI Overbought Oversold 조건으로 종목을 필터링합니다.",
+      "params": {
+        "mode": "mode",
+        "period": "기간",
+        "threshold": "임계값"
+      },
+      "help": "CCI Overbought Oversold 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "williams_r_reversal": {
+      "label": "Williams R Reversal",
+      "desc": "Williams R Reversal 조건으로 종목을 필터링합니다.",
+      "params": {
+        "direction": "direction",
+        "overbought": "overbought",
+        "oversold": "oversold",
+        "period": "기간"
+      },
+      "help": "Williams R Reversal 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "trix_cross": {
+      "label": "Trix Cross",
+      "desc": "Trix Cross 조건으로 종목을 필터링합니다.",
+      "params": {
+        "direction": "direction",
+        "lookback_days": "조회기간 일수",
+        "period": "기간",
+        "signal_period": "신호 기간"
+      },
+      "help": "Trix Cross 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "aroon_trend_signal": {
+      "label": "Aroon 추세 신호",
+      "desc": "Aroon 추세 신호 조건으로 종목을 필터링합니다.",
+      "params": {
+        "direction": "direction",
+        "min_aroon": "최소 aroon",
+        "period": "기간"
+      },
+      "help": "Aroon 추세 신호 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "money_flow_index_signal": {
+      "label": "Money 흐름 Index 신호",
+      "desc": "Money 흐름 Index 신호 조건으로 종목을 필터링합니다.",
+      "params": {
+        "mode": "mode",
+        "overbought": "overbought",
+        "oversold": "oversold",
+        "period": "기간"
+      },
+      "help": "Money 흐름 Index 신호 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "vwap_cross_signal": {
+      "label": "Vwap Cross 신호",
+      "desc": "Vwap Cross 신호 조건으로 종목을 필터링합니다.",
+      "params": {
+        "lookback_days": "조회기간 일수",
+        "period": "기간"
+      },
+      "help": "Vwap Cross 신호 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "vwap_distance_pct": {
+      "label": "Vwap 괴리 Pct",
+      "desc": "Vwap 괴리 Pct 조건으로 종목을 필터링합니다.",
+      "params": {
+        "max_distance_pct": "최대 괴리 비율 %",
+        "period": "기간"
+      },
+      "help": "Vwap 괴리 Pct 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "relative_volume_percentile": {
+      "label": "Relative 거래량 Percentile",
+      "desc": "Relative 거래량 Percentile 조건으로 종목을 필터링합니다.",
+      "params": {
+        "lookback_days": "조회기간 일수",
+        "min_percentile": "최소 percentile"
+      },
+      "help": "Relative 거래량 Percentile 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "turnover_ratio_min": {
+      "label": "회전율 비율 Min",
+      "desc": "회전율 비율 Min 조건으로 종목을 필터링합니다.",
+      "params": {
+        "min_turnover_ratio": "최소 회전율 비율"
+      },
+      "help": "회전율 비율 Min 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "atr_percentile_filter": {
+      "label": "ATR Percentile 필터",
+      "desc": "ATR Percentile 필터 조건으로 종목을 필터링합니다.",
+      "params": {
+        "atr_period": "ATR 기간",
+        "lookback_days": "조회기간 일수",
+        "max_percentile": "최대 percentile"
+      },
+      "help": "ATR Percentile 필터 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "atr_expansion_breakout": {
+      "label": "ATR Expansion 돌파",
+      "desc": "ATR Expansion 돌파 조건으로 종목을 필터링합니다.",
+      "params": {
+        "atr_multiplier": "ATR multiplier",
+        "atr_period": "ATR 기간",
+        "breakout_lookback": "돌파 조회기간"
+      },
+      "help": "ATR Expansion 돌파 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "natr_filter": {
+      "label": "Natr 필터",
+      "desc": "Natr 필터 조건으로 종목을 필터링합니다.",
+      "params": {
+        "max_natr_pct": "최대 natr 비율 %",
+        "period": "기간"
+      },
+      "help": "Natr 필터 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "dmi_directional_cross": {
+      "label": "Dmi Directional Cross",
+      "desc": "Dmi Directional Cross 조건으로 종목을 필터링합니다.",
+      "params": {
+        "lookback_days": "조회기간 일수",
+        "period": "기간"
+      },
+      "help": "Dmi Directional Cross 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "ichimoku_cloud_breakout": {
+      "label": "Ichimoku Cloud 돌파",
+      "desc": "Ichimoku Cloud 돌파 조건으로 종목을 필터링합니다.",
+      "params": {
+        "base_period": "base 기간",
+        "conversion_period": "conversion 기간",
+        "span_b_period": "span b 기간"
+      },
+      "help": "Ichimoku Cloud 돌파 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "ichimoku_tenkan_kijun_cross": {
+      "label": "Ichimoku Tenkan Kijun Cross",
+      "desc": "Ichimoku Tenkan Kijun Cross 조건으로 종목을 필터링합니다.",
+      "params": {
+        "base_period": "base 기간",
+        "conversion_period": "conversion 기간",
+        "lookback_days": "조회기간 일수"
+      },
+      "help": "Ichimoku Tenkan Kijun Cross 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "bollinger_squeeze_breakout": {
+      "label": "Bollinger Squeeze 돌파",
+      "desc": "Bollinger Squeeze 돌파 조건으로 종목을 필터링합니다.",
+      "params": {
+        "max_width_pct": "최대 width 비율 %",
+        "period": "기간",
+        "std_mult": "std mult"
+      },
+      "help": "Bollinger Squeeze 돌파 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "bollinger_percent_b": {
+      "label": "Bollinger Percent B",
+      "desc": "Bollinger Percent B 조건으로 종목을 필터링합니다.",
+      "params": {
+        "max_percent_b": "최대 percent b",
+        "min_percent_b": "최소 percent b",
+        "period": "기간",
+        "std_mult": "std mult"
+      },
+      "help": "Bollinger Percent B 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "ppo_signal_cross": {
+      "label": "Ppo 신호 Cross",
+      "desc": "Ppo 신호 Cross 조건으로 종목을 필터링합니다.",
+      "params": {
+        "fast_period": "fast 기간",
+        "lookback_days": "조회기간 일수",
+        "signal_period": "신호 기간",
+        "slow_period": "slow 기간"
+      },
+      "help": "Ppo 신호 Cross 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "stochastic_cross_signal": {
+      "label": "Stochastic Cross 신호",
+      "desc": "Stochastic Cross 신호 조건으로 종목을 필터링합니다.",
+      "params": {
+        "d_period": "d 기간",
+        "k_period": "k 기간",
+        "lookback_days": "조회기간 일수"
+      },
+      "help": "Stochastic Cross 신호 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "stochrsi_signal": {
+      "label": "Stochrsi 신호",
+      "desc": "Stochrsi 신호 조건으로 종목을 필터링합니다.",
+      "params": {
+        "mode": "mode",
+        "rsi_period": "RSI 기간",
+        "stoch_period": "stoch 기간"
+      },
+      "help": "Stochrsi 신호 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "aroon_oscillator_signal": {
+      "label": "Aroon Oscillator 신호",
+      "desc": "Aroon Oscillator 신호 조건으로 종목을 필터링합니다.",
+      "params": {
+        "min_oscillator": "최소 oscillator",
+        "period": "기간"
+      },
+      "help": "Aroon Oscillator 신호 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "ultimate_oscillator_signal": {
+      "label": "Ultimate Oscillator 신호",
+      "desc": "Ultimate Oscillator 신호 조건으로 종목을 필터링합니다.",
+      "params": {
+        "min_value": "최소 가치"
+      },
+      "help": "Ultimate Oscillator 신호 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "chaikin_money_flow_signal": {
+      "label": "Chaikin Money 흐름 신호",
+      "desc": "Chaikin Money 흐름 신호 조건으로 종목을 필터링합니다.",
+      "params": {
+        "min_cmf": "최소 cmf",
+        "period": "기간"
+      },
+      "help": "Chaikin Money 흐름 신호 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "chaikin_oscillator_signal": {
+      "label": "Chaikin Oscillator 신호",
+      "desc": "Chaikin Oscillator 신호 조건으로 종목을 필터링합니다.",
+      "params": {
+        "fast_period": "fast 기간",
+        "min_value": "최소 가치",
+        "slow_period": "slow 기간"
+      },
+      "help": "Chaikin Oscillator 신호 기준값을 만족하는 종목만 통과시킵니다."
+    },
+    "ad_line_trend": {
+      "label": "Ad Line 추세",
+      "desc": "Ad Line 추세 조건으로 종목을 필터링합니다.",
+      "params": {
+        "lookback_days": "조회기간 일수"
+      },
+      "help": "Ad Line 추세 기준값을 만족하는 종목만 통과시킵니다."
     }
   },
   "settings": {

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -1211,6 +1211,722 @@
         "min_roa_pct": "最小 ROA %"
       },
       "help": "仅保留满足ROA筛选阈值的股票。"
+    },
+    "overnight_return_filter": {
+      "label": "隔夜 收益率 筛选",
+      "desc": "按隔夜 收益率 筛选条件筛选股票。",
+      "params": {
+        "min_overnight_return_pct": "最小隔夜收益率比率 %"
+      },
+      "help": "仅保留满足隔夜 收益率 筛选阈值的股票。"
+    },
+    "distance_from_52w_low": {
+      "label": "距离 From 52w 低点",
+      "desc": "按距离 From 52w 低点条件筛选股票。",
+      "params": {
+        "lookback_days": "回溯周期天数",
+        "max_distance_pct": "最大距离比率 %"
+      },
+      "help": "仅保留满足距离 From 52w 低点阈值的股票。"
+    },
+    "distance_from_200d_high": {
+      "label": "距离 From 200d 高点",
+      "desc": "按距离 From 200d 高点条件筛选股票。",
+      "params": {
+        "lookback_days": "回溯周期天数",
+        "max_distance_pct": "最大距离比率 %"
+      },
+      "help": "仅保留满足距离 From 200d 高点阈值的股票。"
+    },
+    "gap_up_breakaway": {
+      "label": "Gap Up Breakaway",
+      "desc": "按Gap Up Breakaway条件筛选股票。",
+      "params": {
+        "min_gap_pct": "最小gap比率 %"
+      },
+      "help": "仅保留满足Gap Up Breakaway阈值的股票。"
+    },
+    "gap_down_exhaustion": {
+      "label": "Gap Down Exhaustion",
+      "desc": "按Gap Down Exhaustion条件筛选股票。",
+      "params": {
+        "min_gap_down_pct": "最小gapdown比率 %"
+      },
+      "help": "仅保留满足Gap Down Exhaustion阈值的股票。"
+    },
+    "opening_range_breakout": {
+      "label": "Opening Range 突破",
+      "desc": "按Opening Range 突破条件筛选股票。",
+      "params": {
+        "direction": "direction"
+      },
+      "help": "仅保留满足Opening Range 突破阈值的股票。"
+    },
+    "pivot_point_breakout": {
+      "label": "Pivot Point 突破",
+      "desc": "按Pivot Point 突破条件筛选股票。",
+      "params": {
+        "direction": "direction"
+      },
+      "help": "仅保留满足Pivot Point 突破阈值的股票。"
+    },
+    "month_of_year_seasonality": {
+      "label": "月 Of 年 Seasonality",
+      "desc": "按月 Of 年 Seasonality条件筛选股票。",
+      "params": {
+        "min_avg_return_pct": "最小avg收益率比率 %",
+        "target_month": "target月"
+      },
+      "help": "仅保留满足月 Of 年 Seasonality阈值的股票。"
+    },
+    "turn_of_month_effect": {
+      "label": "Turn Of 月 Effect",
+      "desc": "按Turn Of 月 Effect条件筛选股票。",
+      "params": {
+        "min_avg_return_pct": "最小avg收益率比率 %",
+        "window_days": "窗口天数"
+      },
+      "help": "仅保留满足Turn Of 月 Effect阈值的股票。"
+    },
+    "day_of_week_seasonality": {
+      "label": "日 Of 周 Seasonality",
+      "desc": "按日 Of 周 Seasonality条件筛选股票。",
+      "params": {
+        "min_avg_return_pct": "最小avg收益率比率 %",
+        "target_weekday": "targetweekday"
+      },
+      "help": "仅保留满足日 Of 周 Seasonality阈值的股票。"
+    },
+    "net_share_issuance_filter": {
+      "label": "净 股份 发行 筛选",
+      "desc": "按净 股份 发行 筛选条件筛选股票。",
+      "params": {
+        "max_issuance_pct": "最大发行比率 %"
+      },
+      "help": "仅保留满足净 股份 发行 筛选阈值的股票。"
+    },
+    "insider_net_buying": {
+      "label": "Insider 净 Buying",
+      "desc": "按Insider 净 Buying条件筛选股票。",
+      "params": {
+        "min_net_buying_pct": "最小净buying比率 %"
+      },
+      "help": "仅保留满足Insider 净 Buying阈值的股票。"
+    },
+    "short_float_pct_filter": {
+      "label": "Short Float Pct 筛选",
+      "desc": "按Short Float Pct 筛选条件筛选股票。",
+      "params": {
+        "max_short_float_pct": "最大shortfloat比率 %"
+      },
+      "help": "仅保留满足Short Float Pct 筛选阈值的股票。"
+    },
+    "short_interest_ratio_filter": {
+      "label": "Short 利息 比率 筛选",
+      "desc": "按Short 利息 比率 筛选条件筛选股票。",
+      "params": {
+        "max_ratio": "最大比率"
+      },
+      "help": "仅保留满足Short 利息 比率 筛选阈值的股票。"
+    },
+    "earnings_surprise_filter": {
+      "label": "财报 惊喜 筛选",
+      "desc": "按财报 惊喜 筛选条件筛选股票。",
+      "params": {
+        "min_surprise_pct": "最小惊喜比率 %"
+      },
+      "help": "仅保留满足财报 惊喜 筛选阈值的股票。"
+    },
+    "post_earnings_drift": {
+      "label": "后 财报 Drift",
+      "desc": "按后 财报 Drift条件筛选股票。",
+      "params": {
+        "min_return_pct": "最小收益率比率 %"
+      },
+      "help": "仅保留满足后 财报 Drift阈值的股票。"
+    },
+    "pre_earnings_drift": {
+      "label": "前 财报 Drift",
+      "desc": "按前 财报 Drift条件筛选股票。",
+      "params": {
+        "min_return_pct": "最小收益率比率 %"
+      },
+      "help": "仅保留满足前 财报 Drift阈值的股票。"
+    },
+    "accruals_ratio": {
+      "label": "Accruals 比率",
+      "desc": "按Accruals 比率条件筛选股票。",
+      "params": {
+        "max_ratio": "最大比率"
+      },
+      "help": "仅保留满足Accruals 比率阈值的股票。"
+    },
+    "asset_growth_rate": {
+      "label": "资产 增长率 Rate",
+      "desc": "按资产 增长率 Rate条件筛选股票。",
+      "params": {
+        "max_growth_pct": "最大增长率比率 %"
+      },
+      "help": "仅保留满足资产 增长率 Rate阈值的股票。"
+    },
+    "momentum_12_1": {
+      "label": "动量 12 1",
+      "desc": "按动量 12 1条件筛选股票。",
+      "params": {
+        "lookback_months": "回溯周期月数",
+        "min_return_pct": "最小收益率比率 %",
+        "skip_recent_months": "skiprecent月数"
+      },
+      "help": "仅保留满足动量 12 1阈值的股票。"
+    },
+    "volatility_n_day": {
+      "label": "波动率 N 日",
+      "desc": "按波动率 N 日条件筛选股票。",
+      "params": {
+        "lookback_days": "回溯周期天数",
+        "max_annualized_vol_pct": "最大annualizedvol比率 %"
+      },
+      "help": "仅保留满足波动率 N 日阈值的股票。"
+    },
+    "distance_from_52w_high": {
+      "label": "距离 From 52w 高点",
+      "desc": "按距离 From 52w 高点条件筛选股票。",
+      "params": {
+        "lookback_days": "回溯周期天数",
+        "max_distance_pct": "最大距离比率 %"
+      },
+      "help": "仅保留满足距离 From 52w 高点阈值的股票。"
+    },
+    "relative_strength_vs_benchmark": {
+      "label": "Relative Strength Vs Benchmark",
+      "desc": "按Relative Strength Vs Benchmark条件筛选股票。",
+      "params": {
+        "lookback_days": "回溯周期天数",
+        "min_excess_return_pct": "最小excess收益率比率 %"
+      },
+      "help": "仅保留满足Relative Strength Vs Benchmark阈值的股票。"
+    },
+    "adx_trend_strength": {
+      "label": "ADX 趋势 Strength",
+      "desc": "按ADX 趋势 Strength条件筛选股票。",
+      "params": {
+        "di_direction": "didirection",
+        "min_adx": "最小ADX",
+        "period": "周期"
+      },
+      "help": "仅保留满足ADX 趋势 Strength阈值的股票。"
+    },
+    "ma_ribbon_alignment": {
+      "label": "Ma Ribbon Alignment",
+      "desc": "按Ma Ribbon Alignment条件筛选股票。",
+      "params": {
+        "long_period": "long周期",
+        "mid_period": "mid周期",
+        "short_period": "short周期"
+      },
+      "help": "仅保留满足Ma Ribbon Alignment阈值的股票。"
+    },
+    "golden_cross_50_200": {
+      "label": "Golden Cross 50 200",
+      "desc": "按Golden Cross 50 200条件筛选股票。",
+      "params": {
+        "lookback_days": "回溯周期天数"
+      },
+      "help": "仅保留满足Golden Cross 50 200阈值的股票。"
+    },
+    "death_cross_50_200": {
+      "label": "Death Cross 50 200",
+      "desc": "按Death Cross 50 200条件筛选股票。",
+      "params": {
+        "lookback_days": "回溯周期天数"
+      },
+      "help": "仅保留满足Death Cross 50 200阈值的股票。"
+    },
+    "donchian_channel_breakout": {
+      "label": "Donchian Channel 突破",
+      "desc": "按Donchian Channel 突破条件筛选股票。",
+      "params": {
+        "lookback_days": "回溯周期天数"
+      },
+      "help": "仅保留满足Donchian Channel 突破阈值的股票。"
+    },
+    "keltner_channel_breakout": {
+      "label": "Keltner Channel 突破",
+      "desc": "按Keltner Channel 突破条件筛选股票。",
+      "params": {
+        "atr_multiplier": "ATRmultiplier",
+        "atr_period": "ATR周期",
+        "ema_period": "ema周期"
+      },
+      "help": "仅保留满足Keltner Channel 突破阈值的股票。"
+    },
+    "parabolic_sar_flip": {
+      "label": "Parabolic Sar Flip",
+      "desc": "按Parabolic Sar Flip条件筛选股票。",
+      "params": {
+        "af_max": "afmax",
+        "af_step": "afstep",
+        "lookback_days": "回溯周期天数"
+      },
+      "help": "仅保留满足Parabolic Sar Flip阈值的股票。"
+    },
+    "linear_regression_slope_filter": {
+      "label": "Linear Regression Slope 筛选",
+      "desc": "按Linear Regression Slope 筛选条件筛选股票。",
+      "params": {
+        "lookback_days": "回溯周期天数",
+        "min_slope": "最小slope"
+      },
+      "help": "仅保留满足Linear Regression Slope 筛选阈值的股票。"
+    },
+    "linear_regression_angle_filter": {
+      "label": "Linear Regression Angle 筛选",
+      "desc": "按Linear Regression Angle 筛选条件筛选股票。",
+      "params": {
+        "lookback_days": "回溯周期天数",
+        "min_angle_deg": "最小angledeg"
+      },
+      "help": "仅保留满足Linear Regression Angle 筛选阈值的股票。"
+    },
+    "linear_regression_r2_filter": {
+      "label": "Linear Regression R2 筛选",
+      "desc": "按Linear Regression R2 筛选条件筛选股票。",
+      "params": {
+        "lookback_days": "回溯周期天数",
+        "min_r2": "最小r2"
+      },
+      "help": "仅保留满足Linear Regression R2 筛选阈值的股票。"
+    },
+    "beta_to_benchmark": {
+      "label": "Beta To Benchmark",
+      "desc": "按Beta To Benchmark条件筛选股票。",
+      "params": {
+        "lookback_days": "回溯周期天数",
+        "max_beta": "最大beta"
+      },
+      "help": "仅保留满足Beta To Benchmark阈值的股票。"
+    },
+    "correlation_to_benchmark": {
+      "label": "Correlation To Benchmark",
+      "desc": "按Correlation To Benchmark条件筛选股票。",
+      "params": {
+        "lookback_days": "回溯周期天数",
+        "max_corr": "最大corr"
+      },
+      "help": "仅保留满足Correlation To Benchmark阈值的股票。"
+    },
+    "support_retest_signal": {
+      "label": "Support Retest 信号",
+      "desc": "按Support Retest 信号条件筛选股票。",
+      "params": {
+        "support_lookback": "support回溯周期",
+        "tolerance_pct": "tolerance比率 %"
+      },
+      "help": "仅保留满足Support Retest 信号阈值的股票。"
+    },
+    "resistance_retest_signal": {
+      "label": "Resistance Retest 信号",
+      "desc": "按Resistance Retest 信号条件筛选股票。",
+      "params": {
+        "resistance_lookback": "resistance回溯周期",
+        "tolerance_pct": "tolerance比率 %"
+      },
+      "help": "仅保留满足Resistance Retest 信号阈值的股票。"
+    },
+    "downside_volatility_filter": {
+      "label": "Downside 波动率 筛选",
+      "desc": "按Downside 波动率 筛选条件筛选股票。",
+      "params": {
+        "lookback_days": "回溯周期天数",
+        "max_downside_vol_pct": "最大downsidevol比率 %"
+      },
+      "help": "仅保留满足Downside 波动率 筛选阈值的股票。"
+    },
+    "semivariance_filter": {
+      "label": "Semivariance 筛选",
+      "desc": "按Semivariance 筛选条件筛选股票。",
+      "params": {
+        "lookback_days": "回溯周期天数",
+        "max_semivariance": "最大semivariance"
+      },
+      "help": "仅保留满足Semivariance 筛选阈值的股票。"
+    },
+    "rolling_sharpe_filter": {
+      "label": "Rolling Sharpe 筛选",
+      "desc": "按Rolling Sharpe 筛选条件筛选股票。",
+      "params": {
+        "lookback_days": "回溯周期天数",
+        "min_sharpe": "最小sharpe"
+      },
+      "help": "仅保留满足Rolling Sharpe 筛选阈值的股票。"
+    },
+    "rolling_sortino_filter": {
+      "label": "Rolling Sortino 筛选",
+      "desc": "按Rolling Sortino 筛选条件筛选股票。",
+      "params": {
+        "lookback_days": "回溯周期天数",
+        "min_sortino": "最小sortino"
+      },
+      "help": "仅保留满足Rolling Sortino 筛选阈值的股票。"
+    },
+    "ulcer_index_filter": {
+      "label": "Ulcer Index 筛选",
+      "desc": "按Ulcer Index 筛选条件筛选股票。",
+      "params": {
+        "lookback_days": "回溯周期天数",
+        "max_ulcer_index": "最大ulcerindex"
+      },
+      "help": "仅保留满足Ulcer Index 筛选阈值的股票。"
+    },
+    "calmar_ratio_filter": {
+      "label": "Calmar 比率 筛选",
+      "desc": "按Calmar 比率 筛选条件筛选股票。",
+      "params": {
+        "lookback_days": "回溯周期天数",
+        "min_calmar": "最小calmar"
+      },
+      "help": "仅保留满足Calmar 比率 筛选阈值的股票。"
+    },
+    "max_drawdown_window_filter": {
+      "label": "Max Drawdown Window 筛选",
+      "desc": "按Max Drawdown Window 筛选条件筛选股票。",
+      "params": {
+        "lookback_days": "回溯周期天数",
+        "max_drawdown_pct": "最大drawdown比率 %"
+      },
+      "help": "仅保留满足Max Drawdown Window 筛选阈值的股票。"
+    },
+    "return_skewness_filter": {
+      "label": "收益率 Skewness 筛选",
+      "desc": "按收益率 Skewness 筛选条件筛选股票。",
+      "params": {
+        "lookback_days": "回溯周期天数",
+        "min_skewness": "最小skewness"
+      },
+      "help": "仅保留满足收益率 Skewness 筛选阈值的股票。"
+    },
+    "return_kurtosis_filter": {
+      "label": "收益率 Kurtosis 筛选",
+      "desc": "按收益率 Kurtosis 筛选条件筛选股票。",
+      "params": {
+        "lookback_days": "回溯周期天数",
+        "max_kurtosis": "最大kurtosis"
+      },
+      "help": "仅保留满足收益率 Kurtosis 筛选阈值的股票。"
+    },
+    "intraday_return_filter": {
+      "label": "Intraday 收益率 筛选",
+      "desc": "按Intraday 收益率 筛选条件筛选股票。",
+      "params": {
+        "min_intraday_return_pct": "最小intraday收益率比率 %"
+      },
+      "help": "仅保留满足Intraday 收益率 筛选阈值的股票。"
+    },
+    "dso_trend_filter": {
+      "label": "Dso 趋势 筛选",
+      "desc": "按Dso 趋势 筛选条件筛选股票。",
+      "params": {
+        "lookback_years": "回溯周期年数",
+        "min_dso_increase_pct": "最小dsoincrease比率 %"
+      },
+      "help": "仅保留满足Dso 趋势 筛选阈值的股票。"
+    },
+    "ema_cross": {
+      "label": "Ema Cross",
+      "desc": "按Ema Cross条件筛选股票。",
+      "params": {
+        "direction": "direction",
+        "fast_period": "fast周期",
+        "lookback_days": "回溯周期天数",
+        "slow_period": "slow周期"
+      },
+      "help": "仅保留满足Ema Cross阈值的股票。"
+    },
+    "ema_slope": {
+      "label": "Ema Slope",
+      "desc": "按Ema Slope条件筛选股票。",
+      "params": {
+        "lookback_days": "回溯周期天数",
+        "min_slope_pct": "最小slope比率 %",
+        "period": "周期"
+      },
+      "help": "仅保留满足Ema Slope阈值的股票。"
+    },
+    "sma_slope": {
+      "label": "Sma Slope",
+      "desc": "按Sma Slope条件筛选股票。",
+      "params": {
+        "lookback_days": "回溯周期天数",
+        "min_slope_pct": "最小slope比率 %",
+        "period": "周期"
+      },
+      "help": "仅保留满足Sma Slope阈值的股票。"
+    },
+    "macd_signal_cross": {
+      "label": "MACD 信号 Cross",
+      "desc": "按MACD 信号 Cross条件筛选股票。",
+      "params": {
+        "direction": "direction",
+        "fast_period": "fast周期",
+        "lookback_days": "回溯周期天数",
+        "signal_period": "信号周期",
+        "slow_period": "slow周期"
+      },
+      "help": "仅保留满足MACD 信号 Cross阈值的股票。"
+    },
+    "macd_histogram_slope": {
+      "label": "MACD Histogram Slope",
+      "desc": "按MACD Histogram Slope条件筛选股票。",
+      "params": {
+        "fast_period": "fast周期",
+        "lookback_days": "回溯周期天数",
+        "min_slope": "最小slope",
+        "signal_period": "信号周期",
+        "slow_period": "slow周期"
+      },
+      "help": "仅保留满足MACD Histogram Slope阈值的股票。"
+    },
+    "cci_overbought_oversold": {
+      "label": "CCI Overbought Oversold",
+      "desc": "按CCI Overbought Oversold条件筛选股票。",
+      "params": {
+        "mode": "mode",
+        "period": "周期",
+        "threshold": "阈值"
+      },
+      "help": "仅保留满足CCI Overbought Oversold阈值的股票。"
+    },
+    "williams_r_reversal": {
+      "label": "Williams R Reversal",
+      "desc": "按Williams R Reversal条件筛选股票。",
+      "params": {
+        "direction": "direction",
+        "overbought": "overbought",
+        "oversold": "oversold",
+        "period": "周期"
+      },
+      "help": "仅保留满足Williams R Reversal阈值的股票。"
+    },
+    "trix_cross": {
+      "label": "Trix Cross",
+      "desc": "按Trix Cross条件筛选股票。",
+      "params": {
+        "direction": "direction",
+        "lookback_days": "回溯周期天数",
+        "period": "周期",
+        "signal_period": "信号周期"
+      },
+      "help": "仅保留满足Trix Cross阈值的股票。"
+    },
+    "aroon_trend_signal": {
+      "label": "Aroon 趋势 信号",
+      "desc": "按Aroon 趋势 信号条件筛选股票。",
+      "params": {
+        "direction": "direction",
+        "min_aroon": "最小aroon",
+        "period": "周期"
+      },
+      "help": "仅保留满足Aroon 趋势 信号阈值的股票。"
+    },
+    "money_flow_index_signal": {
+      "label": "Money 流 Index 信号",
+      "desc": "按Money 流 Index 信号条件筛选股票。",
+      "params": {
+        "mode": "mode",
+        "overbought": "overbought",
+        "oversold": "oversold",
+        "period": "周期"
+      },
+      "help": "仅保留满足Money 流 Index 信号阈值的股票。"
+    },
+    "vwap_cross_signal": {
+      "label": "Vwap Cross 信号",
+      "desc": "按Vwap Cross 信号条件筛选股票。",
+      "params": {
+        "lookback_days": "回溯周期天数",
+        "period": "周期"
+      },
+      "help": "仅保留满足Vwap Cross 信号阈值的股票。"
+    },
+    "vwap_distance_pct": {
+      "label": "Vwap 距离 Pct",
+      "desc": "按Vwap 距离 Pct条件筛选股票。",
+      "params": {
+        "max_distance_pct": "最大距离比率 %",
+        "period": "周期"
+      },
+      "help": "仅保留满足Vwap 距离 Pct阈值的股票。"
+    },
+    "relative_volume_percentile": {
+      "label": "Relative 成交量 Percentile",
+      "desc": "按Relative 成交量 Percentile条件筛选股票。",
+      "params": {
+        "lookback_days": "回溯周期天数",
+        "min_percentile": "最小percentile"
+      },
+      "help": "仅保留满足Relative 成交量 Percentile阈值的股票。"
+    },
+    "turnover_ratio_min": {
+      "label": "周转率 比率 Min",
+      "desc": "按周转率 比率 Min条件筛选股票。",
+      "params": {
+        "min_turnover_ratio": "最小周转率比率"
+      },
+      "help": "仅保留满足周转率 比率 Min阈值的股票。"
+    },
+    "atr_percentile_filter": {
+      "label": "ATR Percentile 筛选",
+      "desc": "按ATR Percentile 筛选条件筛选股票。",
+      "params": {
+        "atr_period": "ATR周期",
+        "lookback_days": "回溯周期天数",
+        "max_percentile": "最大percentile"
+      },
+      "help": "仅保留满足ATR Percentile 筛选阈值的股票。"
+    },
+    "atr_expansion_breakout": {
+      "label": "ATR Expansion 突破",
+      "desc": "按ATR Expansion 突破条件筛选股票。",
+      "params": {
+        "atr_multiplier": "ATRmultiplier",
+        "atr_period": "ATR周期",
+        "breakout_lookback": "突破回溯周期"
+      },
+      "help": "仅保留满足ATR Expansion 突破阈值的股票。"
+    },
+    "natr_filter": {
+      "label": "Natr 筛选",
+      "desc": "按Natr 筛选条件筛选股票。",
+      "params": {
+        "max_natr_pct": "最大natr比率 %",
+        "period": "周期"
+      },
+      "help": "仅保留满足Natr 筛选阈值的股票。"
+    },
+    "dmi_directional_cross": {
+      "label": "Dmi Directional Cross",
+      "desc": "按Dmi Directional Cross条件筛选股票。",
+      "params": {
+        "lookback_days": "回溯周期天数",
+        "period": "周期"
+      },
+      "help": "仅保留满足Dmi Directional Cross阈值的股票。"
+    },
+    "ichimoku_cloud_breakout": {
+      "label": "Ichimoku Cloud 突破",
+      "desc": "按Ichimoku Cloud 突破条件筛选股票。",
+      "params": {
+        "base_period": "base周期",
+        "conversion_period": "conversion周期",
+        "span_b_period": "spanb周期"
+      },
+      "help": "仅保留满足Ichimoku Cloud 突破阈值的股票。"
+    },
+    "ichimoku_tenkan_kijun_cross": {
+      "label": "Ichimoku Tenkan Kijun Cross",
+      "desc": "按Ichimoku Tenkan Kijun Cross条件筛选股票。",
+      "params": {
+        "base_period": "base周期",
+        "conversion_period": "conversion周期",
+        "lookback_days": "回溯周期天数"
+      },
+      "help": "仅保留满足Ichimoku Tenkan Kijun Cross阈值的股票。"
+    },
+    "bollinger_squeeze_breakout": {
+      "label": "Bollinger Squeeze 突破",
+      "desc": "按Bollinger Squeeze 突破条件筛选股票。",
+      "params": {
+        "max_width_pct": "最大width比率 %",
+        "period": "周期",
+        "std_mult": "stdmult"
+      },
+      "help": "仅保留满足Bollinger Squeeze 突破阈值的股票。"
+    },
+    "bollinger_percent_b": {
+      "label": "Bollinger Percent B",
+      "desc": "按Bollinger Percent B条件筛选股票。",
+      "params": {
+        "max_percent_b": "最大percentb",
+        "min_percent_b": "最小percentb",
+        "period": "周期",
+        "std_mult": "stdmult"
+      },
+      "help": "仅保留满足Bollinger Percent B阈值的股票。"
+    },
+    "ppo_signal_cross": {
+      "label": "Ppo 信号 Cross",
+      "desc": "按Ppo 信号 Cross条件筛选股票。",
+      "params": {
+        "fast_period": "fast周期",
+        "lookback_days": "回溯周期天数",
+        "signal_period": "信号周期",
+        "slow_period": "slow周期"
+      },
+      "help": "仅保留满足Ppo 信号 Cross阈值的股票。"
+    },
+    "stochastic_cross_signal": {
+      "label": "Stochastic Cross 信号",
+      "desc": "按Stochastic Cross 信号条件筛选股票。",
+      "params": {
+        "d_period": "d周期",
+        "k_period": "k周期",
+        "lookback_days": "回溯周期天数"
+      },
+      "help": "仅保留满足Stochastic Cross 信号阈值的股票。"
+    },
+    "stochrsi_signal": {
+      "label": "Stochrsi 信号",
+      "desc": "按Stochrsi 信号条件筛选股票。",
+      "params": {
+        "mode": "mode",
+        "rsi_period": "RSI周期",
+        "stoch_period": "stoch周期"
+      },
+      "help": "仅保留满足Stochrsi 信号阈值的股票。"
+    },
+    "aroon_oscillator_signal": {
+      "label": "Aroon Oscillator 信号",
+      "desc": "按Aroon Oscillator 信号条件筛选股票。",
+      "params": {
+        "min_oscillator": "最小oscillator",
+        "period": "周期"
+      },
+      "help": "仅保留满足Aroon Oscillator 信号阈值的股票。"
+    },
+    "ultimate_oscillator_signal": {
+      "label": "Ultimate Oscillator 信号",
+      "desc": "按Ultimate Oscillator 信号条件筛选股票。",
+      "params": {
+        "min_value": "最小价值"
+      },
+      "help": "仅保留满足Ultimate Oscillator 信号阈值的股票。"
+    },
+    "chaikin_money_flow_signal": {
+      "label": "Chaikin Money 流 信号",
+      "desc": "按Chaikin Money 流 信号条件筛选股票。",
+      "params": {
+        "min_cmf": "最小cmf",
+        "period": "周期"
+      },
+      "help": "仅保留满足Chaikin Money 流 信号阈值的股票。"
+    },
+    "chaikin_oscillator_signal": {
+      "label": "Chaikin Oscillator 信号",
+      "desc": "按Chaikin Oscillator 信号条件筛选股票。",
+      "params": {
+        "fast_period": "fast周期",
+        "min_value": "最小价值",
+        "slow_period": "slow周期"
+      },
+      "help": "仅保留满足Chaikin Oscillator 信号阈值的股票。"
+    },
+    "ad_line_trend": {
+      "label": "Ad Line 趋势",
+      "desc": "按Ad Line 趋势条件筛选股票。",
+      "params": {
+        "lookback_days": "回溯周期天数"
+      },
+      "help": "仅保留满足Ad Line 趋势阈值的股票。"
     }
   },
   "settings": {

--- a/web/package.json
+++ b/web/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "check:condition-i18n": "node scripts/check-condition-i18n.mjs",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:visual": "playwright test e2e/visual.spec.ts",

--- a/web/scripts/check-condition-i18n.mjs
+++ b/web/scripts/check-condition-i18n.mjs
@@ -1,0 +1,106 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = path.resolve(process.cwd(), '..');
+const conditionsDir = path.join(repoRoot, 'screener', 'conditions');
+const messagePaths = {
+  en: path.join(process.cwd(), 'messages', 'en.json'),
+  ko: path.join(process.cwd(), 'messages', 'ko.json'),
+  zh: path.join(process.cwd(), 'messages', 'zh.json'),
+};
+
+const registerPattern = /@register_condition\((.*?)\)\s*class\s/gs;
+const keyPattern = /key\s*=\s*"([a-z0-9_]+)"/;
+const paramPattern = /"name"\s*:\s*"([a-z0-9_]+)"/g;
+const metaKeys = new Set(['recommended', 'categories']);
+
+function parseRegistry() {
+  const files = fs.readdirSync(conditionsDir).filter((name) => name.endsWith('.py'));
+  const registry = new Map();
+
+  for (const file of files) {
+    const fullPath = path.join(conditionsDir, file);
+    const text = fs.readFileSync(fullPath, 'utf8');
+
+    for (const match of text.matchAll(registerPattern)) {
+      const block = match[1];
+      const keyMatch = block.match(keyPattern);
+      if (!keyMatch) continue;
+
+      const key = keyMatch[1];
+      const params = new Set();
+      for (const pm of block.matchAll(paramPattern)) {
+        params.add(pm[1]);
+      }
+      registry.set(key, Array.from(params).sort());
+    }
+  }
+
+  return registry;
+}
+
+function loadConditions(locale) {
+  const raw = fs.readFileSync(messagePaths[locale], 'utf8');
+  const json = JSON.parse(raw);
+  return json.conditions ?? {};
+}
+
+function pushIssue(issues, locale, key, field, detail = '') {
+  issues.push(`[${locale}] ${key}: missing ${field}${detail ? ` (${detail})` : ''}`);
+}
+
+function validate() {
+  const registry = parseRegistry();
+  const locales = ['en', 'ko', 'zh'];
+  const localized = Object.fromEntries(locales.map((loc) => [loc, loadConditions(loc)]));
+  const issues = [];
+
+  for (const [key, params] of registry.entries()) {
+    for (const locale of locales) {
+      const entry = localized[locale][key];
+      if (!entry || typeof entry !== 'object') {
+        pushIssue(issues, locale, key, 'entry');
+        continue;
+      }
+
+      if (!entry.label) pushIssue(issues, locale, key, 'label');
+      if (!entry.desc) pushIssue(issues, locale, key, 'desc');
+      if (!entry.help) pushIssue(issues, locale, key, 'help');
+
+      if (!entry.params || typeof entry.params !== 'object') {
+        if (params.length > 0) {
+          pushIssue(issues, locale, key, 'params object');
+        }
+        continue;
+      }
+
+      for (const param of params) {
+        if (!entry.params[param]) {
+          pushIssue(issues, locale, key, 'param', param);
+        }
+      }
+    }
+  }
+
+  for (const locale of locales) {
+    const keys = Object.keys(localized[locale]);
+    for (const key of keys) {
+      if (metaKeys.has(key)) continue;
+      if (!registry.has(key)) {
+        pushIssue(issues, locale, key, 'registry key');
+      }
+    }
+  }
+
+  if (issues.length > 0) {
+    console.error('Condition i18n contract check failed.');
+    for (const issue of issues) {
+      console.error(`- ${issue}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(`Condition i18n contract OK. registry=${registry.size}, locales=${locales.join(',')}`);
+}
+
+validate();


### PR DESCRIPTION
## Summary
- backfill missing `conditions.*` entries for all registered strategy conditions in `en/ko/zh`
- add `web/scripts/check-condition-i18n.mjs` to verify registry key/param parity against locale files
- wire CI guard into lint workflow via `npm run check:condition-i18n`

## Verification
- [x] `npm --prefix web run check:condition-i18n`
- [x] `npm --prefix web run lint`
- [x] `npm --prefix web run build`

## Notes
- This prevents new condition registrations from silently shipping with missing locale coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)