### PR TITLE
feat(brokers): broker abstraction layer + Kiwoom adapter

### DIFF
--- a/brokers/__init__.py
+++ b/brokers/__init__.py
@@ -1,0 +1,123 @@
+"""Broker abstraction layer.
+
+Provides a vendor-agnostic interface for trading operations.
+Concrete adapters (e.g. Kiwoom, Alpaca) implement ``BrokerAdapter``
+and register themselves via ``BrokerRegistry``.
+
+Module-level convenience helpers :func:`get_broker` and
+:func:`list_brokers` operate on a default registry that auto-registers
+all built-in adapters on first import.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import List
+
+from brokers.base import (
+    AmendRequest,
+    BrokerAdapter,
+    BrokerRegistry,
+    ConnectionState,
+    ConnectionStatus,
+    KillSwitchResult,
+    OrderCallback,
+    OrderEvent,
+    OrderRequest,
+    OrderSide,
+    OrderSnapshot,
+    OrderStatus,
+    OrderType,
+)
+from brokers.exceptions import (
+    BrokerConnectionError,
+    BrokerError,
+    BrokerSafetyError,
+    BrokerValidationError,
+    OrderNotFoundError,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Default global registry
+# ---------------------------------------------------------------------------
+
+_default_registry: BrokerRegistry = BrokerRegistry()
+_registry_initialised: bool = False
+
+
+def _register_default_brokers() -> None:
+    """Lazily register all built-in broker adapters.
+
+    Each adapter import is wrapped in a ``try``/``except`` so that a
+    missing optional dependency (e.g. the Kiwoom COM library on Linux)
+    does not prevent the rest of the package from loading.
+    """
+    global _registry_initialised  # noqa: PLW0603
+    if _registry_initialised:
+        return
+    _registry_initialised = True
+
+    # -- Kiwoom adapter ----------------------------------------------------
+    try:
+        from brokers.kiwoom.adapter import KiwoomBrokerAdapter
+
+        _default_registry.register("kiwoom", KiwoomBrokerAdapter)
+        logger.debug("Registered broker adapter: kiwoom")
+    except Exception:
+        logger.debug("Kiwoom adapter not available; skipping registration", exc_info=True)
+
+
+def get_broker(name: str) -> BrokerAdapter:
+    """Return an adapter instance from the default registry.
+
+    Parameters
+    ----------
+    name:
+        Broker identifier (e.g. ``"kiwoom"``).
+
+    Raises
+    ------
+    KeyError
+        If *name* is not registered.
+    """
+    _register_default_brokers()
+    return _default_registry.get(name)
+
+
+def list_brokers() -> List[str]:
+    """Return the names of all registered brokers."""
+    _register_default_brokers()
+    return _default_registry.list_brokers()
+
+
+__all__ = [
+    # Exceptions
+    "BrokerError",
+    "BrokerConnectionError",
+    "BrokerValidationError",
+    "OrderNotFoundError",
+    "BrokerSafetyError",
+    # Enums
+    "OrderSide",
+    "OrderType",
+    "OrderStatus",
+    "ConnectionState",
+    # DTOs
+    "ConnectionStatus",
+    "OrderRequest",
+    "OrderSnapshot",
+    "AmendRequest",
+    "KillSwitchResult",
+    "OrderEvent",
+    # Type aliases
+    "OrderCallback",
+    # ABC
+    "BrokerAdapter",
+    # Factory
+    "BrokerRegistry",
+    # Convenience helpers
+    "get_broker",
+    "list_brokers",
+]

--- a/brokers/base.py
+++ b/brokers/base.py
@@ -1,0 +1,427 @@
+"""Broker abstraction base module.
+
+Defines the canonical enums, Pydantic DTOs, abstract adapter interface,
+and a singleton registry/factory that concrete broker implementations
+plug into.
+"""
+
+from __future__ import annotations
+
+import threading
+from abc import ABC, abstractmethod
+from enum import Enum
+from typing import Callable, Dict, List, Optional, Type
+
+from pydantic import BaseModel, Field, model_validator
+
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+
+class OrderSide(str, Enum):
+    """Direction of an order."""
+
+    BUY = "BUY"
+    SELL = "SELL"
+
+
+class OrderType(str, Enum):
+    """Price determination strategy."""
+
+    MARKET = "MARKET"
+    LIMIT = "LIMIT"
+
+
+class OrderStatus(str, Enum):
+    """Lifecycle status of an order."""
+
+    RECEIVED = "RECEIVED"
+    CONFIRMED = "CONFIRMED"
+    FILLED = "FILLED"
+    CANCELED = "CANCELED"
+    REJECTED = "REJECTED"
+    PARTIAL = "PARTIAL"
+
+
+class ConnectionState(str, Enum):
+    """Broker connection state."""
+
+    CONNECTED = "connected"
+    DISCONNECTED = "disconnected"
+    CONNECTING = "connecting"
+    UNAVAILABLE = "unavailable"
+
+
+# ---------------------------------------------------------------------------
+# DTOs (Pydantic v2 BaseModel)
+# ---------------------------------------------------------------------------
+
+
+class ConnectionStatus(BaseModel):
+    """Snapshot of the broker connection state.
+
+    Attributes:
+        broker: Identifier of the broker (e.g. ``"kiwoom"``, ``"alpaca"``).
+        status: Current connection state.
+        is_paper_trading: ``True`` when running on a paper/mock server.
+        user_id: Authenticated user identifier, if available.
+        accounts: List of account numbers accessible through this connection.
+        updated_at: ISO-8601 timestamp of the last status change.
+    """
+
+    broker: str = Field(..., description="Broker identifier")
+    status: ConnectionState = Field(..., description="Current connection state")
+    is_paper_trading: Optional[bool] = Field(
+        None, description="Whether running in paper-trading mode"
+    )
+    user_id: Optional[str] = Field(None, description="Authenticated user ID")
+    accounts: List[str] = Field(
+        default_factory=list, description="Accessible account numbers"
+    )
+    updated_at: Optional[str] = Field(
+        None, description="Last status change timestamp (ISO 8601)"
+    )
+
+
+class OrderRequest(BaseModel):
+    """Parameters required to place a new order.
+
+    Attributes:
+        ticker: Instrument symbol (e.g. ``"005930"`` for Samsung).
+        side: Buy or sell.
+        quantity: Number of shares/contracts. Must be > 0.
+        order_type: Market or limit.
+        price: Required for limit orders; ignored for market orders.
+        account_id: Target account. ``None`` uses the broker default.
+    """
+
+    ticker: str = Field(..., description="Instrument symbol")
+    side: OrderSide = Field(..., description="Order direction")
+    quantity: int = Field(..., gt=0, description="Number of shares/contracts")
+    order_type: OrderType = Field(..., description="Market or limit")
+    price: Optional[float] = Field(
+        None, description="Limit price (required for LIMIT orders)"
+    )
+    account_id: Optional[str] = Field(
+        None, description="Target account (None = broker default)"
+    )
+
+    @model_validator(mode="after")
+    def _check_limit_price(self) -> OrderRequest:
+        if self.order_type == OrderType.LIMIT and not self.price:
+            raise ValueError("price is required for LIMIT orders")
+        return self
+
+
+class OrderSnapshot(BaseModel):
+    """Immutable point-in-time view of an order.
+
+    Attributes:
+        order_id: Broker-assigned unique identifier.
+        broker: Originating broker name.
+        ticker: Instrument symbol.
+        side: Buy or sell.
+        quantity: Originally requested quantity.
+        filled_quantity: Quantity filled so far.
+        unfilled_quantity: Remaining quantity.
+        order_type: Market or limit.
+        price: Limit price (``None`` for market orders).
+        filled_price: Volume-weighted average fill price.
+        status: Current lifecycle status.
+        created_at: Creation timestamp (ISO 8601).
+        updated_at: Last modification timestamp (ISO 8601).
+    """
+
+    order_id: str = Field(..., description="Broker-assigned order identifier")
+    broker: str = Field(..., description="Originating broker name")
+    ticker: str = Field(..., description="Instrument symbol")
+    side: OrderSide = Field(..., description="Order direction")
+    quantity: int = Field(..., description="Originally requested quantity")
+    filled_quantity: int = Field(0, description="Quantity filled so far")
+    unfilled_quantity: int = Field(0, description="Remaining unfilled quantity")
+    order_type: OrderType = Field(..., description="Market or limit")
+    price: Optional[float] = Field(
+        None, description="Limit price (None for market orders)"
+    )
+    filled_price: Optional[float] = Field(
+        None, description="Volume-weighted average fill price"
+    )
+    status: OrderStatus = Field(..., description="Current lifecycle status")
+    created_at: str = Field(..., description="Creation timestamp (ISO 8601)")
+    updated_at: Optional[str] = Field(
+        None, description="Last modification timestamp (ISO 8601)"
+    )
+
+
+class AmendRequest(BaseModel):
+    """Parameters for amending an existing order.
+
+    At least one of ``quantity`` or ``price`` must be provided.
+
+    Attributes:
+        quantity: New quantity (must be > 0 if provided).
+        price: New limit price.
+    """
+
+    quantity: Optional[int] = Field(None, gt=0, description="New quantity")
+    price: Optional[float] = Field(None, description="New limit price")
+
+    @model_validator(mode="after")
+    def _check_at_least_one(self) -> AmendRequest:
+        if self.quantity is None and self.price is None:
+            raise ValueError("at least one of quantity or price must be provided")
+        return self
+
+
+class KillSwitchResult(BaseModel):
+    """Outcome of a kill-switch activation.
+
+    Attributes:
+        activated: Whether the kill switch was successfully activated.
+        cancelled_orders: Number of open orders that were cancelled.
+    """
+
+    activated: bool = Field(..., description="Whether the kill switch was activated")
+    cancelled_orders: int = Field(0, description="Number of orders cancelled")
+
+
+class OrderEvent(BaseModel):
+    """Real-time order status update pushed to subscribers.
+
+    Attributes:
+        broker: Originating broker name.
+        order_id: Broker-assigned order identifier.
+        ticker: Instrument symbol.
+        status: New lifecycle status.
+        filled_quantity: Cumulative filled quantity.
+        unfilled_quantity: Remaining unfilled quantity.
+        filled_price: Latest (or average) fill price.
+    """
+
+    broker: str = Field(..., description="Originating broker name")
+    order_id: str = Field(..., description="Broker-assigned order identifier")
+    ticker: str = Field(..., description="Instrument symbol")
+    status: OrderStatus = Field(..., description="New lifecycle status")
+    filled_quantity: int = Field(0, description="Cumulative filled quantity")
+    unfilled_quantity: int = Field(0, description="Remaining unfilled quantity")
+    filled_price: Optional[float] = Field(None, description="Latest fill price")
+
+
+# ---------------------------------------------------------------------------
+# Type alias
+# ---------------------------------------------------------------------------
+
+OrderCallback = Callable[[OrderEvent], None]
+"""Signature for real-time order event listeners."""
+
+
+# ---------------------------------------------------------------------------
+# Abstract Broker Adapter
+# ---------------------------------------------------------------------------
+
+
+class BrokerAdapter(ABC):
+    """Vendor-agnostic interface that every broker integration must implement.
+
+    Concrete subclasses provide market-specific logic (e.g. Kiwoom for KRX,
+    Alpaca for US equities) while callers interact through this uniform API.
+    """
+
+    # -- identity -----------------------------------------------------------
+
+    @property
+    @abstractmethod
+    def broker_name(self) -> str:
+        """Return the canonical broker identifier (e.g. ``"kiwoom"``)."""
+
+    @property
+    @abstractmethod
+    def supported_markets(self) -> List[str]:
+        """Return market codes this adapter can trade (e.g. ``["KRX"]``)."""
+
+    # -- connection ---------------------------------------------------------
+
+    @abstractmethod
+    def get_connection_status(self) -> ConnectionStatus:
+        """Return the current connection state.
+
+        Returns:
+            A ``ConnectionStatus`` snapshot.
+
+        Raises:
+            BrokerConnectionError: If the status cannot be determined.
+        """
+
+    # -- order lifecycle ----------------------------------------------------
+
+    @abstractmethod
+    def place_order(self, request: OrderRequest) -> OrderSnapshot:
+        """Submit a new order to the broker.
+
+        Args:
+            request: Validated order parameters.
+
+        Returns:
+            An ``OrderSnapshot`` with at least ``RECEIVED`` status.
+
+        Raises:
+            BrokerValidationError: If the request fails broker-side validation.
+            BrokerConnectionError: If the broker is unreachable.
+            BrokerSafetyError: If a safety rule blocks the order.
+        """
+
+    @abstractmethod
+    def get_orders(self) -> List[OrderSnapshot]:
+        """Retrieve all tracked orders for the current session.
+
+        Returns:
+            A list of ``OrderSnapshot`` objects (may be empty).
+
+        Raises:
+            BrokerConnectionError: If the broker is unreachable.
+        """
+
+    @abstractmethod
+    def cancel_order(self, order_id: str) -> None:
+        """Cancel an open order.
+
+        Args:
+            order_id: Broker-assigned order identifier.
+
+        Raises:
+            OrderNotFoundError: If the order does not exist.
+            BrokerConnectionError: If the broker is unreachable.
+            BrokerSafetyError: If cancellation is blocked by a safety rule.
+        """
+
+    @abstractmethod
+    def amend_order(self, order_id: str, request: AmendRequest) -> None:
+        """Modify an open order (quantity and/or price).
+
+        Args:
+            order_id: Broker-assigned order identifier.
+            request: Fields to amend.
+
+        Raises:
+            OrderNotFoundError: If the order does not exist.
+            BrokerValidationError: If the amendment is invalid.
+            BrokerConnectionError: If the broker is unreachable.
+        """
+
+    # -- emergency ----------------------------------------------------------
+
+    @abstractmethod
+    def activate_kill_switch(self) -> KillSwitchResult:
+        """Activate the emergency kill switch.
+
+        Cancels all open orders and blocks new submissions until reset.
+
+        Returns:
+            A ``KillSwitchResult`` with the count of cancelled orders.
+
+        Raises:
+            BrokerConnectionError: If the broker is unreachable.
+        """
+
+    # -- real-time subscriptions --------------------------------------------
+
+    @abstractmethod
+    def subscribe_orders(self, callback: OrderCallback) -> None:
+        """Register a callback for real-time order events.
+
+        Args:
+            callback: Function invoked with each ``OrderEvent``.
+
+        Raises:
+            BrokerConnectionError: If the subscription cannot be established.
+        """
+
+    @abstractmethod
+    def unsubscribe_orders(self, callback: OrderCallback) -> None:
+        """Remove a previously registered order event callback.
+
+        Args:
+            callback: The exact callback reference passed to ``subscribe_orders``.
+        """
+
+
+# ---------------------------------------------------------------------------
+# Broker Registry (Factory)
+# ---------------------------------------------------------------------------
+
+
+class BrokerRegistry:
+    """Thread-safe factory that maps broker names to lazy singleton adapters.
+
+    Usage::
+
+        registry = BrokerRegistry()
+        registry.register("kiwoom", KiwoomAdapter)
+        adapter = registry.get("kiwoom")   # instantiated on first call
+    """
+
+    def __init__(self) -> None:
+        self._classes: Dict[str, Type[BrokerAdapter]] = {}
+        self._instances: Dict[str, BrokerAdapter] = {}
+        self._lock = threading.Lock()
+
+    def register(self, name: str, adapter_class: Type[BrokerAdapter]) -> None:
+        """Register an adapter class under the given name.
+
+        Args:
+            name: Canonical broker identifier (case-sensitive).
+            adapter_class: A concrete ``BrokerAdapter`` subclass.
+
+        Raises:
+            TypeError: If *adapter_class* is not a ``BrokerAdapter`` subclass.
+        """
+        if not (isinstance(adapter_class, type) and issubclass(adapter_class, BrokerAdapter)):
+            raise TypeError(
+                f"adapter_class must be a BrokerAdapter subclass, got {adapter_class!r}"
+            )
+        with self._lock:
+            self._classes[name] = adapter_class
+            # Invalidate a cached instance so the new class takes effect.
+            old = self._instances.pop(name, None)
+            if old is not None and hasattr(old, "close"):
+                try:
+                    old.close()
+                except Exception:
+                    pass
+
+    def get(self, name: str) -> BrokerAdapter:
+        """Return a singleton adapter instance for *name*.
+
+        The adapter is instantiated lazily on the first call and reused
+        on subsequent calls.
+
+        Args:
+            name: Registered broker identifier.
+
+        Returns:
+            A ``BrokerAdapter`` instance.
+
+        Raises:
+            KeyError: If *name* has not been registered.
+        """
+        with self._lock:
+            if name in self._instances:
+                return self._instances[name]
+            cls = self._classes.get(name)
+            if cls is None:
+                raise KeyError(f"broker {name!r} is not registered")
+            instance = cls()
+            self._instances[name] = instance
+            return instance
+
+    def list_brokers(self) -> List[str]:
+        """Return registered broker names in sorted order."""
+        with self._lock:
+            return sorted(self._classes)
+
+    def is_registered(self, name: str) -> bool:
+        """Check whether a broker name is registered."""
+        with self._lock:
+            return name in self._classes

--- a/brokers/exceptions.py
+++ b/brokers/exceptions.py
@@ -1,0 +1,65 @@
+"""Broker-layer exception hierarchy.
+
+Every exception carries an implicit HTTP status mapping so that API
+routers can translate domain errors into appropriate responses without
+leaking internal details.
+
+Hierarchy
+---------
+::
+
+    RuntimeError
+    └── BrokerError                    (500 Internal Server Error)
+        ├── BrokerConnectionError      (503 Service Unavailable)
+        ├── BrokerSafetyError          (409 Conflict)
+        └── ...
+
+    RuntimeError + ValueError
+    └── BrokerValidationError          (400 Bad Request)
+
+    RuntimeError + KeyError
+    └── OrderNotFoundError             (404 Not Found)
+"""
+
+from __future__ import annotations
+
+
+class BrokerError(RuntimeError):
+    """Base exception for all broker operations.
+
+    HTTP mapping: **500 Internal Server Error**
+    """
+
+
+class BrokerConnectionError(BrokerError):
+    """Raised when the broker connection is unavailable or times out.
+
+    HTTP mapping: **503 Service Unavailable**
+    """
+
+
+class BrokerValidationError(BrokerError, ValueError):
+    """Raised when an order request fails input validation.
+
+    Inherits from both ``BrokerError`` (for broker-layer catching) and
+    ``ValueError`` (for generic validation catching).
+
+    HTTP mapping: **400 Bad Request**
+    """
+
+
+class OrderNotFoundError(BrokerError, KeyError):
+    """Raised when a referenced order ID does not exist.
+
+    Inherits from both ``BrokerError`` (for broker-layer catching) and
+    ``KeyError`` (for generic lookup catching).
+
+    HTTP mapping: **404 Not Found**
+    """
+
+
+class BrokerSafetyError(BrokerError):
+    """Raised when a safety rule (kill switch, duplicate guard, etc.) blocks an operation.
+
+    HTTP mapping: **409 Conflict**
+    """

--- a/brokers/kiwoom/__init__.py
+++ b/brokers/kiwoom/__init__.py
@@ -1,0 +1,7 @@
+"""Kiwoom broker adapter package."""
+
+from __future__ import annotations
+
+from brokers.kiwoom.adapter import KiwoomBrokerAdapter
+
+__all__ = ["KiwoomBrokerAdapter"]

--- a/brokers/kiwoom/adapter.py
+++ b/brokers/kiwoom/adapter.py
@@ -1,0 +1,266 @@
+"""Kiwoom OpenAPI+ broker adapter.
+
+Wraps :class:`api.services.kiwoom_service.KiwoomService` behind the
+:class:`brokers.base.BrokerAdapter` ABC so that callers interact with a
+vendor-agnostic interface.  ``KiwoomService`` code is **not** modified --
+all translation between broker-specific dicts and canonical DTOs happens
+here.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any, Dict, List, Optional
+
+from api.services.kiwoom_service import KiwoomService
+from brokers.base import (
+    AmendRequest,
+    BrokerAdapter,
+    ConnectionState,
+    ConnectionStatus,
+    KillSwitchResult,
+    OrderCallback,
+    OrderEvent,
+    OrderRequest,
+    OrderSnapshot,
+    OrderStatus,
+)
+from brokers.exceptions import (
+    BrokerConnectionError,
+    BrokerError,
+    BrokerSafetyError,
+    BrokerValidationError,
+    OrderNotFoundError,
+)
+from kiwoom.safety import SafetyViolation
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Chejan status string -> canonical OrderStatus mapping
+# ---------------------------------------------------------------------------
+
+_CHEJAN_STATUS_MAP: Dict[str, OrderStatus] = {
+    "CANCELLED": OrderStatus.CANCELED,
+    "PLACED": OrderStatus.CONFIRMED,
+    "PENDING": OrderStatus.RECEIVED,
+}
+
+
+def _resolve_order_status(raw: str) -> OrderStatus:
+    """Map a chejan status string to the canonical :class:`OrderStatus`.
+
+    Falls back to ``RECEIVED`` if the value is unrecognised.
+    """
+    if raw in _CHEJAN_STATUS_MAP:
+        return _CHEJAN_STATUS_MAP[raw]
+    try:
+        return OrderStatus(raw)
+    except ValueError:
+        return OrderStatus.RECEIVED
+
+
+# ---------------------------------------------------------------------------
+# Adapter
+# ---------------------------------------------------------------------------
+
+
+class KiwoomBrokerAdapter(BrokerAdapter):
+    """Adapt :class:`KiwoomService` to the :class:`BrokerAdapter` interface.
+
+    Instantiation obtains the ``KiwoomService`` singleton and subscribes to
+    chejan (order execution) events so that registered callbacks receive
+    :class:`OrderEvent` objects in real-time.
+    """
+
+    def __init__(self) -> None:
+        self._service: KiwoomService = KiwoomService.get_instance()
+        self._callbacks: List[OrderCallback] = []
+        self._cb_lock: threading.RLock = threading.RLock()
+
+        # Subscribe to the chejan handler's observer pipeline.
+        self._service._chejan.add_observer(self._on_chejan_event)
+
+    def close(self) -> None:
+        """Unsubscribe from chejan events and release resources."""
+        self._service._chejan.remove_observer(self._on_chejan_event)
+        with self._cb_lock:
+            self._callbacks.clear()
+
+    # -- Properties --------------------------------------------------------
+
+    @property
+    def broker_name(self) -> str:  # noqa: D401
+        """Return ``\"kiwoom\"``."""
+        return "kiwoom"
+
+    @property
+    def supported_markets(self) -> List[str]:
+        """Return ``[\"KRX\"]``."""
+        return ["KRX"]
+
+    # -- Connection --------------------------------------------------------
+
+    def get_connection_status(self) -> ConnectionStatus:
+        """Query the underlying service and return a canonical DTO."""
+        raw: Dict[str, Any] = self._service.get_connection_status()
+
+        return ConnectionStatus(
+            status=ConnectionState(raw["status"]),
+            is_paper_trading=raw.get("is_mock_trading"),
+            broker="kiwoom",
+            user_id=raw.get("user_id"),
+            accounts=raw.get("accounts", []),
+            updated_at=raw.get("updated_at"),
+        )
+
+    # -- Orders ------------------------------------------------------------
+
+    def place_order(self, request: OrderRequest) -> OrderSnapshot:
+        """Place a new order via ``KiwoomService`` and return a snapshot."""
+        try:
+            raw: Dict[str, Any] = self._service.place_order(
+                ticker=request.ticker,
+                side=request.side.value,
+                quantity=request.quantity,
+                order_type=request.order_type.value,
+                price=request.price,
+            )
+        except ValueError as exc:
+            raise BrokerValidationError(str(exc)) from exc
+        except SafetyViolation as exc:
+            raise BrokerSafetyError(str(exc)) from exc
+        except RuntimeError as exc:
+            if "no accounts" in str(exc).lower():
+                raise BrokerConnectionError(str(exc)) from exc
+            raise BrokerError(str(exc)) from exc
+
+        return self._raw_order_to_snapshot(raw)
+
+    def get_orders(self) -> List[OrderSnapshot]:
+        """Return all tracked orders as canonical snapshots."""
+        raw_list: List[Dict[str, Any]] = self._service.get_orders()
+        return [self._raw_order_to_snapshot(r) for r in raw_list]
+
+    def cancel_order(self, order_id: str) -> None:
+        """Cancel an open order by its ID."""
+        try:
+            self._service.cancel_order(order_id)
+        except KeyError as exc:
+            raise OrderNotFoundError(str(exc)) from exc
+        except SafetyViolation as exc:
+            raise BrokerSafetyError(str(exc)) from exc
+        except RuntimeError as exc:
+            raise BrokerError(str(exc)) from exc
+
+    def amend_order(self, order_id: str, request: AmendRequest) -> None:
+        """Amend (modify) an open order."""
+        try:
+            self._service.amend_order(
+                order_id=order_id,
+                quantity=request.quantity,
+                price=request.price,
+            )
+        except KeyError as exc:
+            raise OrderNotFoundError(str(exc)) from exc
+        except ValueError as exc:
+            raise BrokerValidationError(str(exc)) from exc
+        except SafetyViolation as exc:
+            raise BrokerSafetyError(str(exc)) from exc
+        except RuntimeError as exc:
+            raise BrokerError(str(exc)) from exc
+
+    # -- Kill switch -------------------------------------------------------
+
+    def activate_kill_switch(self) -> KillSwitchResult:
+        """Activate the emergency kill switch."""
+        raw: Dict[str, Any] = self._service.activate_kill_switch()
+        return KillSwitchResult(
+            activated=raw["activated"],
+            cancelled_orders=raw["cancelled_orders"],
+        )
+
+    # -- Subscriptions -----------------------------------------------------
+
+    def subscribe_orders(self, callback: OrderCallback) -> None:
+        """Register a callback for real-time order events."""
+        with self._cb_lock:
+            if callback not in self._callbacks:
+                self._callbacks.append(callback)
+
+    def unsubscribe_orders(self, callback: OrderCallback) -> None:
+        """Remove a previously registered callback."""
+        with self._cb_lock:
+            try:
+                self._callbacks.remove(callback)
+            except ValueError:
+                pass
+
+    # -- Internal helpers --------------------------------------------------
+
+    def _on_chejan_event(self, payload: Dict[str, Any]) -> None:
+        """Observer callback invoked by the chejan handler.
+
+        Translates the raw chejan dict into an :class:`OrderEvent` and
+        dispatches to all registered callbacks.  Non-order events and
+        events lacking an ``order_no`` are silently ignored.
+        """
+        if payload.get("type") != "order":
+            return
+
+        order_no: Optional[str] = payload.get("order_no")
+        if not order_no:
+            return
+
+        status = _resolve_order_status(payload.get("status", ""))
+
+        event = OrderEvent(
+            order_id=order_no,
+            ticker=payload.get("code", ""),
+            status=status,
+            filled_quantity=payload.get("filled_qty", 0),
+            unfilled_quantity=payload.get("unfilled_qty", 0),
+            filled_price=self._safe_float(payload.get("fill_price")),
+            broker="kiwoom",
+        )
+
+        with self._cb_lock:
+            callbacks = list(self._callbacks)
+
+        for cb in callbacks:
+            try:
+                cb(event)
+            except Exception:
+                logger.exception(
+                    "Order callback raised for order_id=%s", order_no
+                )
+
+    @staticmethod
+    def _safe_float(value: Any) -> Optional[float]:
+        """Convert *value* to float, returning ``None`` on failure."""
+        if not value:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _raw_order_to_snapshot(raw: Dict[str, Any]) -> OrderSnapshot:
+        """Convert a dict returned by ``KiwoomService`` to an ``OrderSnapshot``."""
+        return OrderSnapshot(
+            order_id=raw["order_id"],
+            ticker=raw["ticker"],
+            side=raw["side"],
+            quantity=raw["quantity"],
+            filled_quantity=raw.get("filled_quantity", 0),
+            unfilled_quantity=raw.get("unfilled_quantity", 0),
+            order_type=raw["order_type"],
+            price=raw.get("price"),
+            filled_price=raw.get("filled_price"),
+            status=raw["status"],
+            created_at=raw["created_at"],
+            updated_at=raw.get("updated_at"),
+            broker="kiwoom",
+        )

--- a/tests/test_broker_adapter.py
+++ b/tests/test_broker_adapter.py
@@ -1,0 +1,737 @@
+"""Unit tests for the brokers/ package public API.
+
+Covers:
+- brokers.exceptions  -- exception hierarchy and inheritance
+- brokers.base        -- DTO validation, BrokerRegistry
+- brokers.kiwoom.adapter -- KiwoomBrokerAdapter (KiwoomService fully mocked)
+- brokers.__init__    -- module-level get_broker() / list_brokers()
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from brokers.base import (
+    AmendRequest,
+    BrokerAdapter,
+    BrokerRegistry,
+    ConnectionState,
+    ConnectionStatus,
+    KillSwitchResult,
+    OrderCallback,
+    OrderEvent,
+    OrderRequest,
+    OrderSide,
+    OrderSnapshot,
+    OrderStatus,
+    OrderType,
+)
+from brokers.exceptions import (
+    BrokerConnectionError,
+    BrokerError,
+    BrokerSafetyError,
+    BrokerValidationError,
+    OrderNotFoundError,
+)
+from kiwoom.safety import SafetyViolation
+
+# =========================================================================
+# 1. Exception hierarchy tests
+# =========================================================================
+
+
+class TestExceptionHierarchy:
+    """Verify the broker exception hierarchy matches documented MRO."""
+
+    def test_broker_error_is_runtime_error(self) -> None:
+        assert issubclass(BrokerError, RuntimeError)
+        err = BrokerError("boom")
+        assert isinstance(err, RuntimeError)
+
+    def test_broker_validation_error_is_value_error(self) -> None:
+        assert issubclass(BrokerValidationError, ValueError)
+        assert issubclass(BrokerValidationError, BrokerError)
+        err = BrokerValidationError("bad input")
+        assert isinstance(err, ValueError)
+        assert isinstance(err, BrokerError)
+
+    def test_order_not_found_is_key_error(self) -> None:
+        assert issubclass(OrderNotFoundError, KeyError)
+        assert issubclass(OrderNotFoundError, BrokerError)
+        err = OrderNotFoundError("ORD999")
+        assert isinstance(err, KeyError)
+        assert isinstance(err, BrokerError)
+
+    def test_broker_safety_error_is_broker_error(self) -> None:
+        assert issubclass(BrokerSafetyError, BrokerError)
+        err = BrokerSafetyError("kill switch active")
+        assert isinstance(err, BrokerError)
+        assert isinstance(err, RuntimeError)
+
+    def test_broker_connection_error_is_broker_error(self) -> None:
+        assert issubclass(BrokerConnectionError, BrokerError)
+        err = BrokerConnectionError("timeout")
+        assert isinstance(err, BrokerError)
+        assert isinstance(err, RuntimeError)
+
+
+# =========================================================================
+# 2. DTO validation tests
+# =========================================================================
+
+
+class TestDTOValidation:
+    """Verify Pydantic DTOs enforce constraints correctly."""
+
+    def test_order_request_rejects_zero_quantity(self) -> None:
+        with pytest.raises(ValidationError):
+            OrderRequest(
+                ticker="005930",
+                side=OrderSide.BUY,
+                quantity=0,
+                order_type=OrderType.LIMIT,
+                price=70000.0,
+            )
+
+    def test_order_request_market_without_price(self) -> None:
+        req = OrderRequest(
+            ticker="005930",
+            side=OrderSide.BUY,
+            quantity=10,
+            order_type=OrderType.MARKET,
+            price=None,
+        )
+        assert req.price is None
+        assert req.order_type == OrderType.MARKET
+
+    def test_order_request_limit_with_price(self) -> None:
+        req = OrderRequest(
+            ticker="005930",
+            side=OrderSide.BUY,
+            quantity=10,
+            order_type=OrderType.LIMIT,
+            price=100.0,
+        )
+        assert req.price == 100.0
+        assert req.order_type == OrderType.LIMIT
+
+    def test_order_snapshot_round_trip(self) -> None:
+        snap = OrderSnapshot(
+            order_id="ORD1",
+            broker="kiwoom",
+            ticker="005930",
+            side=OrderSide.BUY,
+            quantity=10,
+            filled_quantity=5,
+            unfilled_quantity=5,
+            order_type=OrderType.LIMIT,
+            price=70000.0,
+            filled_price=69500.0,
+            status=OrderStatus.PARTIAL,
+            created_at="2026-01-01T00:00:00",
+            updated_at="2026-01-01T00:01:00",
+        )
+        dumped = snap.model_dump()
+        reconstructed = OrderSnapshot(**dumped)
+        assert reconstructed == snap
+        assert reconstructed.order_id == "ORD1"
+        assert reconstructed.filled_quantity == 5
+
+    def test_amend_request_partial_fields(self) -> None:
+        # Only quantity
+        amend_qty = AmendRequest(quantity=20)
+        assert amend_qty.quantity == 20
+        assert amend_qty.price is None
+
+        # Only price
+        amend_price = AmendRequest(price=75000.0)
+        assert amend_price.quantity is None
+        assert amend_price.price == 75000.0
+
+    def test_connection_status_defaults(self) -> None:
+        status = ConnectionStatus(
+            broker="test",
+            status=ConnectionState.DISCONNECTED,
+        )
+        assert status.accounts == []
+        assert status.is_paper_trading is None
+        assert status.user_id is None
+        assert status.updated_at is None
+
+
+# =========================================================================
+# 3. BrokerRegistry tests
+# =========================================================================
+
+
+class _DummyAdapter(BrokerAdapter):
+    """Minimal concrete adapter for registry tests."""
+
+    @property
+    def broker_name(self) -> str:
+        return "dummy"
+
+    @property
+    def supported_markets(self) -> list[str]:
+        return ["TEST"]
+
+    def get_connection_status(self) -> ConnectionStatus:
+        return ConnectionStatus(
+            broker="dummy", status=ConnectionState.CONNECTED
+        )
+
+    def place_order(self, request: OrderRequest) -> OrderSnapshot:
+        raise NotImplementedError
+
+    def get_orders(self) -> list[OrderSnapshot]:
+        return []
+
+    def cancel_order(self, order_id: str) -> None:
+        raise NotImplementedError
+
+    def amend_order(self, order_id: str, request: AmendRequest) -> None:
+        raise NotImplementedError
+
+    def activate_kill_switch(self) -> KillSwitchResult:
+        raise NotImplementedError
+
+    def subscribe_orders(self, callback: OrderCallback) -> None:
+        pass
+
+    def unsubscribe_orders(self, callback: OrderCallback) -> None:
+        pass
+
+
+class TestBrokerRegistry:
+    """Verify BrokerRegistry register/get/list semantics."""
+
+    def test_registry_register_and_get(self) -> None:
+        registry = BrokerRegistry()
+        registry.register("dummy", _DummyAdapter)
+        adapter = registry.get("dummy")
+        assert isinstance(adapter, _DummyAdapter)
+        assert adapter.broker_name == "dummy"
+
+    def test_registry_singleton(self) -> None:
+        registry = BrokerRegistry()
+        registry.register("dummy", _DummyAdapter)
+        first = registry.get("dummy")
+        second = registry.get("dummy")
+        assert first is second
+
+    def test_registry_unknown_raises_key_error(self) -> None:
+        registry = BrokerRegistry()
+        with pytest.raises(KeyError, match="not registered"):
+            registry.get("nonexistent")
+
+    def test_registry_list_brokers(self) -> None:
+        registry = BrokerRegistry()
+        registry.register("beta", _DummyAdapter)
+        registry.register("alpha", _DummyAdapter)
+        assert registry.list_brokers() == ["alpha", "beta"]
+
+    def test_registry_reject_non_adapter(self) -> None:
+        registry = BrokerRegistry()
+        with pytest.raises(TypeError, match="BrokerAdapter subclass"):
+            registry.register("bad", dict)  # type: ignore[arg-type]
+
+
+# =========================================================================
+# 4. KiwoomBrokerAdapter tests (KiwoomService mocked)
+# =========================================================================
+
+# Shared raw order dict factory
+_RAW_ORDER_TEMPLATE = {
+    "order_id": "ORD1",
+    "ticker": "005930",
+    "side": "BUY",
+    "quantity": 10,
+    "filled_quantity": 0,
+    "unfilled_quantity": 10,
+    "order_type": "LIMIT",
+    "price": 70000.0,
+    "filled_price": None,
+    "status": "RECEIVED",
+    "created_at": "2026-01-01T00:00:00",
+    "updated_at": None,
+}
+
+
+def _make_raw_order(**overrides: object) -> dict:
+    """Return a copy of the template order dict with optional overrides."""
+    d = dict(_RAW_ORDER_TEMPLATE)
+    d.update(overrides)
+    return d
+
+
+@pytest.fixture()
+def mock_kiwoom_service(monkeypatch):
+    """Replace KiwoomService with a MagicMock before importing the adapter.
+
+    The fixture patches ``KiwoomService`` at the module level so that
+    ``KiwoomBrokerAdapter.__init__`` never touches real COM objects.
+    """
+    service = MagicMock()
+    service._chejan = MagicMock()
+
+    monkeypatch.setattr(
+        "brokers.kiwoom.adapter.KiwoomService",
+        MagicMock(get_instance=MagicMock(return_value=service)),
+    )
+    return service
+
+
+def _make_adapter():
+    """Instantiate a fresh KiwoomBrokerAdapter (call after patching)."""
+    from brokers.kiwoom.adapter import KiwoomBrokerAdapter
+
+    return KiwoomBrokerAdapter()
+
+
+# -- Identity --------------------------------------------------------------
+
+
+class TestKiwoomIdentity:
+    def test_broker_name(self, mock_kiwoom_service) -> None:
+        adapter = _make_adapter()
+        assert adapter.broker_name == "kiwoom"
+
+    def test_supported_markets(self, mock_kiwoom_service) -> None:
+        adapter = _make_adapter()
+        assert adapter.supported_markets == ["KRX"]
+
+
+# -- Connection status -----------------------------------------------------
+
+
+class TestKiwoomConnectionStatus:
+    def test_get_connection_status(self, mock_kiwoom_service) -> None:
+        mock_kiwoom_service.get_connection_status.return_value = {
+            "status": "connected",
+            "is_mock_trading": True,
+            "user_id": "test",
+            "accounts": ["123"],
+            "updated_at": "2026-01-01T00:00:00",
+        }
+        adapter = _make_adapter()
+        result = adapter.get_connection_status()
+
+        assert result.broker == "kiwoom"
+        assert result.status == ConnectionState.CONNECTED
+        assert result.is_paper_trading is True
+        assert result.user_id == "test"
+        assert result.accounts == ["123"]
+        assert result.updated_at == "2026-01-01T00:00:00"
+
+
+# -- place_order -----------------------------------------------------------
+
+
+class TestKiwoomPlaceOrder:
+    def test_place_order_success(self, mock_kiwoom_service) -> None:
+        mock_kiwoom_service.place_order.return_value = _make_raw_order()
+        adapter = _make_adapter()
+
+        request = OrderRequest(
+            ticker="005930",
+            side=OrderSide.BUY,
+            quantity=10,
+            order_type=OrderType.LIMIT,
+            price=70000.0,
+        )
+        result = adapter.place_order(request)
+
+        assert isinstance(result, OrderSnapshot)
+        assert result.broker == "kiwoom"
+        assert result.order_id == "ORD1"
+        assert result.status == OrderStatus.RECEIVED
+
+        mock_kiwoom_service.place_order.assert_called_once_with(
+            ticker="005930",
+            side="BUY",
+            quantity=10,
+            order_type="LIMIT",
+            price=70000.0,
+        )
+
+    def test_place_order_validation_error(self, mock_kiwoom_service) -> None:
+        mock_kiwoom_service.place_order.side_effect = ValueError("bad ticker")
+        adapter = _make_adapter()
+
+        request = OrderRequest(
+            ticker="INVALID",
+            side=OrderSide.BUY,
+            quantity=1,
+            order_type=OrderType.MARKET,
+        )
+
+        with pytest.raises(BrokerValidationError, match="bad ticker"):
+            adapter.place_order(request)
+
+    def test_place_order_safety_violation(self, mock_kiwoom_service) -> None:
+        mock_kiwoom_service.place_order.side_effect = SafetyViolation(
+            "kill switch"
+        )
+        adapter = _make_adapter()
+
+        request = OrderRequest(
+            ticker="005930",
+            side=OrderSide.BUY,
+            quantity=1,
+            order_type=OrderType.MARKET,
+        )
+
+        with pytest.raises(BrokerSafetyError, match="kill switch"):
+            adapter.place_order(request)
+
+    def test_place_order_no_accounts(self, mock_kiwoom_service) -> None:
+        mock_kiwoom_service.place_order.side_effect = RuntimeError(
+            "No accounts available"
+        )
+        adapter = _make_adapter()
+
+        request = OrderRequest(
+            ticker="005930",
+            side=OrderSide.BUY,
+            quantity=1,
+            order_type=OrderType.MARKET,
+        )
+
+        with pytest.raises(BrokerConnectionError, match="No accounts"):
+            adapter.place_order(request)
+
+    def test_place_order_runtime_error(self, mock_kiwoom_service) -> None:
+        mock_kiwoom_service.place_order.side_effect = RuntimeError(
+            "OCX failure"
+        )
+        adapter = _make_adapter()
+
+        request = OrderRequest(
+            ticker="005930",
+            side=OrderSide.BUY,
+            quantity=1,
+            order_type=OrderType.MARKET,
+        )
+
+        with pytest.raises(BrokerError, match="OCX failure"):
+            adapter.place_order(request)
+
+
+# -- get_orders ------------------------------------------------------------
+
+
+class TestKiwoomGetOrders:
+    def test_get_orders(self, mock_kiwoom_service) -> None:
+        mock_kiwoom_service.get_orders.return_value = [
+            _make_raw_order(order_id="ORD1"),
+            _make_raw_order(order_id="ORD2", status="FILLED", filled_quantity=10, unfilled_quantity=0),
+        ]
+        adapter = _make_adapter()
+        orders = adapter.get_orders()
+
+        assert len(orders) == 2
+        assert all(isinstance(o, OrderSnapshot) for o in orders)
+        assert orders[0].order_id == "ORD1"
+        assert orders[1].order_id == "ORD2"
+        assert orders[1].status == OrderStatus.FILLED
+
+
+# -- cancel_order ----------------------------------------------------------
+
+
+class TestKiwoomCancelOrder:
+    def test_cancel_order_success(self, mock_kiwoom_service) -> None:
+        mock_kiwoom_service.cancel_order.return_value = None
+        adapter = _make_adapter()
+        adapter.cancel_order("ORD1")
+        mock_kiwoom_service.cancel_order.assert_called_once_with("ORD1")
+
+    def test_cancel_order_not_found(self, mock_kiwoom_service) -> None:
+        mock_kiwoom_service.cancel_order.side_effect = KeyError("ORD999")
+        adapter = _make_adapter()
+
+        with pytest.raises(OrderNotFoundError):
+            adapter.cancel_order("ORD999")
+
+    def test_cancel_order_safety(self, mock_kiwoom_service) -> None:
+        mock_kiwoom_service.cancel_order.side_effect = SafetyViolation(
+            "blocked"
+        )
+        adapter = _make_adapter()
+
+        with pytest.raises(BrokerSafetyError, match="blocked"):
+            adapter.cancel_order("ORD1")
+
+
+# -- amend_order -----------------------------------------------------------
+
+
+class TestKiwoomAmendOrder:
+    def test_amend_order_success(self, mock_kiwoom_service) -> None:
+        mock_kiwoom_service.amend_order.return_value = None
+        adapter = _make_adapter()
+
+        amend = AmendRequest(quantity=20, price=71000.0)
+        adapter.amend_order("ORD1", amend)
+
+        mock_kiwoom_service.amend_order.assert_called_once_with(
+            order_id="ORD1",
+            quantity=20,
+            price=71000.0,
+        )
+
+    def test_amend_order_not_found(self, mock_kiwoom_service) -> None:
+        mock_kiwoom_service.amend_order.side_effect = KeyError("ORD999")
+        adapter = _make_adapter()
+
+        with pytest.raises(OrderNotFoundError):
+            adapter.amend_order("ORD999", AmendRequest(quantity=5))
+
+    def test_amend_order_validation_error(self, mock_kiwoom_service) -> None:
+        mock_kiwoom_service.amend_order.side_effect = ValueError(
+            "invalid quantity"
+        )
+        adapter = _make_adapter()
+
+        with pytest.raises(BrokerValidationError, match="invalid quantity"):
+            adapter.amend_order("ORD1", AmendRequest(price=0.0))
+
+
+# -- kill switch -----------------------------------------------------------
+
+
+class TestKiwoomKillSwitch:
+    def test_kill_switch(self, mock_kiwoom_service) -> None:
+        mock_kiwoom_service.activate_kill_switch.return_value = {
+            "activated": True,
+            "cancelled_orders": 3,
+        }
+        adapter = _make_adapter()
+        result = adapter.activate_kill_switch()
+
+        assert isinstance(result, KillSwitchResult)
+        assert result.activated is True
+        assert result.cancelled_orders == 3
+
+
+# -- subscribe / unsubscribe / chejan dispatch -----------------------------
+
+
+class TestKiwoomSubscription:
+    def test_subscribe_and_dispatch(self, mock_kiwoom_service) -> None:
+        adapter = _make_adapter()
+
+        received: list[OrderEvent] = []
+        callback: OrderCallback = lambda ev: received.append(ev)
+        adapter.subscribe_orders(callback)
+
+        # Simulate a chejan order event
+        adapter._on_chejan_event(
+            {
+                "type": "order",
+                "order_no": "ORD42",
+                "code": "005930",
+                "status": "FILLED",
+                "filled_qty": 10,
+                "unfilled_qty": 0,
+                "fill_price": 70000,
+            }
+        )
+
+        assert len(received) == 1
+        event = received[0]
+        assert event.order_id == "ORD42"
+        assert event.broker == "kiwoom"
+        assert event.status == OrderStatus.FILLED
+        assert event.filled_quantity == 10
+        assert event.filled_price == 70000.0
+
+    def test_subscribe_ignores_balance_events(
+        self, mock_kiwoom_service
+    ) -> None:
+        adapter = _make_adapter()
+
+        received: list[OrderEvent] = []
+        adapter.subscribe_orders(lambda ev: received.append(ev))
+
+        adapter._on_chejan_event(
+            {
+                "type": "balance",
+                "order_no": "ORD42",
+                "code": "005930",
+                "status": "FILLED",
+            }
+        )
+
+        assert len(received) == 0
+
+    def test_subscribe_ignores_no_order_no(
+        self, mock_kiwoom_service
+    ) -> None:
+        adapter = _make_adapter()
+
+        received: list[OrderEvent] = []
+        adapter.subscribe_orders(lambda ev: received.append(ev))
+
+        adapter._on_chejan_event(
+            {
+                "type": "order",
+                "order_no": "",
+                "code": "005930",
+                "status": "FILLED",
+            }
+        )
+
+        assert len(received) == 0
+
+    def test_unsubscribe_removes_callback(
+        self, mock_kiwoom_service
+    ) -> None:
+        adapter = _make_adapter()
+
+        received: list[OrderEvent] = []
+        callback: OrderCallback = lambda ev: received.append(ev)
+        adapter.subscribe_orders(callback)
+        adapter.unsubscribe_orders(callback)
+
+        adapter._on_chejan_event(
+            {
+                "type": "order",
+                "order_no": "ORD42",
+                "code": "005930",
+                "status": "FILLED",
+                "filled_qty": 10,
+                "unfilled_qty": 0,
+                "fill_price": 70000,
+            }
+        )
+
+        assert len(received) == 0
+
+    def test_subscribe_no_duplicates(self, mock_kiwoom_service) -> None:
+        adapter = _make_adapter()
+
+        call_count = 0
+
+        def counting_callback(ev: OrderEvent) -> None:
+            nonlocal call_count
+            call_count += 1
+
+        # Register the same callback twice
+        adapter.subscribe_orders(counting_callback)
+        adapter.subscribe_orders(counting_callback)
+
+        adapter._on_chejan_event(
+            {
+                "type": "order",
+                "order_no": "ORD42",
+                "code": "005930",
+                "status": "FILLED",
+                "filled_qty": 10,
+                "unfilled_qty": 0,
+                "fill_price": 70000,
+            }
+        )
+
+        # Should only be called once despite two registrations
+        assert call_count == 1
+
+
+# -- chejan status mapping -------------------------------------------------
+
+
+class TestChejanStatusMapping:
+    """Verify raw chejan status strings map to canonical OrderStatus."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, mock_kiwoom_service):
+        self.adapter = _make_adapter()
+
+    def _dispatch_and_get_status(self, raw_status: str) -> OrderStatus:
+        received: list[OrderEvent] = []
+        callback: OrderCallback = lambda ev: received.append(ev)
+        self.adapter.subscribe_orders(callback)
+
+        self.adapter._on_chejan_event(
+            {
+                "type": "order",
+                "order_no": "ORD1",
+                "code": "005930",
+                "status": raw_status,
+                "filled_qty": 0,
+                "unfilled_qty": 10,
+                "fill_price": None,
+            }
+        )
+
+        self.adapter.unsubscribe_orders(callback)
+        assert len(received) == 1
+        return received[0].status
+
+    def test_cancelled_maps_to_canceled(self) -> None:
+        assert self._dispatch_and_get_status("CANCELLED") == OrderStatus.CANCELED
+
+    def test_placed_maps_to_confirmed(self) -> None:
+        assert self._dispatch_and_get_status("PLACED") == OrderStatus.CONFIRMED
+
+    def test_pending_maps_to_received(self) -> None:
+        assert self._dispatch_and_get_status("PENDING") == OrderStatus.RECEIVED
+
+    def test_filled_maps_to_filled(self) -> None:
+        assert self._dispatch_and_get_status("FILLED") == OrderStatus.FILLED
+
+    def test_unknown_falls_back_to_received(self) -> None:
+        assert self._dispatch_and_get_status("XYZABC") == OrderStatus.RECEIVED
+
+
+# =========================================================================
+# 5. Module-level convenience functions
+# =========================================================================
+
+
+class TestModuleLevelFunctions:
+    """Test brokers.get_broker() and brokers.list_brokers()."""
+
+    def test_list_brokers_includes_kiwoom(self, mock_kiwoom_service) -> None:
+        import brokers
+
+        # Reset the module registry state so our mock is used
+        brokers._registry_initialised = False
+        brokers._default_registry = BrokerRegistry()
+
+        # Manually register with the mocked adapter class
+        from brokers.kiwoom.adapter import KiwoomBrokerAdapter
+
+        brokers._default_registry.register("kiwoom", KiwoomBrokerAdapter)
+        brokers._registry_initialised = True
+
+        result = brokers.list_brokers()
+        assert "kiwoom" in result
+
+    def test_get_broker_returns_adapter(self, mock_kiwoom_service) -> None:
+        import brokers
+
+        brokers._registry_initialised = False
+        brokers._default_registry = BrokerRegistry()
+
+        from brokers.kiwoom.adapter import KiwoomBrokerAdapter
+
+        brokers._default_registry.register("kiwoom", KiwoomBrokerAdapter)
+        brokers._registry_initialised = True
+
+        adapter = brokers.get_broker("kiwoom")
+        assert isinstance(adapter, BrokerAdapter)
+        assert adapter.broker_name == "kiwoom"
+
+    def test_get_broker_unknown_raises(self, mock_kiwoom_service) -> None:
+        import brokers
+
+        brokers._registry_initialised = False
+        brokers._default_registry = BrokerRegistry()
+        brokers._registry_initialised = True
+
+        with pytest.raises(KeyError, match="not registered"):
+            brokers.get_broker("nonexistent")


### PR DESCRIPTION
## Summary
- Introduce `BrokerAdapter` ABC with 10 abstract methods (connection, orders, kill switch, streaming)
- 6 broker-agnostic Pydantic DTOs: `ConnectionStatus`, `OrderRequest`, `OrderSnapshot`, `AmendRequest`, `KillSwitchResult`, `OrderEvent`
- 5-class exception hierarchy with HTTP status mapping (`BrokerError` → 500, `BrokerValidationError` → 400, etc.)
- Thread-safe `BrokerRegistry` factory with lazy singleton instantiation
- `KiwoomBrokerAdapter` wrapping existing `KiwoomService` via adapter pattern (no existing code modified)
- Model validators: LIMIT price required, AmendRequest requires at least one field
- 45 unit tests covering DTOs, registry, adapter delegation, exception translation, chejan event dispatch

## Architecture

```
brokers/
├── __init__.py       # get_broker(), list_brokers(), auto-registration
├── base.py           # BrokerAdapter ABC + DTOs + BrokerRegistry
├── exceptions.py     # BrokerError hierarchy
└── kiwoom/
    ├── __init__.py
    └── adapter.py    # KiwoomBrokerAdapter → KiwoomService delegation
```

## Test plan
- [x] `pytest tests/test_broker_adapter.py` — 45/45 passed
- [x] `pytest tests/test_kiwoom_p4_order.py tests/test_kiwoom_p8_safety.py` — 15/15 passed (regression)
- [x] No existing files modified (zero regression risk)

Closes #515
Parent epic: #514

🤖 Generated with [Claude Code](https://claude.com/claude-code)