### PR TITLE
feat(web): show currency unit on strategy price range fields

### DIFF
--- a/web/src/components/strategy/nodes/ConditionNode.tsx
+++ b/web/src/components/strategy/nodes/ConditionNode.tsx
@@ -8,6 +8,7 @@ import { useTranslations } from 'next-intl';
 import { getDownstreamNodeIds, type StrategyNodeData } from '@/lib/strategy/graphSerializer';
 import type { ConditionParam } from '@/lib/strategy/conditionRegistry';
 import { useConditions } from '@/contexts/ConditionsContext';
+import { useUserSettings } from '@/contexts/UserSettingsContext';
 import NodeEditPopup, {
   FieldLabel,
   SelectInput,
@@ -28,6 +29,7 @@ function ConditionNode({ data, selected }: NodeProps) {
   const t = useTranslations('strategy');
   const tCond = useTranslations('conditions');
   const { conditions, getConditionMeta } = useConditions();
+  const { settings } = useUserSettings();
   const nodeData = data as unknown as StrategyNodeData;
   const meta = nodeData.condition_type
     ? getConditionMeta(nodeData.condition_type)
@@ -228,6 +230,7 @@ function ConditionNode({ data, selected }: NodeProps) {
                 <div className="space-y-3">
                   {paired.map(([minP, maxP]) => {
                     const suffix = minP.name.replace(/^min_/, '');
+                    const isPriceRange = suffix === 'price';
                     return (
                       <div key={`pair-${suffix}`}>
                         <FieldLabel>
@@ -238,6 +241,7 @@ function ConditionNode({ data, selected }: NodeProps) {
                           {tCond.has(currentMeta.key + '.params.' + maxP.name)
                             ? tCond(currentMeta.key + '.params.' + maxP.name)
                             : toTitleCaseFromKey(maxP.name)}
+                          {isPriceRange ? ` (${settings.baseCurrency})` : ''}
                         </FieldLabel>
                         <div className="flex items-center gap-2">
                           <InlineNumberInput
@@ -258,6 +262,11 @@ function ConditionNode({ data, selected }: NodeProps) {
                             onChange={handleParamChange}
                           />
                         </div>
+                        {isPriceRange && (
+                          <p className="mt-1 text-[11px] text-gray-500 dark:text-gray-400">
+                            Unit: {settings.baseCurrency}
+                          </p>
+                        )}
                       </div>
                     );
                   })}


### PR DESCRIPTION
## Summary
- Show the active user base currency on price range (`min_price` / `max_price`) condition inputs in the strategy node edit popup.
- Improve clarity for mixed-market usage by making unit context explicit in both the field label and helper text.

## Changes
- `web/src/components/strategy/nodes/ConditionNode.tsx`
  - Read `settings.baseCurrency` from `useUserSettings()`
  - Append currency unit to price-range label
  - Add inline helper text `Unit: <baseCurrency>` under price range inputs

## Test Plan
- [x] Visual code inspection for price-range paired fields
- [ ] Frontend lint/typecheck in CI environment

Closes #483

🤖 Generated with [Claude Code](https://claude.com/claude-code)