### PR TITLE
fix(i18n): prevent strategy namespace missing-message regressions

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -353,6 +353,7 @@
     "andMore": "+{count} more",
     "filterMetrics": "Filter Values",
     "runFirst": "Run strategy to see results",
+    "loadingConditions": "Loading conditions...",
     "exportJson": "Export JSON",
     "lastRunAt": "Last run: {time}",
     "exportCsv": "Export CSV",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -353,6 +353,7 @@
     "andMore": "+{count}개 더",
     "filterMetrics": "필터 값",
     "runFirst": "전략을 먼저 실행하세요",
+    "loadingConditions": "조건 로딩 중...",
     "exportJson": "JSON 내보내기",
     "lastRunAt": "마지막 실행: {time}",
     "exportCsv": "CSV 내보내기",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -352,6 +352,8 @@
     "andMore": "+{count} 更多",
     "applyChanges": "应用更改",
     "filterMetrics": "过滤值",
+    "runFirst": "请先运行策略查看结果",
+    "loadingConditions": "正在加载条件...",
     "exportJson": "导出 JSON",
     "lastRunAt": "上次运行: {time}",
     "exportCsv": "导出CSV",

--- a/web/package.json
+++ b/web/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "eslint",
     "check:condition-i18n": "node scripts/check-condition-i18n.mjs",
+    "check:strategy-i18n": "node scripts/check-strategy-i18n.mjs",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:visual": "playwright test e2e/visual.spec.ts",

--- a/web/scripts/check-strategy-i18n.mjs
+++ b/web/scripts/check-strategy-i18n.mjs
@@ -1,0 +1,72 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const messagePaths = {
+  en: path.join(process.cwd(), 'messages', 'en.json'),
+  ko: path.join(process.cwd(), 'messages', 'ko.json'),
+  zh: path.join(process.cwd(), 'messages', 'zh.json'),
+};
+
+function loadStrategyMessages(locale) {
+  const raw = fs.readFileSync(messagePaths[locale], 'utf8');
+  const json = JSON.parse(raw);
+  return json.strategy ?? {};
+}
+
+function flattenKeys(obj, prefix = '') {
+  if (!obj || typeof obj !== 'object' || Array.isArray(obj)) {
+    return [];
+  }
+
+  const keys = [];
+  for (const key of Object.keys(obj)) {
+    const fullKey = prefix ? `${prefix}.${key}` : key;
+    keys.push(fullKey);
+    keys.push(...flattenKeys(obj[key], fullKey));
+  }
+  return keys;
+}
+
+function validate() {
+  const locales = ['en', 'ko', 'zh'];
+  const strategyByLocale = Object.fromEntries(locales.map((loc) => [loc, loadStrategyMessages(loc)]));
+
+  const baseline = new Set(flattenKeys(strategyByLocale.en));
+  const issues = [];
+
+  for (const locale of ['ko', 'zh']) {
+    const currentKeys = new Set(flattenKeys(strategyByLocale[locale]));
+
+    for (const key of baseline) {
+      if (!currentKeys.has(key)) {
+        issues.push(`[${locale}] missing key: strategy.${key}`);
+      }
+    }
+
+    for (const key of currentKeys) {
+      if (!baseline.has(key)) {
+        issues.push(`[${locale}] extra key: strategy.${key}`);
+      }
+    }
+  }
+
+  const requiredKey = 'loadingConditions';
+  for (const locale of locales) {
+    const value = strategyByLocale[locale][requiredKey];
+    if (typeof value !== 'string' || value.trim().length === 0) {
+      issues.push(`[${locale}] missing/empty key: strategy.${requiredKey}`);
+    }
+  }
+
+  if (issues.length > 0) {
+    console.error('Strategy i18n keyset check failed.');
+    for (const issue of issues) {
+      console.error(`- ${issue}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(`Strategy i18n keyset OK. locales=${locales.join(',')}, keys=${baseline.size}`);
+}
+
+validate();


### PR DESCRIPTION
## Summary
- add `strategy.loadingConditions` key to `en/ko/zh` strategy namespaces
- add missing `strategy.runFirst` key in zh locale
- add `web/scripts/check-strategy-i18n.mjs` for EN baseline keyset parity checks across strategy namespace
- add `check:strategy-i18n` npm script

## Verification
- [x] `npm --prefix web run check:strategy-i18n`
- [x] `npm --prefix web run check:condition-i18n`
- [x] `npm --prefix web run lint -- "src/components/strategy/NodePalette.tsx"`

## Issue
- closes #488

🤖 Generated with Codex