### PR TITLE
docs(readme): restructure EN/KO guides around UI workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,339 +1,145 @@
 # quant-investment
 
-Quantitative investment strategy development and backtesting project
+A full-stack quant investing workspace for screening, strategy design, backtesting, portfolio monitoring, and analysis.
 
-[한국어 README](README_KO.md)
+Language: [한국어 README](README_KO.md)
 
----
+## What Is This Project?
 
-## Web UI (New!)
+`quant-investment` combines:
+- FastAPI backend for screening, strategy execution, and portfolio APIs
+- Next.js web UI for daily quant workflows
+- Python research/runtime modules for data, indicators, and backtests
 
-The platform now includes a web-based dashboard for easy access to all features.
+Primary goal: move from idea to executable strategy with one connected toolchain.
 
-### Quick Start
+## What You Can Do In The UI
 
-```bash
-# Start both API and Web servers
-./scripts/dev.sh
-```
+| Area | Route | What You Can Do |
+|---|---|---|
+| Dashboard | `/[locale]` | Check market/portfolio summary and recent activity |
+| Screening | `/[locale]/screening` | Build filters, run scans, inspect condition matches |
+| Strategy Builder | `/[locale]/strategy` | Compose node-based strategy graph, save/load strategy, deploy run |
+| Backtest | Strategy page panel | Backtest selected strategy parameters and review results |
+| Portfolio | `/[locale]/portfolio` | Track holdings, positions, and order desk actions |
+| Analysis & Reports | `/[locale]/analysis`, `/[locale]/reports` | Review chart/indicator context and generated analysis reports |
 
-### Development URLs
+## Quick Start
 
-| Service | URL | Description |
-|---------|-----|-------------|
-| Web Dashboard | http://localhost:3000 | Main user interface |
-| API | http://localhost:8000 | REST API backend |
-| Swagger Docs | http://localhost:8000/docs | Interactive API documentation |
-| ReDoc | http://localhost:8000/redoc | Alternative API documentation |
+### 1) Requirements
 
-### Individual Services
+- Python 3.13+
+- Node.js 20+
+- npm 10+
 
-```bash
-# API only (FastAPI)
-./scripts/run_api.sh
-
-# Web only (Next.js) - requires API running
-./scripts/run_web.sh
-```
-
-### Docker Deployment
+### 2) Install
 
 ```bash
-# Build and run all services
-docker-compose up -d
-
-# Build specific service
-docker-compose up -d api
-docker-compose up -d web
-
-# View logs
-docker-compose logs -f
-
-# Stop all services
-docker-compose down
-```
-
-### Documentation
-
-- [API Reference](docs/API_REFERENCE.md) - Complete REST API documentation
-- [Development Guide](docs/DEVELOPMENT_GUIDE.md) - Setup and contribution guide
-
----
-
-## Daily Routine (Run Every Day)
-
-### 1. Portfolio Sell Signal Check
-Check if any holdings should be sold based on stop-loss, take-profit, or technical signals.
-
-```bash
-python scripts/live/portfolio_sell_checker.py
-```
-
-### 2. Investor Trading Analysis
-Check foreign/institutional buying & selling trends.
-
-```bash
-# Single stock
-python scripts/investor_trading.py 005930
-
-# Top foreign/institutional rankings (recommended)
-python scripts/investor_trading.py --top 10
-
-# Institution only
-python scripts/investor_trading.py --top-institution 10
-```
-
-### 3. Daily Market Report
-Golden/death cross detection for KOSPI and US stocks.
-
-```bash
-# Korean (KOSPI)
-python scripts/screening/korean_daily_report.py
-
-# US (S&P 500)
-python scripts/screening/us_daily_report.py
-python scripts/screening/us_daily_report.py --sector Technology
-```
-
----
-
-## AI-Powered Stock Analysis
-
-Semi-automated analysis pipeline using Claude AI:
-1. Screen stocks touching 240-day MA
-2. Enrich with technical indicators, fundamentals, and news
-3. Analyze with Claude for valuation and entry timing
-4. Generate report with position sizing recommendations
-
-### Option 1: Claude API
-
-```bash
-# Full analysis (requires ANTHROPIC_API_KEY)
-export ANTHROPIC_API_KEY="your-api-key"
-python scripts/analysis/run_daily_analysis.py
-
-# Single market
-python scripts/analysis/run_daily_analysis.py --market KOSPI
-python scripts/analysis/run_daily_analysis.py --market SP500
-```
-
-### Option 2: Claude Code Integration
-
-```bash
-# Run screening and enrichment, save JSON for Claude Code
-python scripts/analysis/run_daily_analysis.py --claude-code
-
-# Then in Claude Code, use the /analyze-stocks skill
-# or ask Claude Code to analyze the saved JSON file
-```
-
-### Other Options
-
-```bash
-# Data enrichment only (no analysis)
-python scripts/analysis/run_daily_analysis.py --enrich-only
-
-# Custom capital for position sizing
-python scripts/analysis/run_daily_analysis.py --capital 50000000
-```
-
-**Output includes:**
-- Valuation score (1-10)
-- Risk assessment
-- Entry recommendation (BUY/WAIT/AVOID)
-- Position sizing with stop-loss
-
----
-
-## Stock Screening (Finding Opportunities)
-
-### Accumulation Zone Detection
-Find stocks in quiet accumulation phase (low volatility + low volume).
-
-```bash
-# Basic preset
-python scripts/screening/accumulation_screen.py --preset accumulation_basic
-
-# With OBV divergence (recommended)
-python scripts/screening/accumulation_screen.py --preset accumulation_obv
-```
-
-### Moving Average Screener
-```bash
-# Stocks touching MA
-python scripts/screening/korean_ma_touch.py
-
-# Stocks below MA
-python scripts/screening/korean_ma_below.py
-
-# MA crossover detection
-python scripts/screening/korean_crossover.py
-```
-
-### Breakout Detection
-```bash
-# Use the new condition-based screener
-from screener import StockScreener, BottomBreakoutCondition, BreakoutWithVolumeCondition
-```
-
----
-
-## Backtesting (Strategy Research)
-
-Test trading strategies with historical data.
-
-```bash
-# Basic backtest (Korean stock)
-python scripts/backtesting/run_backtest.py --ticker 005930.KS --period 1y
-
-# US stock with EMA strategy
-python scripts/backtesting/run_backtest.py --ticker AAPL --strategy ema
-
-# Parameter optimization
-python scripts/backtesting/run_backtest.py --ticker 005930.KS --optimize
-```
-
-**Available Strategies:**
-| Strategy | Description | Default |
-|----------|-------------|---------|
-| `sma` | Simple MA crossover | n1=10, n2=20 |
-| `ema` | Exponential MA crossover | n1=12, n2=26 |
-
----
-
-## Live Monitoring (Continuous)
-
-### Options Tracker Bot
-Detects unusual options activity for NVDA, AAPL, TSLA, AMZN.
-
-```bash
-# One-time check
-python scripts/live/options_tracker.py --once
-
-# Continuous monitoring (every 60 seconds)
-python scripts/live/options_tracker.py
-```
-
----
-
-## Configuration
-
-| File | Description |
-|------|-------------|
-| `config/portfolio.yaml` | Your holdings & sell conditions |
-| `config/base_config.yaml` | Data paths, API, logging settings |
-
-**Environment Variables:**
-| Variable | Description |
-|----------|-------------|
-| `ANTHROPIC_API_KEY` | Claude API key for AI analysis |
-| `FINNHUB_API_KEY` | Finnhub API for news (optional) |
-| `MARKETAUX_API_KEY` | Marketaux API for news (optional) |
-
----
-
-## Installation
-
-```bash
-# Clone and setup
-git clone https://github.com/yourusername/quant-investment.git
-cd quant-investment
 python -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
+npm --prefix web install
 ```
 
----
+### 3) Run (Recommended Dev Ports)
 
-## Stack
-
-- **Python 3.13**
-- **FastAPI** - REST API backend
-- **Next.js 16** - Web frontend (App Router)
-- **Claude API** - AI-powered stock analysis
-- **Backtesting.py** - Strategy backtesting
-- **yfinance** - US stock data
-- **pykrx** - Korean stock data (KOSPI/KOSDAQ)
-- **pandas/numpy** - Data processing
-- **Tailwind CSS** - Frontend styling
-
----
-
-## Project Structure
-
-```
-quant-investment/
-├── api/                        # FastAPI backend
-│   ├── main.py                 # Application entry point
-│   ├── routers/                # API endpoints
-│   ├── schemas/                # Request/response models
-│   └── services/               # Business logic
-├── web/                        # Next.js frontend
-│   ├── src/app/                # Pages (App Router)
-│   ├── src/components/         # React components
-│   └── src/lib/                # Utilities
-├── scripts/
-│   ├── analysis/               # AI-powered analysis
-│   │   └── run_daily_analysis.py
-│   ├── screening/              # Stock screening
-│   │   ├── accumulation_screen.py
-│   │   ├── korean_daily_report.py
-│   │   ├── us_daily_report.py
-│   │   └── korean_ma_*.py
-│   ├── backtesting/            # Strategy backtesting
-│   │   └── run_backtest.py
-│   ├── live/                   # Live monitoring
-│   │   ├── portfolio_sell_checker.py
-│   │   └── options_tracker.py
-│   ├── dev.sh                  # Start all services
-│   ├── run_api.sh              # Start API only
-│   └── run_web.sh              # Start web only
-├── llm/                        # Claude AI integration
-│   ├── claude_client.py
-│   ├── stock_analyzer.py
-│   └── prompts/
-├── data_enrichment/            # Data enrichment modules
-│   ├── technical.py
-│   ├── fundamental.py
-│   └── news.py
-├── pipeline/                   # Analysis pipeline
-│   └── report_generator.py
-├── screener/                   # Screening library
-│   ├── conditions/             # Screening conditions
-│   └── stock_screener.py
-├── portfolio/                  # Portfolio management
-│   └── position_sizing.py
-├── config/                     # Configuration files
-├── data/                       # Data cache
-├── docker-compose.yml          # Docker configuration
-└── Dockerfile.api              # API Docker image
+API (port `8002`):
+```bash
+source venv/bin/activate && uvicorn api.main:app --host 0.0.0.0 --port 8002 --reload
 ```
 
----
+Web (port `3002`):
+```bash
+cd web && PORT=3002 npm run dev
+```
 
-## Documentation
+### 4) Open
 
-### API & Development
-- [API Reference](docs/API_REFERENCE.md) - Complete REST API documentation
-- [Development Guide](docs/DEVELOPMENT_GUIDE.md) - Setup and contribution guide
+- Web UI: `http://localhost:3002`
+- API Docs: `http://localhost:8002/docs`
 
-### Screener
-- [Screener Conditions Architecture](docs/SCREENER_CONDITIONS.md) - All 28 condition classes and usage
-- [Accumulation Zone Screening](docs/ACCUMULATION_SCREENING.md) - Quiet accumulation detection guide
-- [Breakout Conditions](docs/BREAKOUT_CONDITIONS.md) - Breakout detection conditions
-- [Korean MA Screener](docs/KOREAN_MA_SCREENER.md) - Korean stock MA touch screener
+## Core Workflows
 
-### Analysis & Monitoring
-- [Analysis Pipeline](docs/ANALYSIS_PIPELINE.md) - AI-powered analysis workflow
-- [Options Tracker Bot](docs/OPTIONS_TRACKER_README.md) - Options activity monitoring
-- [Market Calendar](docs/MARKET_CALENDAR_README.md) - Market hours utility
+### Workflow A: Build And Execute A Strategy
 
-### Work Plans
-- [Analysis Pipeline Plan](docs/works/20260211_semi_auto_analysis_pipeline.md)
-- [UI Integration Plan](docs/works/20260212_ui_integration_project.md)
+1. Open Strategy Builder (`/[locale]/strategy`)
+2. Add universe + condition nodes
+3. Configure condition parameters
+4. Click deploy/run
+5. Inspect matched symbols and intermediate results
 
----
+### Workflow B: Strategy To Backtest
 
-## License
+1. Save or load a strategy in Strategy Builder
+2. Open backtest panel
+3. Select period and strategy inputs
+4. Run backtest and inspect equity/trade metrics
 
-MIT
+### Workflow C: Screening To Analysis
+
+1. Run screening on `/[locale]/screening`
+2. Open symbol analysis page
+3. Review technical/fundamental/AI context
+4. Save findings into report workflow
+
+## Configuration
+
+### Key Config Files
+
+- `config/base_config.yaml`: global runtime/data/logging config
+- `config/screening_criteria.yaml`: screening defaults
+- `portfolio/`: portfolio logic and sizing modules
+
+### Environment Variables
+
+| Variable | Purpose |
+|---|---|
+| `ANTHROPIC_API_KEY` | AI analysis integration |
+| `FINNHUB_API_KEY` | Optional news/data source |
+| `MARKETAUX_API_KEY` | Optional news/data source |
+
+## API/Web Development
+
+### Backend
+
+```bash
+source venv/bin/activate
+uvicorn api.main:app --host 0.0.0.0 --port 8002 --reload
+```
+
+### Frontend
+
+```bash
+cd web
+PORT=3002 npm run dev
+```
+
+### Useful Checks
+
+```bash
+npm --prefix web run lint
+npm --prefix web run check:condition-i18n
+npm --prefix web run check:strategy-i18n
+```
+
+## Troubleshooting
+
+- Web cannot call API:
+  - Check API is running on the expected port
+  - Check frontend API base URL/env for your local setup
+- i18n key errors (`MISSING_MESSAGE`):
+  - Run `npm --prefix web run check:strategy-i18n`
+  - Run `npm --prefix web run check:condition-i18n`
+- Strategy run returns empty results:
+  - Confirm universe/condition thresholds are not overly strict
+
+## Roadmap / Limitations
+
+- Broker integrations are in progress (Kiwoom/IBKR related issues)
+- Some advanced quant conditions are still being expanded
+- Multi-market workflow is evolving by issue-based increments
+
+## Language Switch (EN/KO)
+
+- English (primary): `README.md`
+- Korean: `README_KO.md`

--- a/README_KO.md
+++ b/README_KO.md
@@ -1,261 +1,145 @@
 # quant-investment
 
-퀀트 투자 전략 개발 및 백테스팅 프로젝트
+스크리닝, 전략 설계, 백테스팅, 포트폴리오 모니터링, 분석을 하나로 연결한 퀀트 투자 워크스페이스입니다.
 
-[English README](README.md)
+언어: [English README](README.md)
 
----
+## 이 프로젝트는 무엇인가요?
 
-## 매일 실행 (Daily Routine)
+`quant-investment`는 아래를 통합합니다.
+- FastAPI 백엔드: 스크리닝/전략 실행/포트폴리오 API
+- Next.js 웹 UI: 일상적인 퀀트 작업 흐름 제공
+- Python 연구/실행 모듈: 데이터, 지표, 백테스트
 
-### 1. 포트폴리오 매도 신호 체크
-보유 종목의 손절/익절/기술적 매도 신호 확인
+핵심 목표는 아이디어를 실행 가능한 전략으로 빠르게 연결하는 것입니다.
 
-```bash
-python scripts/live/portfolio_sell_checker.py
-```
+## UI에서 할 수 있는 일
 
-### 2. 투자자별 매매 동향
-외국인/기관 순매수/순매도 현황 확인
+| 영역 | 경로 | 가능한 작업 |
+|---|---|---|
+| 대시보드 | `/[locale]` | 시장/포트폴리오 요약, 최근 상태 확인 |
+| 스크리닝 | `/[locale]/screening` | 조건 조합, 스캔 실행, 통과 종목 확인 |
+| 전략 빌더 | `/[locale]/strategy` | 노드 기반 전략 그래프 구성, 저장/불러오기, 실행 |
+| 백테스트 | 전략 페이지 패널 | 기간/파라미터 기반 전략 성능 검증 |
+| 포트폴리오 | `/[locale]/portfolio` | 보유 종목, 포지션, 주문 데스크 확인 |
+| 분석/리포트 | `/[locale]/analysis`, `/[locale]/reports` | 차트/지표/분석 리포트 확인 |
 
-```bash
-# 개별 종목 조회
-python scripts/investor_trading.py 005930
+## 빠른 시작
 
-# 외국인/기관 순매수 상위 전체 (추천)
-python scripts/investor_trading.py --top 10
+### 1) 요구사항
 
-# 기관만 조회
-python scripts/investor_trading.py --top-institution 10
+- Python 3.13+
+- Node.js 20+
+- npm 10+
 
-# KOSDAQ 조회
-python scripts/investor_trading.py --top 10 --market KOSDAQ
-```
-
-### 3. 일일 마켓 리포트
-코스피/미국 종목 골든크로스/데스크로스 감지
-
-```bash
-# 한국 (코스피)
-python scripts/screening/korean_daily_report.py
-
-# 미국 (S&P 500)
-python scripts/screening/us_daily_report.py
-python scripts/screening/us_daily_report.py --sector Technology
-```
-
----
-
-## AI 기반 주식 분석 (신규!)
-
-Claude AI를 활용한 반자동 분석 파이프라인:
-1. 240일선 터치 종목 스크리닝
-2. 기술적 지표, 재무제표, 뉴스 데이터 수집
-3. Claude AI로 저평가 분석 및 진입 타이밍 판단
-4. 포지션 사이징 포함 리포트 생성
-
-### 옵션 1: Claude API 사용
+### 2) 설치
 
 ```bash
-# 전체 분석 (ANTHROPIC_API_KEY 필요)
-export ANTHROPIC_API_KEY="your-api-key"
-python scripts/analysis/run_daily_analysis.py
-
-# 단일 마켓
-python scripts/analysis/run_daily_analysis.py --market KOSPI
-python scripts/analysis/run_daily_analysis.py --market SP500
-```
-
-### 옵션 2: Claude Code 연동
-
-```bash
-# 스크리닝 + 데이터 수집, JSON으로 저장
-python scripts/analysis/run_daily_analysis.py --claude-code
-
-# 이후 Claude Code에서 /analyze-stocks 스킬 사용
-# 또는 저장된 JSON 파일을 Claude Code에게 분석 요청
-```
-
-### 기타 옵션
-
-```bash
-# 데이터 수집만 (분석 없이)
-python scripts/analysis/run_daily_analysis.py --enrich-only
-
-# 자본금 설정 (포지션 사이징용)
-python scripts/analysis/run_daily_analysis.py --capital 50000000
-```
-
-**분석 결과:**
-- 저평가 점수 (1-10)
-- 리스크 평가
-- 진입 추천 (BUY/WAIT/AVOID)
-- 손절가 포함 포지션 사이징
-
----
-
-## 종목 발굴 (Stock Screening)
-
-### 매집 구간 탐지
-조용한 매집 구간 종목 찾기 (저변동성 + 저거래량)
-
-```bash
-# 기본 프리셋
-python scripts/screening/accumulation_screen.py --preset accumulation_basic
-
-# OBV 다이버전스 포함 (추천)
-python scripts/screening/accumulation_screen.py --preset accumulation_obv
-
-# 더 엄격한 조건
-python scripts/screening/accumulation_screen.py --preset accumulation_basic --bb-width 8.0 --volume-mult 0.7
-```
-
-### 이동평균선 스크리너
-```bash
-# 이평선 터치 종목
-python scripts/screening/korean_ma_touch.py
-
-# 이평선 하향 돌파 종목
-python scripts/screening/korean_ma_below.py
-
-# 이평선 크로스오버 감지
-python scripts/screening/korean_crossover.py
-```
-
-### 돌파 감지
-```bash
-# 새로운 조건 기반 스크리너 사용
-from screener import StockScreener, BottomBreakoutCondition, BreakoutWithVolumeCondition
-```
-
----
-
-## 백테스팅 (전략 연구)
-
-과거 데이터로 트레이딩 전략 테스트
-
-```bash
-# 기본 백테스트 (한국 주식)
-python scripts/backtesting/run_backtest.py --ticker 005930.KS --period 1y
-
-# 미국 주식 + EMA 전략
-python scripts/backtesting/run_backtest.py --ticker AAPL --strategy ema
-
-# 파라미터 최적화
-python scripts/backtesting/run_backtest.py --ticker 005930.KS --optimize
-```
-
-**사용 가능한 전략:**
-| 전략 | 설명 | 기본값 |
-|------|------|--------|
-| `sma` | 단순 이평선 크로스오버 | n1=10, n2=20 |
-| `ema` | 지수 이평선 크로스오버 | n1=12, n2=26 |
-
----
-
-## 실시간 모니터링 (Live)
-
-### 옵션 추적 봇
-NVDA, AAPL, TSLA, AMZN 옵션 거래량 이상 징후 감지
-
-```bash
-# 일회성 체크
-python scripts/live/options_tracker.py --once
-
-# 지속 모니터링 (60초마다)
-python scripts/live/options_tracker.py
-```
-
----
-
-## 설정 파일
-
-| 파일 | 설명 |
-|------|------|
-| `config/portfolio.yaml` | 보유 종목 & 매도 조건 |
-| `config/base_config.yaml` | 데이터 경로, API, 로깅 설정 |
-
-**환경 변수:**
-| 변수 | 설명 |
-|------|------|
-| `ANTHROPIC_API_KEY` | Claude API 키 (AI 분석용) |
-| `FINNHUB_API_KEY` | Finnhub API 키 (뉴스, 선택) |
-| `MARKETAUX_API_KEY` | Marketaux API 키 (뉴스, 선택) |
-
----
-
-## 설치
-
-```bash
-# 클론 및 설정
-git clone https://github.com/yourusername/quant-investment.git
-cd quant-investment
 python -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
+npm --prefix web install
 ```
 
----
+### 3) 실행 (권장 개발 포트)
 
-## 기술 스택
-- **Python 3.13**
-- **Claude API** - AI 기반 주식 분석
-- **Backtesting.py** - 전략 백테스팅
-- **yfinance** - 미국 주가 데이터
-- **pykrx** - 한국 주식 데이터 (코스피/코스닥)
-- **pandas/numpy** - 데이터 처리
-
----
-
-## 프로젝트 구조
-
-```
-quant-investment/
-├── scripts/
-│   ├── analysis/               # AI 기반 분석
-│   │   └── run_daily_analysis.py
-│   ├── screening/              # 종목 스크리닝
-│   │   ├── accumulation_screen.py
-│   │   ├── korean_daily_report.py
-│   │   ├── us_daily_report.py
-│   │   └── korean_ma_*.py
-│   ├── backtesting/            # 백테스팅
-│   │   └── run_backtest.py
-│   └── live/                   # 실시간 모니터링
-│       ├── portfolio_sell_checker.py
-│       └── options_tracker.py
-├── llm/                        # Claude AI 연동
-│   ├── claude_client.py
-│   ├── stock_analyzer.py
-│   └── prompts/
-├── data_enrichment/            # 데이터 수집 모듈
-│   ├── technical.py
-│   ├── fundamental.py
-│   └── news.py
-├── pipeline/                   # 분석 파이프라인
-│   └── report_generator.py
-├── screener/                   # 스크리닝 라이브러리
-│   ├── conditions/             # 스크리닝 조건
-│   └── stock_screener.py
-├── portfolio/                  # 포트폴리오 관리
-│   └── position_sizing.py
-├── config/                     # 설정 파일
-└── data/                       # 데이터 캐시
+API (`8002`):
+```bash
+source venv/bin/activate && uvicorn api.main:app --host 0.0.0.0 --port 8002 --reload
 ```
 
----
+Web (`3002`):
+```bash
+cd web && PORT=3002 npm run dev
+```
 
-## 문서
+### 4) 접속
 
-- [백엔드 핵심 로직 개요 (데이터 수집/스크리닝/전략 실행)](docs/ko/BACKEND_LOGIC_OVERVIEW.md)
-- [돌파 조건 (Breakout Conditions)](docs/BREAKOUT_CONDITIONS.md)
-- [한국 주식 MA 스크리너](docs/KOREAN_MA_SCREENER.md)
-- [옵션 추적 봇](docs/OPTIONS_TRACKER_README.md)
-- [마켓 캘린더](docs/MARKET_CALENDAR_README.md)
-- [분석 파이프라인 계획](docs/works/20260211_semi_auto_analysis_pipeline.md)
+- Web UI: `http://localhost:3002`
+- API 문서: `http://localhost:8002/docs`
 
----
+## 핵심 작업 시나리오
 
-## 라이선스
+### 시나리오 A: 전략 생성 후 실행
 
-MIT
+1. 전략 빌더(`/[locale]/strategy`) 접속
+2. 유니버스/조건 노드 배치
+3. 조건 파라미터 조정
+4. 배포/실행 버튼 클릭
+5. 매칭 결과와 중간 결과 확인
+
+### 시나리오 B: 전략 검증(백테스트)
+
+1. 전략 저장 또는 불러오기
+2. 백테스트 패널 열기
+3. 기간/입력값 선택
+4. 결과(수익곡선/거래내역/지표) 검토
+
+### 시나리오 C: 스크리닝에서 분석으로
+
+1. `/[locale]/screening`에서 스캔 실행
+2. 종목 분석 페이지 이동
+3. 기술/재무/AI 컨텍스트 확인
+4. 리포트 흐름으로 연결
+
+## 설정
+
+### 주요 설정 파일
+
+- `config/base_config.yaml`: 전역 런타임/데이터/로깅
+- `config/screening_criteria.yaml`: 스크리닝 기본값
+- `portfolio/`: 포트폴리오 로직 및 포지션 사이징 모듈
+
+### 환경 변수
+
+| 변수 | 용도 |
+|---|---|
+| `ANTHROPIC_API_KEY` | AI 분석 연동 |
+| `FINNHUB_API_KEY` | 선택적 뉴스/데이터 소스 |
+| `MARKETAUX_API_KEY` | 선택적 뉴스/데이터 소스 |
+
+## API/Web 개발
+
+### 백엔드
+
+```bash
+source venv/bin/activate
+uvicorn api.main:app --host 0.0.0.0 --port 8002 --reload
+```
+
+### 프론트엔드
+
+```bash
+cd web
+PORT=3002 npm run dev
+```
+
+### 유용한 점검 명령
+
+```bash
+npm --prefix web run lint
+npm --prefix web run check:condition-i18n
+npm --prefix web run check:strategy-i18n
+```
+
+## 문제 해결
+
+- Web에서 API 호출 실패:
+  - API 실행 포트 확인
+  - 프론트 API 베이스 URL/env 확인
+- i18n 키 에러(`MISSING_MESSAGE`):
+  - `npm --prefix web run check:strategy-i18n`
+  - `npm --prefix web run check:condition-i18n`
+- 전략 실행 결과가 비어 있음:
+  - 유니버스/조건 임계값이 너무 엄격한지 확인
+
+## 로드맵 / 제한사항
+
+- 브로커 연동(Kiwoom/IBKR)은 이슈 기반으로 진행 중
+- 고급 퀀트 조건은 단계적으로 확장 중
+- 다중 시장 워크플로우는 점진적으로 고도화 중
+
+## 언어 전환 (EN/KO)
+
+- 영문 기준 문서: `README.md`
+- 한국어 문서: `README_KO.md`


### PR DESCRIPTION
## Summary
- rebuild `README.md` as primary English documentation
- refresh `README_KO.md` as synchronized Korean counterpart with cross-links
- center docs on UI capabilities and user workflows (strategy build/backtest/screening-analysis)
- update local dev commands and default ports to current repo workflow (API 8002, Web 3002)
- remove stale references and align config paths with existing files

## Verification
- [x] verified no stale README references (`localhost:3000`, `localhost:8000`, `config/portfolio.yaml`)
- [x] verified referenced config files exist (`config/base_config.yaml`, `config/screening_criteria.yaml`)
- [x] validated docs-referenced i18n check command executes (`npm --prefix web run check:strategy-i18n`)

## Issue
- closes #490

🤖 Generated with Codex