### PR TITLE
feat(brokers): Tiger Brokers adapter — auth, orders, streaming

### DIFF
--- a/brokers/__init__.py
+++ b/brokers/__init__.py
@@ -77,6 +77,15 @@ def _register_default_brokers() -> None:
     except Exception:
         logger.debug("IBKR adapter not available; skipping registration", exc_info=True)
 
+    # -- Tiger adapter ------------------------------------------------------
+    try:
+        from brokers.tiger.adapter import TigerBrokerAdapter
+
+        _default_registry.register("tiger", TigerBrokerAdapter)
+        logger.debug("Registered broker adapter: tiger")
+    except Exception:
+        logger.debug("Tiger adapter not available; skipping registration", exc_info=True)
+
 
 def get_broker(name: str) -> BrokerAdapter:
     """Return an adapter instance from the default registry.

--- a/brokers/tiger/__init__.py
+++ b/brokers/tiger/__init__.py
@@ -1,0 +1,7 @@
+"""Tiger Brokers adapter package."""
+
+from __future__ import annotations
+
+from brokers.tiger.adapter import TigerBrokerAdapter
+
+__all__ = ["TigerBrokerAdapter"]

--- a/brokers/tiger/adapter.py
+++ b/brokers/tiger/adapter.py
@@ -1,0 +1,431 @@
+"""Tiger Brokers adapter.
+
+Implements :class:`brokers.base.BrokerAdapter` for Tiger Brokers via
+the ``tigeropen`` Python SDK (TradeClient for REST, PushClient for streaming).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from datetime import datetime, timezone
+from typing import Any, List, Optional
+
+from brokers.base import (
+    AmendRequest,
+    BrokerAdapter,
+    ConnectionState,
+    ConnectionStatus,
+    KillSwitchResult,
+    OrderCallback,
+    OrderRequest,
+    OrderSide,
+    OrderSnapshot,
+    OrderStatus,
+    OrderType,
+)
+from brokers.exceptions import (
+    BrokerConnectionError,
+    BrokerSafetyError,
+    BrokerValidationError,
+    OrderNotFoundError,
+)
+from brokers.tiger.constants import (
+    DEFAULT_CURRENCY,
+    MARKET_CURRENCY,
+    ORDER_TYPE_TO_TIGER,
+    SUPPORTED_MARKETS,
+    TIGER_STATUS_MAP,
+    TIGER_TO_ORDER_TYPE,
+)
+from brokers.tiger.session import TigerSession
+from brokers.tiger.stream import TigerOrderStream
+
+logger = logging.getLogger(__name__)
+
+# Lazy SDK imports for graceful degradation
+try:
+    from tigeropen.common.util.contract_utils import stock_contract
+    from tigeropen.common.util.order_utils import limit_order, market_order
+    from tigeropen.trade.domain.order import Order
+
+    _SDK_UTILS_AVAILABLE = True
+except ImportError:
+    stock_contract = None  # type: ignore[assignment]
+    limit_order = None  # type: ignore[assignment]
+    market_order = None  # type: ignore[assignment]
+    Order = None  # type: ignore[assignment]
+    _SDK_UTILS_AVAILABLE = False
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class TigerBrokerAdapter(BrokerAdapter):
+    """Adapt Tiger Brokers to the BrokerAdapter interface.
+
+    Environment Variables
+    ---------------------
+    TIGER_ID:
+        Tiger developer ID (required).
+    TIGER_PRIVATE_KEY:
+        Path to RSA private key PEM file (required).
+    TIGER_ACCOUNT:
+        Account number (required).
+    TIGER_LICENSE:
+        License type (default ``"TBNZ"``).
+    """
+
+    def __init__(self) -> None:
+        # Kill switch
+        self._kill_switch_active = False
+        self._kill_lock = threading.RLock()
+
+        # Sub-components
+        try:
+            self._session = TigerSession()
+            account = os.environ.get("TIGER_ACCOUNT", "")
+            self._stream = TigerOrderStream(self._session.config, account)
+            self._available = True
+        except Exception:
+            logger.warning(
+                "Tiger Brokers not available; adapter in UNAVAILABLE state",
+                exc_info=True,
+            )
+            self._session = None  # type: ignore[assignment]
+            self._stream = None  # type: ignore[assignment]
+            self._available = False
+
+    def close(self) -> None:
+        """Release resources."""
+        if self._stream:
+            self._stream.stop()
+
+    # -- identity -----------------------------------------------------------
+
+    @property
+    def broker_name(self) -> str:  # noqa: D401
+        return "tiger"
+
+    @property
+    def supported_markets(self) -> List[str]:
+        return list(SUPPORTED_MARKETS)
+
+    # -- connection ---------------------------------------------------------
+
+    def get_connection_status(self) -> ConnectionStatus:
+        if not self._available:
+            return ConnectionStatus(
+                broker="tiger",
+                status=ConnectionState.UNAVAILABLE,
+                updated_at=_now_iso(),
+            )
+
+        try:
+            self._session.check_connection()
+            state = ConnectionState.CONNECTED
+        except BrokerConnectionError:
+            return ConnectionStatus(
+                broker="tiger",
+                status=ConnectionState.DISCONNECTED,
+                updated_at=_now_iso(),
+            )
+
+        # Discover accounts
+        accounts: list[str] = []
+        is_paper: Optional[bool] = None
+        try:
+            acct_list = self._session.get_accounts()
+            accounts = [a["account_id"] for a in acct_list]
+            is_paper = any(a["is_paper"] for a in acct_list) if acct_list else None
+        except Exception:
+            logger.debug("Tiger account discovery failed", exc_info=True)
+
+        return ConnectionStatus(
+            broker="tiger",
+            status=state,
+            is_paper_trading=is_paper,
+            accounts=accounts,
+            updated_at=_now_iso(),
+        )
+
+    # -- order lifecycle ----------------------------------------------------
+
+    def place_order(self, request: OrderRequest) -> OrderSnapshot:
+        self._ensure_available()
+        self._check_kill_switch()
+
+        if not _SDK_UTILS_AVAILABLE:
+            raise BrokerConnectionError("tigeropen SDK is not installed")
+
+        currency = self._resolve_currency(request.ticker)
+        contract = stock_contract(symbol=request.ticker, currency=currency)
+
+        account = request.account_id or os.environ.get("TIGER_ACCOUNT", "")
+
+        if request.order_type == OrderType.LIMIT:
+            if request.price is None:
+                raise BrokerValidationError("price is required for LIMIT orders")
+            order = limit_order(
+                account=account,
+                contract=contract,
+                action="BUY" if request.side == OrderSide.BUY else "SELL",
+                limit_price=request.price,
+                quantity=request.quantity,
+            )
+        else:
+            order = market_order(
+                account=account,
+                contract=contract,
+                action="BUY" if request.side == OrderSide.BUY else "SELL",
+                quantity=request.quantity,
+            )
+
+        try:
+            self._session.client.place_order(order)
+        except BrokerConnectionError:
+            raise
+        except Exception as exc:
+            error_msg = str(exc).lower()
+            if any(kw in error_msg for kw in ("timeout", "connection", "network", "socket")):
+                raise BrokerConnectionError(
+                    f"Tiger order failed (network): {exc}"
+                ) from exc
+            raise BrokerValidationError(
+                f"Tiger order rejected: {exc}"
+            ) from exc
+
+        order_id = str(getattr(order, "id", "") or getattr(order, "order_id", "") or "PENDING")
+
+        return OrderSnapshot(
+            order_id=order_id,
+            broker="tiger",
+            ticker=request.ticker,
+            side=request.side,
+            quantity=request.quantity,
+            order_type=request.order_type,
+            price=request.price,
+            status=OrderStatus.RECEIVED,
+            created_at=_now_iso(),
+        )
+
+    def get_orders(self) -> List[OrderSnapshot]:
+        self._ensure_available()
+
+        try:
+            orders = self._session.client.get_orders()
+        except Exception as exc:
+            raise BrokerConnectionError(
+                f"Failed to fetch Tiger orders: {exc}"
+            ) from exc
+
+        if not orders:
+            return []
+
+        result: list[OrderSnapshot] = []
+        for order in orders:
+            try:
+                result.append(self._order_to_snapshot(order))
+            except Exception:
+                logger.debug("Skipping unparsable Tiger order: %s", order, exc_info=True)
+
+        return result
+
+    def cancel_order(self, order_id: str) -> None:
+        self._ensure_available()
+
+        try:
+            self._session.client.cancel_order(id=int(order_id))
+        except (ValueError, TypeError) as exc:
+            raise OrderNotFoundError(
+                f"Invalid order ID: {order_id}"
+            ) from exc
+        except Exception as exc:
+            error_msg = str(exc).lower()
+            if "not found" in error_msg or "does not exist" in error_msg:
+                raise OrderNotFoundError(
+                    f"Order {order_id} not found"
+                ) from exc
+            raise BrokerConnectionError(
+                f"Failed to cancel Tiger order: {exc}"
+            ) from exc
+
+    def amend_order(self, order_id: str, request: AmendRequest) -> None:
+        self._ensure_available()
+        self._check_kill_switch()
+
+        try:
+            order_int_id = int(order_id)
+        except (ValueError, TypeError) as exc:
+            raise OrderNotFoundError(
+                f"Invalid order ID: {order_id}"
+            ) from exc
+
+        if not _SDK_UTILS_AVAILABLE:
+            raise BrokerConnectionError("tigeropen SDK is not installed")
+
+        try:
+            order = Order()
+            order.id = order_int_id
+            if request.quantity is not None:
+                order.quantity = request.quantity
+            if request.price is not None:
+                order.limit_price = request.price
+
+            self._session.client.modify_order(order)
+        except (BrokerConnectionError, OrderNotFoundError):
+            raise
+        except Exception as exc:
+            error_msg = str(exc).lower()
+            if "not found" in error_msg or "does not exist" in error_msg:
+                raise OrderNotFoundError(
+                    f"Order {order_id} not found"
+                ) from exc
+            if any(kw in error_msg for kw in ("timeout", "connection", "network", "socket")):
+                raise BrokerConnectionError(
+                    f"Tiger amend failed (network): {exc}"
+                ) from exc
+            raise BrokerValidationError(
+                f"Failed to amend Tiger order: {exc}"
+            ) from exc
+
+    # -- emergency ----------------------------------------------------------
+
+    def activate_kill_switch(self) -> KillSwitchResult:
+        self._ensure_available()
+
+        with self._kill_lock:
+            self._kill_switch_active = True
+
+        cancelled = 0
+        try:
+            orders = self.get_orders()
+            open_statuses = {OrderStatus.RECEIVED, OrderStatus.CONFIRMED, OrderStatus.PARTIAL}
+            for order in orders:
+                if order.status in open_statuses:
+                    try:
+                        self.cancel_order(order.order_id)
+                        cancelled += 1
+                    except Exception:
+                        logger.warning(
+                            "Failed to cancel order %s during kill switch",
+                            order.order_id,
+                            exc_info=True,
+                        )
+        except Exception:
+            logger.warning("Failed to fetch orders during kill switch", exc_info=True)
+
+        logger.warning("Tiger kill switch activated, cancelled %d orders", cancelled)
+        return KillSwitchResult(activated=True, cancelled_orders=cancelled)
+
+    # -- subscriptions ------------------------------------------------------
+
+    def subscribe_orders(self, callback: OrderCallback) -> None:
+        self._ensure_available()
+        self._stream.add_callback(callback)
+        self._stream.start()
+
+    def unsubscribe_orders(self, callback: OrderCallback) -> None:
+        if self._stream:
+            self._stream.remove_callback(callback)
+
+    # -- internal helpers ---------------------------------------------------
+
+    def _ensure_available(self) -> None:
+        if not self._available:
+            raise BrokerConnectionError("Tiger Brokers not available")
+
+    def _check_kill_switch(self) -> None:
+        with self._kill_lock:
+            if self._kill_switch_active:
+                raise BrokerSafetyError(
+                    "Kill switch is active; new orders are blocked"
+                )
+
+    @staticmethod
+    def _resolve_currency(ticker: str) -> str:
+        """Infer currency from ticker suffix convention.
+
+        HK-listed tickers typically end with ``.HK`` (e.g. ``0700.HK``),
+        SG-listed tickers end with ``.SI``.  Everything else defaults to USD.
+        """
+        upper = ticker.upper()
+        if upper.endswith(".HK"):
+            return MARKET_CURRENCY["HK"]
+        if upper.endswith(".SI"):
+            return MARKET_CURRENCY["SG"]
+        return DEFAULT_CURRENCY
+
+    def _order_to_snapshot(self, order: Any) -> OrderSnapshot:
+        """Convert a Tiger SDK Order object to an ``OrderSnapshot``."""
+        order_id = str(
+            getattr(order, "id", "") or getattr(order, "order_id", "") or ""
+        )
+
+        # Ticker
+        contract = getattr(order, "contract", None)
+        ticker = ""
+        if contract:
+            ticker = str(getattr(contract, "symbol", "") or "")
+        if not ticker:
+            ticker = str(getattr(order, "symbol", "") or "")
+
+        # Side
+        raw_action = str(getattr(order, "action", "") or "").upper()
+        if raw_action in ("BUY", "B"):
+            side = OrderSide.BUY
+        elif raw_action in ("SELL", "S"):
+            side = OrderSide.SELL
+        else:
+            logger.warning("Unknown Tiger order action '%s', defaulting to BUY", raw_action)
+            side = OrderSide.BUY
+
+        # Quantities
+        quantity = self._safe_int(getattr(order, "quantity", 0))
+        filled_qty = self._safe_int(getattr(order, "filled", 0))
+        remaining = self._safe_int(getattr(order, "remaining", quantity - filled_qty))
+
+        # Order type
+        raw_order_type = str(getattr(order, "order_type", "MKT") or "MKT")
+        order_type = TIGER_TO_ORDER_TYPE.get(raw_order_type, OrderType.MARKET)
+
+        # Prices
+        limit_price = self._safe_float(getattr(order, "limit_price", None))
+        filled_price = self._safe_float(getattr(order, "avg_fill_price", None))
+
+        # Status
+        raw_status = str(getattr(order, "status", "") or "")
+        status = TIGER_STATUS_MAP.get(raw_status, OrderStatus.RECEIVED)
+
+        return OrderSnapshot(
+            order_id=order_id,
+            broker="tiger",
+            ticker=ticker,
+            side=side,
+            quantity=quantity,
+            filled_quantity=filled_qty,
+            unfilled_quantity=remaining,
+            order_type=order_type,
+            price=limit_price,
+            filled_price=filled_price,
+            status=status,
+            created_at=_now_iso(),
+        )
+
+    @staticmethod
+    def _safe_int(value: Any) -> int:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return 0
+
+    @staticmethod
+    def _safe_float(value: Any) -> Optional[float]:
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None

--- a/brokers/tiger/constants.py
+++ b/brokers/tiger/constants.py
@@ -1,0 +1,67 @@
+"""Tiger Brokers SDK constants and status mappings."""
+
+from __future__ import annotations
+
+from brokers.base import OrderStatus, OrderType
+
+# ---------------------------------------------------------------------------
+# Tiger SDK OrderStatus -> canonical OrderStatus
+# ---------------------------------------------------------------------------
+
+TIGER_STATUS_MAP: dict[str, OrderStatus] = {
+    # Initial / New (-1)
+    "Initial": OrderStatus.RECEIVED,
+    "NEW": OrderStatus.RECEIVED,
+    # PendingNew
+    "PendingNew": OrderStatus.RECEIVED,
+    "PENDING_NEW": OrderStatus.RECEIVED,
+    # Held / Submitted (5)
+    "Held": OrderStatus.CONFIRMED,
+    "HELD": OrderStatus.CONFIRMED,
+    "Submitted": OrderStatus.CONFIRMED,
+    "SUBMITTED": OrderStatus.CONFIRMED,
+    # PendingCancel (3)
+    "PendingCancel": OrderStatus.CONFIRMED,
+    "PENDING_CANCEL": OrderStatus.CONFIRMED,
+    # PartiallyFilled (2)
+    "PartiallyFilled": OrderStatus.PARTIAL,
+    "PARTIALLY_FILLED": OrderStatus.PARTIAL,
+    # Filled (6)
+    "Filled": OrderStatus.FILLED,
+    "FILLED": OrderStatus.FILLED,
+    # Cancelled (4)
+    "Cancelled": OrderStatus.CANCELED,
+    "CANCELLED": OrderStatus.CANCELED,
+    # Rejected (7)
+    "Rejected": OrderStatus.REJECTED,
+    "REJECTED": OrderStatus.REJECTED,
+    # Expired (-2)
+    "Expired": OrderStatus.REJECTED,
+    "EXPIRED": OrderStatus.REJECTED,
+}
+
+# ---------------------------------------------------------------------------
+# Canonical OrderType -> Tiger order type string
+# ---------------------------------------------------------------------------
+
+ORDER_TYPE_TO_TIGER: dict[OrderType, str] = {
+    OrderType.MARKET: "MKT",
+    OrderType.LIMIT: "LMT",
+}
+
+TIGER_TO_ORDER_TYPE: dict[str, OrderType] = {v: k for k, v in ORDER_TYPE_TO_TIGER.items()}
+
+# ---------------------------------------------------------------------------
+# Supported markets and currency mapping
+# ---------------------------------------------------------------------------
+
+SUPPORTED_MARKETS: list[str] = ["US", "HK", "SG"]
+
+MARKET_CURRENCY: dict[str, str] = {
+    "US": "USD",
+    "HK": "HKD",
+    "SG": "SGD",
+}
+
+# Default currency when market cannot be determined from ticker
+DEFAULT_CURRENCY: str = "USD"

--- a/brokers/tiger/session.py
+++ b/brokers/tiger/session.py
@@ -1,0 +1,141 @@
+"""Tiger Brokers session management.
+
+Wraps the ``tigeropen`` SDK's ``TigerOpenClientConfig`` and ``TradeClient``
+to provide connection management and account discovery.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, List, Optional
+
+from brokers.exceptions import BrokerConnectionError
+
+logger = logging.getLogger(__name__)
+
+# Lazy SDK imports to allow graceful degradation
+try:
+    from tigeropen.common.consts import Language
+    from tigeropen.tiger_open_config import TigerOpenClientConfig
+    from tigeropen.trade.trade_client import TradeClient
+
+    _SDK_AVAILABLE = True
+except ImportError:
+    _SDK_AVAILABLE = False
+
+
+class TigerSession:
+    """TigerOpenClientConfig + TradeClient creation and management.
+
+    Environment Variables
+    ---------------------
+    TIGER_ID:
+        Tiger developer ID (required).
+    TIGER_PRIVATE_KEY:
+        Path to RSA private key PEM file (required).
+    TIGER_ACCOUNT:
+        Account number (required).
+    TIGER_LICENSE:
+        License type (default ``"TBNZ"``).
+    """
+
+    def __init__(self) -> None:
+        if not _SDK_AVAILABLE:
+            raise BrokerConnectionError(
+                "tigeropen SDK is not installed; run 'pip install tigeropen'"
+            )
+
+        tiger_id = os.environ.get("TIGER_ID")
+        private_key_path = os.environ.get("TIGER_PRIVATE_KEY")
+        account = os.environ.get("TIGER_ACCOUNT")
+        license_type = os.environ.get("TIGER_LICENSE", "TBNZ")
+
+        if not tiger_id:
+            raise BrokerConnectionError("TIGER_ID environment variable is required")
+        if not private_key_path:
+            raise BrokerConnectionError(
+                "TIGER_PRIVATE_KEY environment variable is required"
+            )
+        if not account:
+            raise BrokerConnectionError(
+                "TIGER_ACCOUNT environment variable is required"
+            )
+
+        self._config = TigerOpenClientConfig(sandbox_debug=False)
+        self._config.tiger_id = tiger_id
+        self._config.account = account
+        self._config.language = Language.en_US
+        self._config.license = license_type
+
+        # Read private key
+        try:
+            with open(private_key_path, "r") as f:
+                self._config.private_key = f.read()
+        except FileNotFoundError:
+            raise BrokerConnectionError(
+                f"Private key file not found: {private_key_path}"
+            )
+
+        self._trade_client = TradeClient(self._config)
+        logger.info("Tiger session initialized for account %s", account)
+
+    @property
+    def client(self) -> Any:
+        """Return the ``TradeClient`` instance."""
+        return self._trade_client
+
+    @property
+    def config(self) -> Any:
+        """Return the ``TigerOpenClientConfig`` (needed by PushClient)."""
+        return self._config
+
+    def check_connection(self) -> bool:
+        """Verify connectivity by fetching managed accounts.
+
+        Returns
+        -------
+        bool
+            ``True`` if the connection is healthy.
+
+        Raises
+        ------
+        BrokerConnectionError
+            If the connection check fails.
+        """
+        try:
+            accounts = self._trade_client.get_managed_accounts()
+            if accounts is not None:
+                return True
+            raise BrokerConnectionError("Tiger connection check returned None")
+        except Exception as exc:
+            if isinstance(exc, BrokerConnectionError):
+                raise
+            raise BrokerConnectionError(
+                f"Tiger connection check failed: {exc}"
+            ) from exc
+
+    def get_accounts(self) -> List[dict[str, Any]]:
+        """Discover available accounts.
+
+        Returns
+        -------
+        list[dict]
+            Each dict has ``account_id`` (str) and ``is_paper`` (bool).
+            Paper accounts are detected by 17-digit numeric IDs.
+        """
+        try:
+            accounts = self._trade_client.get_managed_accounts()
+            if not accounts:
+                return []
+            result = []
+            for acct in accounts:
+                acct_str = str(acct)
+                # Paper accounts typically have 17-digit numeric IDs
+                is_paper = acct_str.isdigit() and len(acct_str) == 17
+                result.append({"account_id": acct_str, "is_paper": is_paper})
+            return result
+        except Exception as exc:
+            raise BrokerConnectionError(
+                f"Failed to discover Tiger accounts: {exc}"
+            ) from exc

--- a/brokers/tiger/stream.py
+++ b/brokers/tiger/stream.py
@@ -1,0 +1,148 @@
+"""Tiger Brokers order streaming via PushClient.
+
+Wraps the ``tigeropen`` SDK's ``PushClient`` to deliver real-time
+``OrderEvent`` DTOs to registered callbacks.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any, Optional
+
+from brokers.base import OrderCallback, OrderEvent, OrderStatus
+from brokers.tiger.constants import TIGER_STATUS_MAP
+
+logger = logging.getLogger(__name__)
+
+
+class TigerOrderStream:
+    """PushClient wrapper for real-time order updates.
+
+    Parameters
+    ----------
+    config:
+        A ``TigerOpenClientConfig`` instance (from ``TigerSession.config``).
+    account:
+        The account to subscribe order updates for.
+    """
+
+    def __init__(self, config: Any, account: str) -> None:
+        self._config = config
+        self._account = account
+
+        self._callbacks: list[OrderCallback] = []
+        self._cb_lock = threading.RLock()
+
+        self._push_client: Any = None
+        self._running = False
+
+    # -- callback management ------------------------------------------------
+
+    def add_callback(self, callback: OrderCallback) -> None:
+        with self._cb_lock:
+            if callback not in self._callbacks:
+                self._callbacks.append(callback)
+
+    def remove_callback(self, callback: OrderCallback) -> None:
+        with self._cb_lock:
+            try:
+                self._callbacks.remove(callback)
+            except ValueError:
+                pass
+
+    # -- lifecycle ----------------------------------------------------------
+
+    def start(self) -> None:
+        """Connect PushClient and subscribe to order updates."""
+        if self._running:
+            return
+
+        try:
+            from tigeropen.push.push_client import PushClient
+
+            self._push_client = PushClient(self._config)
+            self._push_client.order_changed = self._on_order_changed
+            self._push_client.connect(self._config.tiger_id, self._config.private_key)
+            self._push_client.subscribe_order(account=self._account)
+            self._running = True
+            logger.info("Tiger order stream started for account %s", self._account)
+        except Exception:
+            logger.exception("Failed to start Tiger order stream")
+            raise
+
+    def stop(self) -> None:
+        """Unsubscribe and disconnect PushClient."""
+        if self._push_client:
+            try:
+                self._push_client.unsubscribe_order()
+            except Exception:
+                logger.debug("Error unsubscribing Tiger orders", exc_info=True)
+            try:
+                self._push_client.disconnect()
+            except Exception:
+                logger.debug("Error disconnecting Tiger push client", exc_info=True)
+
+        self._push_client = None
+        self._running = False
+        logger.info("Tiger order stream stopped")
+
+    # -- internal -----------------------------------------------------------
+
+    def _on_order_changed(self, frame: Any) -> None:
+        """Convert an OrderStatusData frame to OrderEvent and dispatch."""
+        try:
+            order_id = str(getattr(frame, "id", "") or "")
+            if not order_id:
+                return
+
+            ticker = str(getattr(frame, "symbol", "") or "")
+
+            raw_status = str(getattr(frame, "status", "") or "")
+            status = TIGER_STATUS_MAP.get(raw_status, OrderStatus.RECEIVED)
+
+            filled_qty = self._safe_int(getattr(frame, "filled", 0))
+            total_qty = self._safe_int(getattr(frame, "quantity", 0))
+            unfilled_qty = max(0, total_qty - filled_qty)
+
+            filled_price = self._safe_float(getattr(frame, "avg_fill_price", None))
+
+            event = OrderEvent(
+                broker="tiger",
+                order_id=order_id,
+                ticker=ticker,
+                status=status,
+                filled_quantity=filled_qty,
+                unfilled_quantity=unfilled_qty,
+                filled_price=filled_price,
+            )
+
+            with self._cb_lock:
+                callbacks = list(self._callbacks)
+
+            for cb in callbacks:
+                try:
+                    cb(event)
+                except Exception:
+                    logger.exception(
+                        "Tiger order stream callback raised for order %s", order_id
+                    )
+
+        except Exception:
+            logger.exception("Error processing Tiger order update")
+
+    @staticmethod
+    def _safe_int(value: Any) -> int:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return 0
+
+    @staticmethod
+    def _safe_float(value: Any) -> Optional[float]:
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,5 +36,8 @@ pandas_market_calendars>=4.0.0
 sqlalchemy>=2.0.0
 psycopg2-binary>=2.9.0
 
+# Broker SDKs
+tigeropen>=3.5.0
+
 # AI/LLM
 anthropic>=0.18.0

--- a/tests/test_tiger_adapter.py
+++ b/tests/test_tiger_adapter.py
@@ -1,0 +1,895 @@
+"""Unit tests for the Tiger Brokers adapter.
+
+All SDK interactions are mocked — no live Tiger connection needed.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from brokers.base import (
+    AmendRequest,
+    BrokerAdapter,
+    BrokerRegistry,
+    ConnectionState,
+    KillSwitchResult,
+    OrderEvent,
+    OrderRequest,
+    OrderSide,
+    OrderSnapshot,
+    OrderStatus,
+    OrderType,
+)
+from brokers.exceptions import (
+    BrokerConnectionError,
+    BrokerSafetyError,
+    BrokerValidationError,
+    OrderNotFoundError,
+)
+from brokers.tiger.constants import (
+    ORDER_TYPE_TO_TIGER,
+    SUPPORTED_MARKETS,
+    TIGER_STATUS_MAP,
+    TIGER_TO_ORDER_TYPE,
+)
+
+
+# =========================================================================
+# 1. Constants tests
+# =========================================================================
+
+
+class TestConstants:
+    def test_tiger_status_map_covers_expected_statuses(self) -> None:
+        expected_canonical = {
+            OrderStatus.RECEIVED,
+            OrderStatus.CONFIRMED,
+            OrderStatus.PARTIAL,
+            OrderStatus.FILLED,
+            OrderStatus.CANCELED,
+            OrderStatus.REJECTED,
+        }
+        assert expected_canonical == set(TIGER_STATUS_MAP.values())
+
+    def test_order_type_round_trip(self) -> None:
+        for ot in OrderType:
+            tiger_str = ORDER_TYPE_TO_TIGER[ot]
+            assert TIGER_TO_ORDER_TYPE[tiger_str] == ot
+
+    def test_supported_markets(self) -> None:
+        assert SUPPORTED_MARKETS == ["US", "HK", "SG"]
+
+    def test_all_tiger_statuses_mapped(self) -> None:
+        expected_keys = {
+            "Initial", "NEW",
+            "PendingNew", "PENDING_NEW",
+            "Held", "HELD",
+            "Submitted", "SUBMITTED",
+            "PendingCancel", "PENDING_CANCEL",
+            "PartiallyFilled", "PARTIALLY_FILLED",
+            "Filled", "FILLED",
+            "Cancelled", "CANCELLED",
+            "Rejected", "REJECTED",
+            "Expired", "EXPIRED",
+        }
+        assert set(TIGER_STATUS_MAP.keys()) == expected_keys
+
+    def test_submitted_maps_to_confirmed(self) -> None:
+        assert TIGER_STATUS_MAP["Submitted"] == OrderStatus.CONFIRMED
+        assert TIGER_STATUS_MAP["SUBMITTED"] == OrderStatus.CONFIRMED
+
+
+# =========================================================================
+# 2. TigerSession tests
+# =========================================================================
+
+
+class TestTigerSession:
+    @pytest.fixture()
+    def mock_tiger_sdk(self, monkeypatch):
+        """Mock all tigeropen SDK modules."""
+        # Create mock modules
+        mock_config_cls = MagicMock()
+        mock_config_instance = MagicMock()
+        mock_config_cls.return_value = mock_config_instance
+
+        mock_trade_client_cls = MagicMock()
+        mock_trade_client = MagicMock()
+        mock_trade_client_cls.return_value = mock_trade_client
+
+        mock_language = MagicMock()
+        mock_language.en_US = "en_US"
+
+        # Patch modules into sys.modules
+        tigeropen = types.ModuleType("tigeropen")
+        tigeropen_common = types.ModuleType("tigeropen.common")
+        tigeropen_common_consts = types.ModuleType("tigeropen.common.consts")
+        tigeropen_common_consts.Language = mock_language
+        tigeropen_config = types.ModuleType("tigeropen.tiger_open_config")
+        tigeropen_config.TigerOpenClientConfig = mock_config_cls
+        tigeropen_trade = types.ModuleType("tigeropen.trade")
+        tigeropen_trade_client = types.ModuleType("tigeropen.trade.trade_client")
+        tigeropen_trade_client.TradeClient = mock_trade_client_cls
+
+        modules = {
+            "tigeropen": tigeropen,
+            "tigeropen.common": tigeropen_common,
+            "tigeropen.common.consts": tigeropen_common_consts,
+            "tigeropen.tiger_open_config": tigeropen_config,
+            "tigeropen.trade": tigeropen_trade,
+            "tigeropen.trade.trade_client": tigeropen_trade_client,
+        }
+        for name, mod in modules.items():
+            monkeypatch.setitem(sys.modules, name, mod)
+
+        return {
+            "config_cls": mock_config_cls,
+            "config": mock_config_instance,
+            "trade_client_cls": mock_trade_client_cls,
+            "trade_client": mock_trade_client,
+        }
+
+    def test_missing_tiger_id(self, mock_tiger_sdk, monkeypatch, tmp_path) -> None:
+        key_file = tmp_path / "key.pem"
+        key_file.write_text("-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----")
+        monkeypatch.delenv("TIGER_ID", raising=False)
+        monkeypatch.setenv("TIGER_PRIVATE_KEY", str(key_file))
+        monkeypatch.setenv("TIGER_ACCOUNT", "12345")
+
+        # Force reimport
+        import importlib
+        import brokers.tiger.session as sess_mod
+        importlib.reload(sess_mod)
+
+        with pytest.raises(BrokerConnectionError, match="TIGER_ID"):
+            sess_mod.TigerSession()
+
+    def test_missing_private_key(self, mock_tiger_sdk, monkeypatch) -> None:
+        monkeypatch.setenv("TIGER_ID", "test_id")
+        monkeypatch.delenv("TIGER_PRIVATE_KEY", raising=False)
+        monkeypatch.setenv("TIGER_ACCOUNT", "12345")
+
+        import importlib
+        import brokers.tiger.session as sess_mod
+        importlib.reload(sess_mod)
+
+        with pytest.raises(BrokerConnectionError, match="TIGER_PRIVATE_KEY"):
+            sess_mod.TigerSession()
+
+    def test_missing_account(self, mock_tiger_sdk, monkeypatch, tmp_path) -> None:
+        key_file = tmp_path / "key.pem"
+        key_file.write_text("-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----")
+        monkeypatch.setenv("TIGER_ID", "test_id")
+        monkeypatch.setenv("TIGER_PRIVATE_KEY", str(key_file))
+        monkeypatch.delenv("TIGER_ACCOUNT", raising=False)
+
+        import importlib
+        import brokers.tiger.session as sess_mod
+        importlib.reload(sess_mod)
+
+        with pytest.raises(BrokerConnectionError, match="TIGER_ACCOUNT"):
+            sess_mod.TigerSession()
+
+    def test_successful_init(self, mock_tiger_sdk, monkeypatch, tmp_path) -> None:
+        key_file = tmp_path / "key.pem"
+        key_file.write_text("-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----")
+        monkeypatch.setenv("TIGER_ID", "test_id")
+        monkeypatch.setenv("TIGER_PRIVATE_KEY", str(key_file))
+        monkeypatch.setenv("TIGER_ACCOUNT", "12345")
+
+        import importlib
+        import brokers.tiger.session as sess_mod
+        importlib.reload(sess_mod)
+
+        session = sess_mod.TigerSession()
+        assert session.client is not None
+        assert session.config is not None
+
+    def test_check_connection_success(self, mock_tiger_sdk, monkeypatch, tmp_path) -> None:
+        key_file = tmp_path / "key.pem"
+        key_file.write_text("-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----")
+        monkeypatch.setenv("TIGER_ID", "test_id")
+        monkeypatch.setenv("TIGER_PRIVATE_KEY", str(key_file))
+        monkeypatch.setenv("TIGER_ACCOUNT", "12345")
+
+        mock_tiger_sdk["trade_client"].get_managed_accounts.return_value = ["12345"]
+
+        import importlib
+        import brokers.tiger.session as sess_mod
+        importlib.reload(sess_mod)
+
+        session = sess_mod.TigerSession()
+        assert session.check_connection() is True
+
+    def test_check_connection_failure(self, mock_tiger_sdk, monkeypatch, tmp_path) -> None:
+        key_file = tmp_path / "key.pem"
+        key_file.write_text("-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----")
+        monkeypatch.setenv("TIGER_ID", "test_id")
+        monkeypatch.setenv("TIGER_PRIVATE_KEY", str(key_file))
+        monkeypatch.setenv("TIGER_ACCOUNT", "12345")
+
+        mock_tiger_sdk["trade_client"].get_managed_accounts.side_effect = Exception("timeout")
+
+        import importlib
+        import brokers.tiger.session as sess_mod
+        importlib.reload(sess_mod)
+
+        session = sess_mod.TigerSession()
+        with pytest.raises(BrokerConnectionError, match="connection check failed"):
+            session.check_connection()
+
+    def test_get_accounts(self, mock_tiger_sdk, monkeypatch, tmp_path) -> None:
+        key_file = tmp_path / "key.pem"
+        key_file.write_text("-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----")
+        monkeypatch.setenv("TIGER_ID", "test_id")
+        monkeypatch.setenv("TIGER_PRIVATE_KEY", str(key_file))
+        monkeypatch.setenv("TIGER_ACCOUNT", "12345")
+
+        mock_tiger_sdk["trade_client"].get_managed_accounts.return_value = [
+            "12345",
+            "12345678901234567",  # 17-digit = paper
+        ]
+
+        import importlib
+        import brokers.tiger.session as sess_mod
+        importlib.reload(sess_mod)
+
+        session = sess_mod.TigerSession()
+        accounts = session.get_accounts()
+
+        assert len(accounts) == 2
+        assert accounts[0] == {"account_id": "12345", "is_paper": False}
+        assert accounts[1] == {"account_id": "12345678901234567", "is_paper": True}
+
+
+# =========================================================================
+# 3. TigerOrderStream tests
+# =========================================================================
+
+
+class TestTigerOrderStream:
+    def _make_stream(self):
+        from brokers.tiger.stream import TigerOrderStream
+
+        config = MagicMock()
+        return TigerOrderStream(config, "12345")
+
+    def test_add_remove_callback(self) -> None:
+        stream = self._make_stream()
+        cb = MagicMock()
+
+        stream.add_callback(cb)
+        assert cb in stream._callbacks
+
+        stream.remove_callback(cb)
+        assert cb not in stream._callbacks
+
+    def test_no_duplicate_callbacks(self) -> None:
+        stream = self._make_stream()
+        cb = MagicMock()
+
+        stream.add_callback(cb)
+        stream.add_callback(cb)
+        assert len(stream._callbacks) == 1
+
+    def test_remove_nonexistent_callback(self) -> None:
+        stream = self._make_stream()
+        stream.remove_callback(MagicMock())  # Should not raise
+
+    def test_on_order_changed_dispatches_event(self) -> None:
+        stream = self._make_stream()
+        received: list[OrderEvent] = []
+        stream.add_callback(lambda ev: received.append(ev))
+
+        frame = MagicMock()
+        frame.id = 12345
+        frame.symbol = "AAPL"
+        frame.status = "Filled"
+        frame.filled = 100
+        frame.quantity = 100
+        frame.avg_fill_price = 150.50
+
+        stream._on_order_changed(frame)
+
+        assert len(received) == 1
+        event = received[0]
+        assert event.broker == "tiger"
+        assert event.order_id == "12345"
+        assert event.ticker == "AAPL"
+        assert event.status == OrderStatus.FILLED
+        assert event.filled_quantity == 100
+        assert event.unfilled_quantity == 0
+        assert event.filled_price == 150.50
+
+    def test_on_order_changed_skips_empty_id(self) -> None:
+        stream = self._make_stream()
+        received: list[OrderEvent] = []
+        stream.add_callback(lambda ev: received.append(ev))
+
+        frame = MagicMock()
+        frame.id = ""
+        stream._on_order_changed(frame)
+
+        assert len(received) == 0
+
+    def test_on_order_changed_unknown_status_defaults_received(self) -> None:
+        stream = self._make_stream()
+        received: list[OrderEvent] = []
+        stream.add_callback(lambda ev: received.append(ev))
+
+        frame = MagicMock()
+        frame.id = 99
+        frame.symbol = "TSLA"
+        frame.status = "UnknownStatus"
+        frame.filled = 0
+        frame.quantity = 50
+        frame.avg_fill_price = None
+
+        stream._on_order_changed(frame)
+
+        assert len(received) == 1
+        assert received[0].status == OrderStatus.RECEIVED
+
+    def test_callback_exception_does_not_propagate(self) -> None:
+        stream = self._make_stream()
+
+        def bad_callback(ev: OrderEvent) -> None:
+            raise ValueError("callback error")
+
+        stream.add_callback(bad_callback)
+
+        frame = MagicMock()
+        frame.id = 1
+        frame.symbol = "X"
+        frame.status = "Filled"
+        frame.filled = 10
+        frame.quantity = 10
+        frame.avg_fill_price = 100.0
+
+        # Should not raise
+        stream._on_order_changed(frame)
+
+    def test_stop_when_not_started(self) -> None:
+        stream = self._make_stream()
+        stream.stop()  # Should not raise
+
+
+# =========================================================================
+# 4. TigerBrokerAdapter tests
+# =========================================================================
+
+
+@pytest.fixture()
+def mock_tiger_components(monkeypatch):
+    """Patch all Tiger sub-components for adapter tests."""
+    mock_session = MagicMock()
+    mock_stream = MagicMock()
+
+    monkeypatch.setenv("TIGER_ID", "test_id")
+    monkeypatch.setenv("TIGER_PRIVATE_KEY", "/tmp/fake_key.pem")
+    monkeypatch.setenv("TIGER_ACCOUNT", "12345")
+
+    with (
+        patch("brokers.tiger.adapter.TigerSession") as mock_session_cls,
+        patch("brokers.tiger.adapter.TigerOrderStream") as mock_stream_cls,
+    ):
+        mock_session_cls.return_value = mock_session
+        mock_stream_cls.return_value = mock_stream
+        mock_session.config = MagicMock()
+
+        yield {
+            "session": mock_session,
+            "stream": mock_stream,
+        }
+
+
+def _make_tiger_adapter():
+    from brokers.tiger.adapter import TigerBrokerAdapter
+
+    return TigerBrokerAdapter()
+
+
+# -- Identity --------------------------------------------------------------
+
+
+class TestTigerIdentity:
+    def test_broker_name(self, mock_tiger_components) -> None:
+        adapter = _make_tiger_adapter()
+        assert adapter.broker_name == "tiger"
+
+    def test_supported_markets(self, mock_tiger_components) -> None:
+        adapter = _make_tiger_adapter()
+        assert adapter.supported_markets == ["US", "HK", "SG"]
+
+
+# -- Connection status -----------------------------------------------------
+
+
+class TestTigerConnectionStatus:
+    def test_connected(self, mock_tiger_components) -> None:
+        mock_tiger_components["session"].check_connection.return_value = True
+        mock_tiger_components["session"].get_accounts.return_value = [
+            {"account_id": "12345", "is_paper": False}
+        ]
+
+        adapter = _make_tiger_adapter()
+        result = adapter.get_connection_status()
+
+        assert result.broker == "tiger"
+        assert result.status == ConnectionState.CONNECTED
+        assert result.accounts == ["12345"]
+        assert result.is_paper_trading is False
+
+    def test_disconnected(self, mock_tiger_components) -> None:
+        mock_tiger_components["session"].check_connection.side_effect = (
+            BrokerConnectionError("timeout")
+        )
+
+        adapter = _make_tiger_adapter()
+        result = adapter.get_connection_status()
+        assert result.status == ConnectionState.DISCONNECTED
+
+    def test_unavailable_when_init_fails(self) -> None:
+        with patch(
+            "brokers.tiger.adapter.TigerSession",
+            side_effect=Exception("no SDK"),
+        ):
+            adapter = _make_tiger_adapter()
+            assert adapter._available is False
+
+            status = adapter.get_connection_status()
+            assert status.status == ConnectionState.UNAVAILABLE
+
+    def test_paper_trading_detected(self, mock_tiger_components) -> None:
+        mock_tiger_components["session"].check_connection.return_value = True
+        mock_tiger_components["session"].get_accounts.return_value = [
+            {"account_id": "12345678901234567", "is_paper": True}
+        ]
+
+        adapter = _make_tiger_adapter()
+        result = adapter.get_connection_status()
+        assert result.is_paper_trading is True
+
+
+# -- place_order -----------------------------------------------------------
+
+
+class TestTigerPlaceOrder:
+    def test_place_market_order(self, mock_tiger_components) -> None:
+        mock_order = MagicMock()
+        mock_order.id = 1001
+
+        with (
+            patch("brokers.tiger.adapter._SDK_UTILS_AVAILABLE", True),
+            patch(
+                "brokers.tiger.adapter.stock_contract", return_value=MagicMock()
+            ),
+            patch(
+                "brokers.tiger.adapter.market_order", return_value=mock_order
+            ),
+        ):
+            adapter = _make_tiger_adapter()
+            request = OrderRequest(
+                ticker="AAPL",
+                side=OrderSide.BUY,
+                quantity=100,
+                order_type=OrderType.MARKET,
+            )
+            result = adapter.place_order(request)
+
+            assert isinstance(result, OrderSnapshot)
+            assert result.broker == "tiger"
+            assert result.order_id == "1001"
+            assert result.status == OrderStatus.RECEIVED
+            assert result.ticker == "AAPL"
+            assert result.quantity == 100
+
+    def test_place_limit_order(self, mock_tiger_components) -> None:
+        mock_order = MagicMock()
+        mock_order.id = 1002
+
+        with (
+            patch("brokers.tiger.adapter._SDK_UTILS_AVAILABLE", True),
+            patch(
+                "brokers.tiger.adapter.stock_contract", return_value=MagicMock()
+            ),
+            patch(
+                "brokers.tiger.adapter.limit_order", return_value=mock_order
+            ),
+        ):
+            adapter = _make_tiger_adapter()
+            request = OrderRequest(
+                ticker="AAPL",
+                side=OrderSide.SELL,
+                quantity=50,
+                order_type=OrderType.LIMIT,
+                price=150.0,
+            )
+            result = adapter.place_order(request)
+
+            assert result.order_id == "1002"
+            assert result.price == 150.0
+            assert result.side == OrderSide.SELL
+
+    def test_place_order_kill_switch_active(self, mock_tiger_components) -> None:
+        adapter = _make_tiger_adapter()
+        adapter._kill_switch_active = True
+
+        request = OrderRequest(
+            ticker="AAPL",
+            side=OrderSide.BUY,
+            quantity=100,
+            order_type=OrderType.MARKET,
+        )
+        with pytest.raises(BrokerSafetyError, match="Kill switch"):
+            adapter.place_order(request)
+
+    def test_place_order_failure(self, mock_tiger_components) -> None:
+        mock_order = MagicMock()
+        mock_order.id = None
+
+        mock_tiger_components["session"].client.place_order.side_effect = Exception(
+            "Insufficient funds"
+        )
+
+        with (
+            patch("brokers.tiger.adapter._SDK_UTILS_AVAILABLE", True),
+            patch(
+                "brokers.tiger.adapter.stock_contract", return_value=MagicMock()
+            ),
+            patch(
+                "brokers.tiger.adapter.market_order", return_value=mock_order
+            ),
+        ):
+            adapter = _make_tiger_adapter()
+            request = OrderRequest(
+                ticker="AAPL",
+                side=OrderSide.BUY,
+                quantity=100,
+                order_type=OrderType.MARKET,
+            )
+            with pytest.raises(BrokerValidationError, match="Insufficient funds"):
+                adapter.place_order(request)
+
+
+# -- get_orders ------------------------------------------------------------
+
+
+class TestTigerGetOrders:
+    def test_get_orders(self, mock_tiger_components) -> None:
+        order1 = MagicMock()
+        order1.id = 1001
+        order1.contract = MagicMock()
+        order1.contract.symbol = "AAPL"
+        order1.action = "BUY"
+        order1.quantity = 100
+        order1.filled = 100
+        order1.remaining = 0
+        order1.order_type = "MKT"
+        order1.limit_price = None
+        order1.avg_fill_price = 150.25
+        order1.status = "Filled"
+
+        order2 = MagicMock()
+        order2.id = 1002
+        order2.contract = MagicMock()
+        order2.contract.symbol = "TSLA"
+        order2.action = "SELL"
+        order2.quantity = 50
+        order2.filled = 0
+        order2.remaining = 50
+        order2.order_type = "LMT"
+        order2.limit_price = 300.0
+        order2.avg_fill_price = None
+        order2.status = "Held"
+
+        mock_tiger_components["session"].client.get_orders.return_value = [order1, order2]
+
+        adapter = _make_tiger_adapter()
+        orders = adapter.get_orders()
+
+        assert len(orders) == 2
+        assert orders[0].order_id == "1001"
+        assert orders[0].status == OrderStatus.FILLED
+        assert orders[0].filled_quantity == 100
+        assert orders[0].filled_price == 150.25
+        assert orders[1].order_id == "1002"
+        assert orders[1].status == OrderStatus.CONFIRMED
+        assert orders[1].side == OrderSide.SELL
+
+    def test_get_orders_empty(self, mock_tiger_components) -> None:
+        mock_tiger_components["session"].client.get_orders.return_value = []
+        adapter = _make_tiger_adapter()
+        assert adapter.get_orders() == []
+
+    def test_get_orders_none(self, mock_tiger_components) -> None:
+        mock_tiger_components["session"].client.get_orders.return_value = None
+        adapter = _make_tiger_adapter()
+        assert adapter.get_orders() == []
+
+
+# -- cancel_order ----------------------------------------------------------
+
+
+class TestTigerCancelOrder:
+    def test_cancel_order_success(self, mock_tiger_components) -> None:
+        adapter = _make_tiger_adapter()
+        adapter.cancel_order("1001")  # Should not raise
+        mock_tiger_components["session"].client.cancel_order.assert_called_once_with(
+            id=1001
+        )
+
+    def test_cancel_order_not_found(self, mock_tiger_components) -> None:
+        mock_tiger_components["session"].client.cancel_order.side_effect = Exception(
+            "Order not found"
+        )
+
+        adapter = _make_tiger_adapter()
+        with pytest.raises(OrderNotFoundError, match="not found"):
+            adapter.cancel_order("9999")
+
+    def test_cancel_order_invalid_id(self, mock_tiger_components) -> None:
+        adapter = _make_tiger_adapter()
+        with pytest.raises(OrderNotFoundError, match="Invalid order ID"):
+            adapter.cancel_order("not-a-number")
+
+
+# -- amend_order -----------------------------------------------------------
+
+
+class TestTigerAmendOrder:
+    def test_amend_order_quantity(self, mock_tiger_components) -> None:
+        with (
+            patch("brokers.tiger.adapter._SDK_UTILS_AVAILABLE", True),
+            patch("brokers.tiger.adapter.Order") as mock_order_cls,
+        ):
+            mock_order = MagicMock()
+            mock_order_cls.return_value = mock_order
+
+            adapter = _make_tiger_adapter()
+            adapter.amend_order("1001", AmendRequest(quantity=200))
+
+            assert mock_order.id == 1001
+            assert mock_order.quantity == 200
+            mock_tiger_components["session"].client.modify_order.assert_called_once_with(
+                mock_order
+            )
+
+    def test_amend_order_price(self, mock_tiger_components) -> None:
+        with (
+            patch("brokers.tiger.adapter._SDK_UTILS_AVAILABLE", True),
+            patch("brokers.tiger.adapter.Order") as mock_order_cls,
+        ):
+            mock_order = MagicMock()
+            mock_order_cls.return_value = mock_order
+
+            adapter = _make_tiger_adapter()
+            adapter.amend_order("1001", AmendRequest(price=155.0))
+
+            assert mock_order.limit_price == 155.0
+
+    def test_amend_order_kill_switch_active(self, mock_tiger_components) -> None:
+        adapter = _make_tiger_adapter()
+        adapter._kill_switch_active = True
+
+        with pytest.raises(BrokerSafetyError, match="Kill switch"):
+            adapter.amend_order("1001", AmendRequest(quantity=200))
+
+    def test_amend_order_invalid_id(self, mock_tiger_components) -> None:
+        adapter = _make_tiger_adapter()
+        with pytest.raises(OrderNotFoundError, match="Invalid order ID"):
+            adapter.amend_order("invalid", AmendRequest(quantity=200))
+
+
+# -- kill switch -----------------------------------------------------------
+
+
+class TestTigerKillSwitch:
+    def test_kill_switch_cancels_open_orders(self, mock_tiger_components) -> None:
+        order_open = MagicMock()
+        order_open.id = 1001
+        order_open.contract = MagicMock()
+        order_open.contract.symbol = "AAPL"
+        order_open.action = "BUY"
+        order_open.quantity = 100
+        order_open.filled = 0
+        order_open.remaining = 100
+        order_open.order_type = "MKT"
+        order_open.limit_price = None
+        order_open.avg_fill_price = None
+        order_open.status = "Held"  # CONFIRMED -> should be cancelled
+
+        order_filled = MagicMock()
+        order_filled.id = 1002
+        order_filled.contract = MagicMock()
+        order_filled.contract.symbol = "TSLA"
+        order_filled.action = "SELL"
+        order_filled.quantity = 50
+        order_filled.filled = 50
+        order_filled.remaining = 0
+        order_filled.order_type = "LMT"
+        order_filled.limit_price = 300.0
+        order_filled.avg_fill_price = 300.0
+        order_filled.status = "Filled"  # terminal -> should NOT be cancelled
+
+        mock_tiger_components["session"].client.get_orders.return_value = [
+            order_open, order_filled
+        ]
+
+        adapter = _make_tiger_adapter()
+        result = adapter.activate_kill_switch()
+
+        assert isinstance(result, KillSwitchResult)
+        assert result.activated is True
+        assert result.cancelled_orders == 1
+        assert adapter._kill_switch_active is True
+
+    def test_kill_switch_cancels_partial_orders(self, mock_tiger_components) -> None:
+        order_partial = MagicMock()
+        order_partial.id = 1003
+        order_partial.contract = MagicMock()
+        order_partial.contract.symbol = "GOOG"
+        order_partial.action = "BUY"
+        order_partial.quantity = 100
+        order_partial.filled = 30
+        order_partial.remaining = 70
+        order_partial.order_type = "LMT"
+        order_partial.limit_price = 180.0
+        order_partial.avg_fill_price = 179.5
+        order_partial.status = "PartiallyFilled"  # PARTIAL -> should be cancelled
+
+        mock_tiger_components["session"].client.get_orders.return_value = [order_partial]
+
+        adapter = _make_tiger_adapter()
+        result = adapter.activate_kill_switch()
+
+        assert result.cancelled_orders == 1
+
+    def test_kill_switch_blocks_new_orders(self, mock_tiger_components) -> None:
+        mock_tiger_components["session"].client.get_orders.return_value = []
+
+        adapter = _make_tiger_adapter()
+        adapter.activate_kill_switch()
+
+        request = OrderRequest(
+            ticker="AAPL",
+            side=OrderSide.BUY,
+            quantity=100,
+            order_type=OrderType.MARKET,
+        )
+        with pytest.raises(BrokerSafetyError, match="Kill switch"):
+            adapter.place_order(request)
+
+
+# -- subscriptions ---------------------------------------------------------
+
+
+class TestTigerSubscription:
+    def test_subscribe_delegates_to_stream(self, mock_tiger_components) -> None:
+        adapter = _make_tiger_adapter()
+        cb = MagicMock()
+        adapter.subscribe_orders(cb)
+
+        mock_tiger_components["stream"].add_callback.assert_called_once_with(cb)
+        mock_tiger_components["stream"].start.assert_called_once()
+
+    def test_unsubscribe_delegates_to_stream(self, mock_tiger_components) -> None:
+        adapter = _make_tiger_adapter()
+        cb = MagicMock()
+        adapter.unsubscribe_orders(cb)
+
+        mock_tiger_components["stream"].remove_callback.assert_called_once_with(cb)
+
+
+# -- unavailable state -----------------------------------------------------
+
+
+class TestTigerUnavailable:
+    def test_unavailable_when_init_fails(self) -> None:
+        with patch(
+            "brokers.tiger.adapter.TigerSession", side_effect=Exception("no SDK")
+        ):
+            adapter = _make_tiger_adapter()
+            assert adapter._available is False
+
+            status = adapter.get_connection_status()
+            assert status.status == ConnectionState.UNAVAILABLE
+
+            with pytest.raises(BrokerConnectionError, match="not available"):
+                adapter.place_order(
+                    OrderRequest(
+                        ticker="AAPL",
+                        side=OrderSide.BUY,
+                        quantity=1,
+                        order_type=OrderType.MARKET,
+                    )
+                )
+
+    def test_unavailable_get_orders(self) -> None:
+        with patch(
+            "brokers.tiger.adapter.TigerSession", side_effect=Exception("no SDK")
+        ):
+            adapter = _make_tiger_adapter()
+            with pytest.raises(BrokerConnectionError, match="not available"):
+                adapter.get_orders()
+
+    def test_unavailable_cancel_order(self) -> None:
+        with patch(
+            "brokers.tiger.adapter.TigerSession", side_effect=Exception("no SDK")
+        ):
+            adapter = _make_tiger_adapter()
+            with pytest.raises(BrokerConnectionError, match="not available"):
+                adapter.cancel_order("1001")
+
+
+# =========================================================================
+# 5. Registry integration
+# =========================================================================
+
+
+class TestTigerRegistration:
+    def test_tiger_registered_in_default_registry(
+        self, mock_tiger_components
+    ) -> None:
+        import brokers
+
+        brokers._registry_initialised = False
+        brokers._default_registry = BrokerRegistry()
+
+        from brokers.tiger.adapter import TigerBrokerAdapter
+
+        brokers._default_registry.register("tiger", TigerBrokerAdapter)
+        brokers._registry_initialised = True
+
+        assert "tiger" in brokers.list_brokers()
+
+    def test_currency_resolution(self, mock_tiger_components) -> None:
+        from brokers.tiger.adapter import TigerBrokerAdapter
+
+        assert TigerBrokerAdapter._resolve_currency("AAPL") == "USD"
+        assert TigerBrokerAdapter._resolve_currency("0700.HK") == "HKD"
+        assert TigerBrokerAdapter._resolve_currency("D05.SI") == "SGD"
+        assert TigerBrokerAdapter._resolve_currency("tsla") == "USD"
+        assert TigerBrokerAdapter._resolve_currency("9988.hk") == "HKD"
+
+    def test_place_order_network_error(self, mock_tiger_components) -> None:
+        mock_order = MagicMock()
+        mock_order.id = None
+
+        mock_tiger_components["session"].client.place_order.side_effect = Exception(
+            "connection timeout"
+        )
+
+        with (
+            patch("brokers.tiger.adapter._SDK_UTILS_AVAILABLE", True),
+            patch("brokers.tiger.adapter.stock_contract", return_value=MagicMock()),
+            patch("brokers.tiger.adapter.market_order", return_value=mock_order),
+        ):
+            adapter = _make_tiger_adapter()
+            request = OrderRequest(
+                ticker="AAPL",
+                side=OrderSide.BUY,
+                quantity=100,
+                order_type=OrderType.MARKET,
+            )
+            with pytest.raises(BrokerConnectionError, match="network"):
+                adapter.place_order(request)
+
+    def test_get_tiger_broker(self, mock_tiger_components) -> None:
+        import brokers
+
+        brokers._registry_initialised = False
+        brokers._default_registry = BrokerRegistry()
+
+        from brokers.tiger.adapter import TigerBrokerAdapter
+
+        brokers._default_registry.register("tiger", TigerBrokerAdapter)
+        brokers._registry_initialised = True
+
+        adapter = brokers.get_broker("tiger")
+        assert isinstance(adapter, BrokerAdapter)
+        assert adapter.broker_name == "tiger"


### PR DESCRIPTION
## Summary

- Implement `TigerBrokerAdapter` following the same `BrokerAdapter` ABC pattern as IBKR (#527)
- Wrap Tiger's `tigeropen` SDK (`TradeClient` for REST, `PushClient` for WebSocket streaming)
- Support US/HK/SG markets with automatic currency resolution (USD/HKD/SGD)

## New Files

| File | Description |
|------|-------------|
| `brokers/tiger/constants.py` | Tiger OrderStatus → canonical mapping, market/currency constants |
| `brokers/tiger/session.py` | `TigerSession` — SDK config wrapper with env var validation |
| `brokers/tiger/stream.py` | `TigerOrderStream` — PushClient wrapper for real-time order events |
| `brokers/tiger/adapter.py` | `TigerBrokerAdapter` — main implementation (orders, kill switch, streaming) |
| `brokers/tiger/__init__.py` | Re-export |
| `tests/test_tiger_adapter.py` | 52 unit tests (fully mocked, no live connection) |

## Modified Files

| File | Change |
|------|--------|
| `brokers/__init__.py` | Register Tiger adapter in default registry |
| `requirements.txt` | Add `tigeropen>=3.5.0` dependency |

## Features

- **Auth**: `TIGER_ID`, `TIGER_PRIVATE_KEY`, `TIGER_ACCOUNT` env vars
- **Orders**: Place (market/limit), cancel, amend, list with status mapping
- **Kill switch**: Cancels RECEIVED, CONFIRMED, and PARTIAL orders
- **Streaming**: Real-time order updates via PushClient WebSocket
- **Multi-market**: Ticker suffix convention (`.HK` → HKD, `.SI` → SGD, default → USD)
- **Graceful degradation**: Works without `tigeropen` installed (UNAVAILABLE state)
- **Exception classification**: Network errors → `BrokerConnectionError`, validation → `BrokerValidationError`

## Test plan

- [x] 52 Tiger adapter tests pass (`pytest tests/test_tiger_adapter.py -v`)
- [x] 113 existing broker tests pass (no regression)
- [x] Registry verification: `list_brokers()` returns `['ibkr', 'kiwoom', 'tiger']`
- [x] Codex code review passed (7 issues found and fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*Reviewed by: Claude Code*