### PR TITLE
Add ranking and long-short basket outputs to strategy API

### DIFF
--- a/api/routers/strategy.py
+++ b/api/routers/strategy.py
@@ -222,6 +222,7 @@ async def run_strategy(request: StrategyExecuteRequest) -> StrategyExecuteRespon
             universe_override=request.universe_override,
             universe_overrides=request.universe_overrides,
             portfolio_construction=request.portfolio_construction,
+            ranking_config=request.ranking_config,
         )
         response_universes = result.get("universes") or request.universe_overrides or [result["universe"]]
         return StrategyExecuteResponse(**result, universes=response_universes)
@@ -281,6 +282,7 @@ async def run_strategy_stream(request: StrategyExecuteRequest):
                 universe_override=request.universe_override,
                 universe_overrides=request.universe_overrides,
                 portfolio_construction=request.portfolio_construction,
+                ranking_config=request.ranking_config,
                 progress_callback=_progress_cb,
                 skip_enrich=True,
             )

--- a/api/schemas/strategy.py
+++ b/api/schemas/strategy.py
@@ -95,6 +95,10 @@ class StrategyExecuteRequest(BaseModel):
         default=None,
         description="Optional post-screening portfolio construction configuration",
     )
+    ranking_config: Optional["RankingConfig"] = Field(
+        default=None,
+        description="Optional cross-sectional ranking and long-short basket settings",
+    )
 
     @model_validator(mode="before")
     @classmethod
@@ -201,6 +205,8 @@ class StrategyExecuteResponse(BaseModel):
     node_results: Dict[str, NodeIntermediateResult] = Field(default_factory=dict)
     weighted_portfolio: List["WeightedPortfolioItem"] = Field(default_factory=list)
     portfolio_construction_result: Optional["PortfolioConstructionResult"] = None
+    ranked_results: List["RankedResultItem"] = Field(default_factory=list)
+    long_short_baskets: Optional["LongShortBaskets"] = None
 
 
 class PortfolioConstructionConfig(BaseModel):
@@ -252,6 +258,69 @@ class PortfolioConstructionResult(BaseModel):
     target_volatility: Optional[float] = None
     suggested_gross_leverage: Optional[float] = None
     fallback_reason: Optional[str] = None
+
+
+class RankingConfig(BaseModel):
+    """Cross-sectional ranking configuration."""
+
+    metric_key: str = Field(
+        default="current_price",
+        description="Metric key to rank by (e.g., current_price, per, pbr, dividend_yield, or condition detail key)",
+    )
+    direction: Literal["asc", "desc"] = Field(
+        default="desc",
+        description="Sort direction for ranking metric",
+    )
+    top_percent: float = Field(
+        default=10.0,
+        gt=0,
+        le=50.0,
+        description="Top bucket percentage for long basket",
+    )
+    bottom_percent: float = Field(
+        default=10.0,
+        ge=0,
+        le=50.0,
+        description="Bottom bucket percentage for short basket",
+    )
+    max_assets: int = Field(
+        default=100,
+        ge=1,
+        le=500,
+        description="Maximum ranked assets to consider",
+    )
+    long_short: bool = Field(
+        default=True,
+        description="Whether to emit both long and short baskets",
+    )
+
+
+class RankedResultItem(BaseModel):
+    """Single ranked item output."""
+
+    ticker: str
+    name: str
+    score: float
+    rank: int = Field(ge=1)
+
+
+class LongShortBasketItem(BaseModel):
+    """Single long/short basket position."""
+
+    ticker: str
+    name: str
+    score: float
+    side: Literal["long", "short"]
+    weight: float = Field(ge=0.0, le=1.0)
+
+
+class LongShortBaskets(BaseModel):
+    """Long and short decile-style baskets."""
+
+    metric_key: str
+    direction: str
+    long: List[LongShortBasketItem] = Field(default_factory=list)
+    short: List[LongShortBasketItem] = Field(default_factory=list)
 
 
 class ConditionParamInfo(BaseModel):

--- a/api/services/strategy_service.py
+++ b/api/services/strategy_service.py
@@ -17,9 +17,13 @@ import pandas as pd
 from api.schemas.strategy import (
     ConditionInfo,
     ConditionParamInfo,
+    LongShortBasketItem,
+    LongShortBaskets,
     NodeIntermediateResult,
     PortfolioConstructionConfig,
     PortfolioConstructionResult,
+    RankedResultItem,
+    RankingConfig,
     StrategyGraph,
     StrategyNode,
     StrategyResultItem,
@@ -477,6 +481,104 @@ def _build_weighted_portfolio(
         suggested_gross_leverage=suggested_leverage,
         fallback_reason=fallback_reason,
     )
+
+
+def _extract_ranking_score(item: StrategyResultItem, metric_key: str) -> Optional[float]:
+    if metric_key == "current_price":
+        return _to_optional_float(item.current_price)
+    if metric_key == "per":
+        return _to_optional_float(item.per)
+    if metric_key == "pbr":
+        return _to_optional_float(item.pbr)
+    if metric_key == "dividend_yield":
+        return _to_optional_float(item.dividend_yield)
+
+    for cond in item.conditions:
+        details = cond.get("details", {}) if isinstance(cond, dict) else {}
+        if isinstance(details, dict) and metric_key in details:
+            score = _to_optional_float(details.get(metric_key))
+            if score is not None:
+                return score
+    return None
+
+
+def _build_ranking_outputs(
+    final_items: List[StrategyResultItem],
+    ranking_config: Optional[RankingConfig],
+) -> tuple[List[RankedResultItem], Optional[LongShortBaskets]]:
+    if not ranking_config:
+        return [], None
+
+    candidates = final_items[: int(ranking_config.max_assets)]
+    scored_rows: List[tuple[StrategyResultItem, float]] = []
+    for item in candidates:
+        score = _extract_ranking_score(item, ranking_config.metric_key)
+        if score is None or not np.isfinite(score):
+            continue
+        scored_rows.append((item, float(score)))
+
+    if not scored_rows:
+        return [], LongShortBaskets(
+            metric_key=ranking_config.metric_key,
+            direction=ranking_config.direction,
+            long=[],
+            short=[],
+        )
+
+    reverse = ranking_config.direction == "desc"
+    scored_rows.sort(key=lambda row: row[1], reverse=reverse)
+
+    ranked_results: List[RankedResultItem] = []
+    for idx, (item, score) in enumerate(scored_rows, start=1):
+        ranked_results.append(
+            RankedResultItem(
+                ticker=item.ticker,
+                name=item.name,
+                score=score,
+                rank=idx,
+            )
+        )
+
+    n = len(scored_rows)
+    top_n = max(1, int(np.ceil(n * (ranking_config.top_percent / 100.0))))
+    long_rows = scored_rows[:top_n]
+
+    short_rows: List[tuple[StrategyResultItem, float]] = []
+    if ranking_config.long_short and ranking_config.bottom_percent > 0:
+        bottom_n = max(1, int(np.ceil(n * (ranking_config.bottom_percent / 100.0))))
+        short_rows = scored_rows[-bottom_n:]
+
+    long_weight = (1.0 / len(long_rows)) if long_rows else 0.0
+    short_weight = (1.0 / len(short_rows)) if short_rows else 0.0
+
+    long_basket = [
+        LongShortBasketItem(
+            ticker=item.ticker,
+            name=item.name,
+            score=score,
+            side="long",
+            weight=float(long_weight),
+        )
+        for item, score in long_rows
+    ]
+    short_basket = [
+        LongShortBasketItem(
+            ticker=item.ticker,
+            name=item.name,
+            score=score,
+            side="short",
+            weight=float(short_weight),
+        )
+        for item, score in short_rows
+    ]
+
+    baskets = LongShortBaskets(
+        metric_key=ranking_config.metric_key,
+        direction=ranking_config.direction,
+        long=long_basket,
+        short=short_basket,
+    )
+    return ranked_results, baskets
 
 
 def get_available_conditions() -> List[ConditionInfo]:
@@ -992,6 +1094,7 @@ def execute_strategy_with_progress(
     universe_override: Optional[str] = None,
     universe_overrides: Optional[List[str]] = None,
     portfolio_construction: Optional[PortfolioConstructionConfig] = None,
+    ranking_config: Optional[RankingConfig] = None,
     progress_callback: Optional[Callable[[int, int, int], None]] = None,
     skip_enrich: bool = False,
 ) -> Dict[str, Any]:
@@ -1005,6 +1108,7 @@ def execute_strategy_with_progress(
         universe_override=universe_override,
         universe_overrides=universe_overrides,
         portfolio_construction=portfolio_construction,
+        ranking_config=ranking_config,
         progress_callback=progress_callback,
         skip_enrich=skip_enrich,
     )
@@ -1015,6 +1119,7 @@ def execute_strategy(
     universe_override: Optional[str] = None,
     universe_overrides: Optional[List[str]] = None,
     portfolio_construction: Optional[PortfolioConstructionConfig] = None,
+    ranking_config: Optional[RankingConfig] = None,
     progress_callback: Optional[Callable[[int, int, int], None]] = None,
     skip_enrich: bool = False,
 ) -> Dict[str, Any]:
@@ -1028,7 +1133,7 @@ def execute_strategy(
 
     Returns:
         Dict with results, counts, universe, conditions used, node_results,
-        and optional weighted portfolio output
+        optional weighted portfolio output, and optional ranking outputs
     """
     started_at = time.perf_counter()
 
@@ -1223,6 +1328,10 @@ def execute_strategy(
         leaf_conditions=leaf_conditions,
         config=portfolio_construction,
     )
+    ranked_results, long_short_baskets = _build_ranking_outputs(
+        final_items=final_items,
+        ranking_config=ranking_config,
+    )
 
     conditions_used = [type(c).__name__ for c in leaf_conditions]
 
@@ -1255,4 +1364,6 @@ def execute_strategy(
         "node_results": node_results,
         "weighted_portfolio": weighted_portfolio,
         "portfolio_construction_result": construction_result,
+        "ranked_results": ranked_results,
+        "long_short_baskets": long_short_baskets,
     }

--- a/api/tests/test_strategy.py
+++ b/api/tests/test_strategy.py
@@ -288,3 +288,69 @@ class TestRunStrategyEndpoint:
         assert captured["portfolio_construction"].mode == "risk_parity"
         assert len(data["weighted_portfolio"]) == 2
         assert data["portfolio_construction_result"]["mode_applied"] == "risk_parity"
+
+    def test_ranking_config_request_is_passed_and_response_contains_long_short(self, monkeypatch):
+        captured = {"ranking_config": None}
+
+        def _mock_execute_strategy(*args, **kwargs):
+            captured["ranking_config"] = kwargs.get("ranking_config")
+            return {
+                "results": [],
+                "total_count": 10,
+                "matched_count": 4,
+                "universe": "SP500",
+                "conditions_used": [],
+                "node_results": {},
+                "ranked_results": [
+                    {"ticker": "MSFT", "name": "Microsoft", "score": 420.0, "rank": 1},
+                    {"ticker": "AAPL", "name": "Apple", "score": 180.0, "rank": 2},
+                    {"ticker": "TSLA", "name": "Tesla", "score": 120.0, "rank": 3},
+                    {"ticker": "INTC", "name": "Intel", "score": 35.0, "rank": 4},
+                ],
+                "long_short_baskets": {
+                    "metric_key": "current_price",
+                    "direction": "desc",
+                    "long": [
+                        {"ticker": "MSFT", "name": "Microsoft", "score": 420.0, "side": "long", "weight": 1.0}
+                    ],
+                    "short": [
+                        {"ticker": "INTC", "name": "Intel", "score": 35.0, "side": "short", "weight": 1.0}
+                    ],
+                },
+            }
+
+        monkeypatch.setattr("api.routers.strategy.execute_strategy", _mock_execute_strategy)
+
+        response = client.post(
+            "/api/strategy/run",
+            json={
+                "graph": {
+                    "nodes": [
+                        {
+                            "id": "c1",
+                            "data": {
+                                "node_type": "condition",
+                                "condition_type": "min_price",
+                                "params": {"min_price": 5000},
+                            },
+                        },
+                        {"id": "o1", "data": {"node_type": "output"}},
+                    ],
+                    "edges": [{"id": "e1", "source": "c1", "target": "o1"}],
+                },
+                "ranking_config": {
+                    "metric_key": "current_price",
+                    "direction": "desc",
+                    "top_percent": 10,
+                    "bottom_percent": 10,
+                    "max_assets": 100,
+                    "long_short": True,
+                },
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert captured["ranking_config"].metric_key == "current_price"
+        assert len(data["ranked_results"]) == 4
+        assert data["long_short_baskets"]["long"][0]["ticker"] == "MSFT"
+        assert data["long_short_baskets"]["short"][0]["ticker"] == "INTC"

--- a/api/tests/test_strategy_service.py
+++ b/api/tests/test_strategy_service.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from api.schemas.strategy import (
     PortfolioConstructionConfig,
+    RankingConfig,
     StrategyGraph,
     StrategyNode,
     StrategyNodeData,
@@ -15,6 +16,7 @@ from api.schemas.strategy import (
     StrategyResultItem,
 )
 from api.services.strategy_service import (
+    _build_ranking_outputs,
     build_conditions_from_graph,
     get_available_conditions,
     CONDITION_CLASS_MAP,
@@ -775,3 +777,58 @@ class TestPortfolioConstruction:
         assert meta is not None
         assert meta.mode_applied == "equal_weight"
         assert meta.fallback_reason == "insufficient_return_history"
+
+
+class TestRankingOutputs:
+    def test_build_ranking_outputs_generates_rank_and_long_short_baskets(self):
+        items = [
+            StrategyResultItem(ticker="AAPL", name="Apple", current_price=180.0, matched=True, conditions=[]),
+            StrategyResultItem(ticker="MSFT", name="Microsoft", current_price=420.0, matched=True, conditions=[]),
+            StrategyResultItem(ticker="TSLA", name="Tesla", current_price=220.0, matched=True, conditions=[]),
+            StrategyResultItem(ticker="INTC", name="Intel", current_price=35.0, matched=True, conditions=[]),
+        ]
+        ranked, baskets = _build_ranking_outputs(
+            final_items=items,
+            ranking_config=RankingConfig(
+                metric_key="current_price",
+                direction="desc",
+                top_percent=25,
+                bottom_percent=25,
+                max_assets=10,
+                long_short=True,
+            ),
+        )
+        assert len(ranked) == 4
+        assert ranked[0].ticker == "MSFT"
+        assert baskets is not None
+        assert len(baskets.long) == 1
+        assert len(baskets.short) == 1
+        assert baskets.long[0].ticker == "MSFT"
+        assert baskets.short[0].ticker == "INTC"
+
+    def test_build_ranking_outputs_can_rank_by_condition_detail_key(self):
+        items = [
+            StrategyResultItem(
+                ticker="AAA",
+                name="AAA",
+                current_price=10.0,
+                matched=True,
+                conditions=[{"details": {"quality_score": 80}}],
+            ),
+            StrategyResultItem(
+                ticker="BBB",
+                name="BBB",
+                current_price=10.0,
+                matched=True,
+                conditions=[{"details": {"quality_score": 60}}],
+            ),
+        ]
+        ranked, baskets = _build_ranking_outputs(
+            final_items=items,
+            ranking_config=RankingConfig(metric_key="quality_score", direction="desc", top_percent=50, bottom_percent=0, long_short=False),
+        )
+        assert len(ranked) == 2
+        assert ranked[0].ticker == "AAA"
+        assert baskets is not None
+        assert len(baskets.long) == 1
+        assert len(baskets.short) == 0


### PR DESCRIPTION
## Summary
- add optional `ranking_config` input for strategy execution
- emit `ranked_results` and `long_short_baskets` in strategy responses
- support ranking by core fields (`current_price`, `per`, `pbr`, `dividend_yield`) and condition-detail metric keys
- propagate ranking config through both sync and SSE strategy run paths
- add focused API/service tests for ranking + long-short behavior

## API additions
- request: `ranking_config` (metric_key, direction, top_percent, bottom_percent, max_assets, long_short)
- response: `ranked_results[]`, `long_short_baskets`

## Test plan
- [x] `python -m pytest api/tests/test_strategy.py::TestRunStrategyEndpoint::test_portfolio_construction_request_is_passed_and_response_contains_weights api/tests/test_strategy.py::TestRunStrategyEndpoint::test_ranking_config_request_is_passed_and_response_contains_long_short api/tests/test_strategy_service.py::TestPortfolioConstruction api/tests/test_strategy_service.py::TestRankingOutputs`
- [ ] full backend suite in CI

Closes #505

🤖 Generated with [Claude Code](https://claude.com/claude-code)