### PR TITLE
feat: add beginner-friendly guidance for strategy conditions

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -373,7 +373,17 @@
     "deleteConfirm": "Delete this strategy?",
     "unsavedChanges": "You have unsaved changes",
     "lastSaved": "Last saved: {time}",
-    "strategyNameRequired": "Strategy name is required"
+    "strategyNameRequired": "Strategy name is required",
+    "guidanceWhenToUse": "When to use",
+    "guidanceHowToRead": "How to read",
+    "guidanceCaution": "Caution",
+    "guidanceFallbackWhenToUse": "Use this condition to narrow candidates before combining with trend/volume confirmation.",
+    "guidanceFallbackHowToReadRange": "Values inside the configured range pass this filter.",
+    "guidanceFallbackHowToReadMin": "Higher values (above the minimum) are favored by this filter.",
+    "guidanceFallbackHowToReadMax": "Lower values (below the maximum) are favored by this filter.",
+    "guidanceFallbackHowToReadTarget": "This checks whether performance is favorable on the selected target bucket (e.g., weekday/month).",
+    "guidanceFallbackHowToReadGeneral": "Tune the threshold using backtest results and keep it stable across market regimes.",
+    "guidanceFallbackCaution": "Avoid using this alone. Combine with risk and trend conditions to reduce false signals."
   },
   "analysis": {
     "title": "Charts & Analysis",
@@ -649,7 +659,10 @@
         "threshold": "RSI threshold",
         "period": "RSI period"
       },
-      "help": "RSI is low — the stock may be oversold and due for a bounce."
+      "help": "RSI is low — the stock may be oversold and due for a bounce.",
+      "whenToUse": "Use for mean-reversion setups after sharp pullbacks.",
+      "howToRead": "Lower RSI means stronger oversold signal. Typical references are around 30.",
+      "caution": "In strong downtrends RSI can stay oversold for extended periods."
     },
     "rsi_overbought": {
       "label": "RSI Overbought",
@@ -658,7 +671,10 @@
         "threshold": "RSI threshold",
         "period": "RSI period"
       },
-      "help": "RSI is high — the stock may be overbought and due for a pullback."
+      "help": "RSI is high — the stock may be overbought and due for a pullback.",
+      "whenToUse": "Use for pullback-risk checks or short-term contrarian setups.",
+      "howToRead": "Higher RSI means stronger overbought signal. Typical references are around 70.",
+      "caution": "In strong uptrends RSI can stay overbought longer than expected."
     },
     "rsi_range": {
       "label": "RSI Range",
@@ -668,7 +684,10 @@
         "upper": "Upper bound",
         "period": "RSI period"
       },
-      "help": "RSI is within a neutral zone — useful for finding stable momentum."
+      "help": "RSI is within a neutral zone — useful for finding stable momentum.",
+      "whenToUse": "Use when you want stable momentum names within a controlled RSI band.",
+      "howToRead": "Only stocks inside the lower-upper RSI band pass.",
+      "caution": "Too narrow a range can overfit and reduce candidate diversity."
     },
     "bollinger_width": {
       "label": "Bollinger Width",
@@ -1290,21 +1309,27 @@
       "help": "Filters stocks based on Turn Of Month threshold settings."
     },
     "day_of_week_seasonality": {
-      "label": "Day Of Week",
-      "desc": "Average weekday return effect",
+      "label": "Day-of-Week Seasonality",
+      "desc": "Filters stocks that historically perform better on a selected weekday.",
       "params": {
         "min_avg_return_pct": "Minimum Avg Return %",
-        "target_weekday": "Target Weekday"
+        "target_weekday": "Target Weekday (0=Mon, 4=Fri)"
       },
-      "help": "Filters stocks based on Day Of Week threshold settings."
+      "help": "Looks for repeatable weekday return patterns in historical data.",
+      "whenToUse": "Use for short-horizon tactical entries when you suspect weekday effects in your market.",
+      "howToRead": "A higher minimum average return is stricter. Start small and verify persistence by period.",
+      "caution": "Weekday effects can disappear after transaction costs or regime shifts; validate out-of-sample."
     },
     "net_share_issuance_filter": {
       "label": "Net Share Issuance Filter",
-      "desc": "Limit net share issuance",
+      "desc": "Limits dilution by filtering companies issuing too many new shares.",
       "params": {
         "max_issuance_pct": "Maximum Issuance %"
       },
-      "help": "Filters stocks based on Net Share Issuance Filter threshold settings."
+      "help": "Keeps companies with controlled net share issuance.",
+      "whenToUse": "Use in quality/value screens to avoid dilution-heavy names.",
+      "howToRead": "This is a max threshold: lower values imply less shareholder dilution.",
+      "caution": "Temporary issuance can be strategic (M&A/capex); review context before excluding."
     },
     "insider_net_buying": {
       "label": "Insider Net Buying",
@@ -1316,27 +1341,36 @@
     },
     "short_float_pct_filter": {
       "label": "Short Float % Filter",
-      "desc": "Short float percentage threshold",
+      "desc": "Limits candidates by short interest as a percentage of float.",
       "params": {
         "max_short_float_pct": "Maximum Short Float %"
       },
-      "help": "Filters stocks based on Short Float % Filter threshold settings."
+      "help": "Keeps stocks where short float is below your risk tolerance.",
+      "whenToUse": "Use to avoid crowded short names in long strategies, or invert logic in squeeze-focused setups.",
+      "howToRead": "This is a max threshold: lower values mean lower shorting pressure and usually lower squeeze risk.",
+      "caution": "High short float is not always bearish; it can also fuel sharp squeezes."
     },
     "short_interest_ratio_filter": {
       "label": "Short Interest Ratio Filter",
-      "desc": "Days-to-cover threshold",
+      "desc": "Filters by days-to-cover level from short interest.",
       "params": {
         "max_ratio": "Maximum Ratio"
       },
-      "help": "Filters stocks based on Short Interest Ratio Filter threshold settings."
+      "help": "Controls exposure to names with heavy short positioning relative to volume.",
+      "whenToUse": "Use with liquidity filters to avoid hard-to-exit names.",
+      "howToRead": "This is a max threshold: lower is generally safer for execution.",
+      "caution": "Low volume periods can inflate days-to-cover temporarily."
     },
     "earnings_surprise_filter": {
       "label": "Earnings Surprise Filter",
-      "desc": "Quarterly earnings surprise threshold",
+      "desc": "Filters stocks with positive earnings surprise vs consensus.",
       "params": {
         "min_surprise_pct": "Minimum Surprise %"
       },
-      "help": "Filters stocks based on Earnings Surprise Filter threshold settings."
+      "help": "Finds names that beat expectations by at least your threshold.",
+      "whenToUse": "Use around earnings seasons for momentum continuation or post-event drift ideas.",
+      "howToRead": "This is a min threshold: higher values demand stronger positive surprise.",
+      "caution": "One-off accounting effects can distort surprise; confirm with guidance/revision metrics."
     },
     "post_earnings_drift": {
       "label": "Post Earnings Drift",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -373,7 +373,17 @@
     "deleteConfirm": "이 전략을 삭제할까요?",
     "unsavedChanges": "저장되지 않은 변경 사항이 있습니다",
     "lastSaved": "마지막 저장: {time}",
-    "strategyNameRequired": "전략 이름을 입력하세요"
+    "strategyNameRequired": "전략 이름을 입력하세요",
+    "guidanceWhenToUse": "언제 사용하면 좋은가",
+    "guidanceHowToRead": "해석 방법",
+    "guidanceCaution": "주의할 점",
+    "guidanceFallbackWhenToUse": "이 조건은 1차 후보를 좁힐 때 사용하고, 추세/거래량 조건과 함께 조합하는 것이 좋습니다.",
+    "guidanceFallbackHowToReadRange": "설정한 범위 안에 값이 들어오면 통과합니다.",
+    "guidanceFallbackHowToReadMin": "최소값 기준 조건이므로 값이 높을수록 통과에 유리합니다.",
+    "guidanceFallbackHowToReadMax": "최대값 기준 조건이므로 값이 낮을수록 통과에 유리합니다.",
+    "guidanceFallbackHowToReadTarget": "선택한 타겟 구간(예: 요일/월)에서 성과가 유리한지를 확인합니다.",
+    "guidanceFallbackHowToReadGeneral": "백테스트 결과를 기준으로 임계값을 조정하고, 시장 국면이 바뀌어도 과도하게 흔들리지 않게 유지하세요.",
+    "guidanceFallbackCaution": "단독 사용보다 리스크/추세 조건과 함께 써서 오신호를 줄이는 것을 권장합니다."
   },
   "analysis": {
     "title": "차트 & 분석",
@@ -649,7 +659,10 @@
         "threshold": "RSI 기준값",
         "period": "RSI 기간"
       },
-      "help": "RSI가 낮아 과매도 상태 — 반등 가능성이 있습니다."
+      "help": "RSI가 낮아 과매도 상태 — 반등 가능성이 있습니다.",
+      "whenToUse": "급락 이후 단기 반등(평균회귀) 후보를 찾을 때 사용합니다.",
+      "howToRead": "RSI가 낮을수록 과매도 강도가 큽니다. 보통 30 전후를 참고합니다.",
+      "caution": "강한 하락 추세에서는 RSI 과매도 상태가 오래 지속될 수 있습니다."
     },
     "rsi_overbought": {
       "label": "RSI 과매수",
@@ -658,7 +671,10 @@
         "threshold": "RSI 기준값",
         "period": "RSI 기간"
       },
-      "help": "RSI가 높아 과매수 상태 — 조정 가능성이 있습니다."
+      "help": "RSI가 높아 과매수 상태 — 조정 가능성이 있습니다.",
+      "whenToUse": "단기 과열 점검 또는 조정 가능성 확인에 사용합니다.",
+      "howToRead": "RSI가 높을수록 과매수 강도가 큽니다. 보통 70 전후를 참고합니다.",
+      "caution": "강한 상승 추세에서는 과매수 신호가 오래 유지될 수 있습니다."
     },
     "rsi_range": {
       "label": "RSI 범위",
@@ -668,7 +684,10 @@
         "upper": "상한값",
         "period": "RSI 기간"
       },
-      "help": "RSI가 중립 구간에 있어 안정적인 모멘텀을 보여줍니다."
+      "help": "RSI가 중립 구간에 있어 안정적인 모멘텀을 보여줍니다.",
+      "whenToUse": "과열/과매도 구간을 피하고 중립 모멘텀 구간만 고를 때 사용합니다.",
+      "howToRead": "하한~상한 범위 안에 RSI가 들어오면 통과합니다.",
+      "caution": "범위를 너무 좁게 잡으면 후보가 과도하게 줄어 과최적화 위험이 커집니다."
     },
     "bollinger_width": {
       "label": "볼린저 밴드 폭",
@@ -1290,21 +1309,27 @@
       "help": "Turn Of 월 Effect 기준값을 만족하는 종목만 통과시킵니다."
     },
     "day_of_week_seasonality": {
-      "label": "일 Of 주 Seasonality",
-      "desc": "일 Of 주 Seasonality 조건으로 종목을 필터링합니다.",
+      "label": "요일 계절성",
+      "desc": "선택한 요일에 평균 수익률이 양호했던 종목을 필터링합니다.",
       "params": {
-        "min_avg_return_pct": "최소 avg 수익률 비율 %",
-        "target_weekday": "target weekday"
+        "min_avg_return_pct": "최소 평균 수익률 %",
+        "target_weekday": "대상 요일 (0=월, 4=금)"
       },
-      "help": "일 Of 주 Seasonality 기준값을 만족하는 종목만 통과시킵니다."
+      "help": "요일별 반복 패턴(캘린더 효과)이 있는 종목을 찾습니다.",
+      "whenToUse": "단기 진입 타이밍을 잡을 때, 특정 요일 효과가 있다고 가정하면 유용합니다.",
+      "howToRead": "최소 평균 수익률을 높일수록 더 엄격해집니다. 낮은 값부터 시작해 안정성을 확인하세요.",
+      "caution": "요일 효과는 거래비용/시장 국면 변화에 쉽게 약해질 수 있으므로 기간 분할 검증이 필요합니다."
     },
     "net_share_issuance_filter": {
-      "label": "순 주식 발행 필터",
-      "desc": "순 주식 발행 필터 조건으로 종목을 필터링합니다.",
+      "label": "순주식발행 필터",
+      "desc": "신주 발행으로 인한 주주 희석이 큰 종목을 제외합니다.",
       "params": {
         "max_issuance_pct": "최대 발행 비율 %"
       },
-      "help": "순 주식 발행 필터 기준값을 만족하는 종목만 통과시킵니다."
+      "help": "순주식발행률이 상한 이하인 종목만 통과시킵니다.",
+      "whenToUse": "품질/가치 전략에서 주주가치 희석 리스크를 줄일 때 사용합니다.",
+      "howToRead": "최대값 조건입니다. 값이 낮을수록 일반적으로 희석 부담이 적습니다.",
+      "caution": "증자에는 성장 투자 목적이 있을 수 있으므로 기업 상황을 함께 보세요."
     },
     "insider_net_buying": {
       "label": "Insider 순 Buying",
@@ -1315,28 +1340,37 @@
       "help": "Insider 순 Buying 기준값을 만족하는 종목만 통과시킵니다."
     },
     "short_float_pct_filter": {
-      "label": "Short Float Pct 필터",
-      "desc": "Short Float Pct 필터 조건으로 종목을 필터링합니다.",
+      "label": "공매도 유통주식 비율 필터",
+      "desc": "유통주식 대비 공매도 비율(Short Float)이 낮은 종목을 선별합니다.",
       "params": {
-        "max_short_float_pct": "최대 short float 비율 %"
+        "max_short_float_pct": "최대 공매도 유통주식 비율 %"
       },
-      "help": "Short Float Pct 필터 기준값을 만족하는 종목만 통과시킵니다."
+      "help": "설정한 상한 이하의 공매도 비율을 가진 종목만 통과시킵니다.",
+      "whenToUse": "롱 전략에서 과도한 숏 포지션 종목을 피하고 싶을 때 사용합니다.",
+      "howToRead": "최대값 조건입니다. 값이 낮을수록 일반적으로 숏 압력이 낮고 변동 리스크가 작습니다.",
+      "caution": "공매도 비율이 높다고 항상 악재는 아닙니다. 숏 스퀴즈 가능성도 함께 고려하세요."
     },
     "short_interest_ratio_filter": {
-      "label": "Short 이자 비율 필터",
-      "desc": "Short 이자 비율 필터 조건으로 종목을 필터링합니다.",
+      "label": "공매도 잔고 일수 필터",
+      "desc": "거래량 대비 공매도 잔고(일수)가 과도한 종목을 제외합니다.",
       "params": {
         "max_ratio": "최대 비율"
       },
-      "help": "Short 이자 비율 필터 기준값을 만족하는 종목만 통과시킵니다."
+      "help": "유동성 대비 공매도 쏠림이 큰 종목 노출을 줄입니다.",
+      "whenToUse": "체결 리스크를 줄이고 싶을 때 유동성 조건과 함께 사용합니다.",
+      "howToRead": "최대값 조건입니다. 값이 낮을수록 일반적으로 매매 난도가 낮습니다.",
+      "caution": "거래량 급감 구간에서는 일시적으로 수치가 왜곡될 수 있습니다."
     },
     "earnings_surprise_filter": {
       "label": "실적 서프라이즈 필터",
-      "desc": "실적 서프라이즈 필터 조건으로 종목을 필터링합니다.",
+      "desc": "컨센서스 대비 실적 서프라이즈가 높은 종목을 필터링합니다.",
       "params": {
         "min_surprise_pct": "최소 서프라이즈 비율 %"
       },
-      "help": "실적 서프라이즈 필터 기준값을 만족하는 종목만 통과시킵니다."
+      "help": "설정한 최소 서프라이즈를 넘는 종목만 통과시킵니다.",
+      "whenToUse": "실적 시즌 모멘텀 전략이나 실적 발표 후 드리프트 전략에서 유용합니다.",
+      "howToRead": "최소값 조건입니다. 값을 높일수록 더 강한 서프라이즈만 선택됩니다.",
+      "caution": "일회성 회계 항목으로 서프라이즈가 부풀려질 수 있어 가이던스/추정치 수정을 함께 확인하세요."
     },
     "post_earnings_drift": {
       "label": "사후 실적 Drift",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -372,7 +372,17 @@
     "deleteConfirm": "删除该策略？",
     "unsavedChanges": "您有未保存的更改",
     "lastSaved": "上次保存：{time}",
-    "strategyNameRequired": "策略名称为必填项"
+    "strategyNameRequired": "策略名称为必填项",
+    "guidanceWhenToUse": "何时使用",
+    "guidanceHowToRead": "如何解读",
+    "guidanceCaution": "注意事项",
+    "guidanceFallbackWhenToUse": "建议先用该条件做初筛，再与趋势/成交量条件组合确认。",
+    "guidanceFallbackHowToReadRange": "数值落在设定区间内时通过该筛选。",
+    "guidanceFallbackHowToReadMin": "这是最小值门槛条件，数值越高通常越容易通过。",
+    "guidanceFallbackHowToReadMax": "这是最大值门槛条件，数值越低通常越容易通过。",
+    "guidanceFallbackHowToReadTarget": "该条件用于检查所选目标桶（如星期/月）是否更有利。",
+    "guidanceFallbackHowToReadGeneral": "请基于回测调参，并保证在不同市场阶段下参数稳定。",
+    "guidanceFallbackCaution": "不建议单独使用，最好与风险/趋势条件组合以减少误判。"
   },
   "analysis": {
     "title": "图表与分析",
@@ -648,7 +658,10 @@
         "threshold": "RSI 阈值",
         "period": "RSI 周期"
       },
-      "help": "RSI 较低——股票可能超卖，有反弹可能。"
+      "help": "RSI 较低——股票可能超卖，有反弹可能。",
+      "whenToUse": "用于急跌后的反弹（均值回归）候选筛选。",
+      "howToRead": "RSI 越低，超卖强度越高。常见参考值约为 30。",
+      "caution": "在强下跌趋势中，超卖状态可能持续较久。"
     },
     "rsi_overbought": {
       "label": "RSI 超买 (RSI Overbought)",
@@ -657,7 +670,10 @@
         "threshold": "RSI 阈值",
         "period": "RSI 周期"
       },
-      "help": "RSI 较高——股票可能超买，有回调可能。"
+      "help": "RSI 较高——股票可能超买，有回调可能。",
+      "whenToUse": "用于识别短期过热与回调风险。",
+      "howToRead": "RSI 越高，超买强度越高。常见参考值约为 70。",
+      "caution": "在强上涨趋势中，超买状态可能持续较久。"
     },
     "rsi_range": {
       "label": "RSI 区间",
@@ -667,7 +683,10 @@
         "upper": "上限",
         "period": "RSI 周期"
       },
-      "help": "RSI 在中性区间内——适合寻找动量稳定的股票。"
+      "help": "RSI 在中性区间内——适合寻找动量稳定的股票。",
+      "whenToUse": "用于筛选处于中性动量区间的标的。",
+      "howToRead": "只有 RSI 落在下限与上限之间的股票才会通过。",
+      "caution": "区间设置过窄会降低样本并增加过拟合风险。"
     },
     "bollinger_width": {
       "label": "布林带宽度 (Bollinger Width)",
@@ -1289,21 +1308,27 @@
       "help": "仅保留满足Turn Of 月 Effect阈值的股票。"
     },
     "day_of_week_seasonality": {
-      "label": "日 Of 周 Seasonality",
-      "desc": "按日 Of 周 Seasonality条件筛选股票。",
+      "label": "星期效应筛选",
+      "desc": "筛选在指定星期几历史平均收益较好的股票。",
       "params": {
-        "min_avg_return_pct": "最小avg收益率比率 %",
-        "target_weekday": "targetweekday"
+        "min_avg_return_pct": "最小平均收益率 %",
+        "target_weekday": "目标星期 (0=周一, 4=周五)"
       },
-      "help": "仅保留满足日 Of 周 Seasonality阈值的股票。"
+      "help": "用于识别按星期重复出现的日历效应。",
+      "whenToUse": "适合短周期择时，当你怀疑市场存在星期效应时使用。",
+      "howToRead": "最小平均收益阈值越高，筛选越严格。建议从较低阈值开始。",
+      "caution": "星期效应可能被交易成本或市场阶段变化削弱，需要样本外验证。"
     },
     "net_share_issuance_filter": {
-      "label": "净 股份 发行 筛选",
-      "desc": "按净 股份 发行 筛选条件筛选股票。",
+      "label": "净增发筛选",
+      "desc": "过滤掉净增发过高、可能稀释股东权益的公司。",
       "params": {
         "max_issuance_pct": "最大发行比率 %"
       },
-      "help": "仅保留满足净 股份 发行 筛选阈值的股票。"
+      "help": "仅保留净增发比例不超过上限的股票。",
+      "whenToUse": "在质量/价值筛选中控制股权稀释风险。",
+      "howToRead": "这是最大值门槛，数值越低通常稀释压力越小。",
+      "caution": "增发也可能用于并购或扩张投资，需结合基本面判断。"
     },
     "insider_net_buying": {
       "label": "Insider 净 Buying",
@@ -1314,28 +1339,37 @@
       "help": "仅保留满足Insider 净 Buying阈值的股票。"
     },
     "short_float_pct_filter": {
-      "label": "Short Float Pct 筛选",
-      "desc": "按Short Float Pct 筛选条件筛选股票。",
+      "label": "流通股做空比例筛选",
+      "desc": "按流通股做空比例（Short Float）控制候选股票。",
       "params": {
-        "max_short_float_pct": "最大shortfloat比率 %"
+        "max_short_float_pct": "最大流通股做空比例 %"
       },
-      "help": "仅保留满足Short Float Pct 筛选阈值的股票。"
+      "help": "仅保留做空比例低于上限的股票。",
+      "whenToUse": "在做多策略中规避做空拥挤标的时很有用。",
+      "howToRead": "这是最大值门槛，数值越低通常代表做空压力越小。",
+      "caution": "高做空比例不一定看空，也可能触发逼空行情。"
     },
     "short_interest_ratio_filter": {
-      "label": "Short 利息 比率 筛选",
-      "desc": "按Short 利息 比率 筛选条件筛选股票。",
+      "label": "做空回补天数筛选",
+      "desc": "按做空回补天数（days-to-cover）控制候选股票。",
       "params": {
         "max_ratio": "最大比率"
       },
-      "help": "仅保留满足Short 利息 比率 筛选阈值的股票。"
+      "help": "降低对做空拥挤且成交量不足标的的暴露。",
+      "whenToUse": "与流动性条件配合使用，可降低执行风险。",
+      "howToRead": "这是最大值门槛，数值越低通常越容易成交。",
+      "caution": "成交量骤降时该指标会被动抬升。"
     },
     "earnings_surprise_filter": {
-      "label": "财报 惊喜 筛选",
-      "desc": "按财报 惊喜 筛选条件筛选股票。",
+      "label": "财报超预期筛选",
+      "desc": "筛选财报相对一致预期超预期的股票。",
       "params": {
         "min_surprise_pct": "最小惊喜比率 %"
       },
-      "help": "仅保留满足财报 惊喜 筛选阈值的股票。"
+      "help": "仅保留超预期幅度达到阈值的股票。",
+      "whenToUse": "适合财报季动量策略或财报后漂移策略。",
+      "howToRead": "这是最小值门槛，阈值越高代表要求越强的超预期。",
+      "caution": "一次性会计项目可能扭曲结果，建议结合指引与预期修正指标。"
     },
     "post_earnings_drift": {
       "label": "后 财报 Drift",

--- a/web/src/components/strategy/nodes/ConditionNode.tsx
+++ b/web/src/components/strategy/nodes/ConditionNode.tsx
@@ -24,6 +24,19 @@ function toTitleCaseFromKey(value: string): string {
     .replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
+function getFallbackHowToRead(paramNames: string[], t: (key: string) => string): string {
+  const hasTarget = paramNames.some((name) => name.startsWith('target_'));
+  const hasLowerUpper = paramNames.includes('lower') || paramNames.includes('upper');
+  const hasMin = paramNames.some((name) => name.startsWith('min_'));
+  const hasMax = paramNames.some((name) => name.startsWith('max_'));
+
+  if (hasTarget) return t('guidanceFallbackHowToReadTarget');
+  if (hasLowerUpper || (hasMin && hasMax)) return t('guidanceFallbackHowToReadRange');
+  if (hasMin) return t('guidanceFallbackHowToReadMin');
+  if (hasMax) return t('guidanceFallbackHowToReadMax');
+  return t('guidanceFallbackHowToReadGeneral');
+}
+
 function ConditionNode({ data, selected }: NodeProps) {
   const t = useTranslations('strategy');
   const tCond = useTranslations('conditions');
@@ -210,6 +223,22 @@ function ConditionNode({ data, selected }: NodeProps) {
             const { paired, standalone } = groupParams(
               currentMeta.params as ConditionParam[]
             );
+            const whenToUseKey = currentMeta.key + '.whenToUse';
+            const howToReadKey = currentMeta.key + '.howToRead';
+            const cautionKey = currentMeta.key + '.caution';
+            const fallbackHowToRead = getFallbackHowToRead(
+              currentMeta.params.map((p) => p.name),
+              t
+            );
+            const whenToUse = tCond.has(whenToUseKey)
+              ? tCond(whenToUseKey)
+              : t('guidanceFallbackWhenToUse');
+            const howToRead = tCond.has(howToReadKey)
+              ? tCond(howToReadKey)
+              : fallbackHowToRead;
+            const caution = tCond.has(cautionKey)
+              ? tCond(cautionKey)
+              : t('guidanceFallbackCaution');
 
             return (
               <>
@@ -286,6 +315,26 @@ function ConditionNode({ data, selected }: NodeProps) {
                       ? tCond(currentMeta.key + '.help')
                       : (currentMeta.description || '')}
                   </p>
+                  <div className="mt-2 space-y-1.5 text-[11px] text-gray-600 dark:text-gray-300 leading-relaxed">
+                    <p>
+                      <span className="font-semibold text-[#1313ec] dark:text-blue-400">
+                        {t('guidanceWhenToUse')}:
+                      </span>{' '}
+                      {whenToUse}
+                    </p>
+                    <p>
+                      <span className="font-semibold text-[#1313ec] dark:text-blue-400">
+                        {t('guidanceHowToRead')}:
+                      </span>{' '}
+                      {howToRead}
+                    </p>
+                    <p>
+                      <span className="font-semibold text-[#1313ec] dark:text-blue-400">
+                        {t('guidanceCaution')}:
+                      </span>{' '}
+                      {caution}
+                    </p>
+                  </div>
                 </div>
               </>
             );


### PR DESCRIPTION
## Summary
- add `whenToUse` / `howToRead` / `caution` guidance rendering in condition node popup
- provide localized fallback guidance based on parameter pattern (min/max/range/target)
- improve high-impact condition copy for novice users in en/ko/zh:
  - `day_of_week_seasonality`
  - `short_float_pct_filter`
  - `short_interest_ratio_filter`
  - `earnings_surprise_filter`
  - `net_share_issuance_filter`
  - `rsi_oversold`, `rsi_overbought`, `rsi_range`

## Verification
- [x] `npm --prefix web run check:condition-i18n`
- [x] `npm --prefix web run lint`
- [x] `npm --prefix web run build`

Closes #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)