### PR TITLE
feat(brokers): unified broker router — API + frontend

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -12,7 +12,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from api.config import get_settings
 from api.database import init_db
-from api.routers import analysis_router, exchange_rates_router, health_router, portfolio_router, screening_router
+from api.routers import analysis_router, broker_router, exchange_rates_router, health_router, portfolio_router, screening_router
 from api.routers.backtest import router as backtest_router
 from api.routers.market import router as market_router
 from api.routers.search import router as search_router
@@ -94,6 +94,7 @@ def create_app() -> FastAPI:
     app.include_router(backtest_router)
     app.include_router(agent_task_router)
     app.include_router(kiwoom_router)
+    app.include_router(broker_router)
 
     # Future routers (추후 추가될 라우터)
     # app.include_router(news_router, prefix="/api/v1")

--- a/api/routers/__init__.py
+++ b/api/routers/__init__.py
@@ -5,6 +5,7 @@ Export all routers for registration in the main application.
 """
 
 from api.routers.analysis import router as analysis_router
+from api.routers.broker import router as broker_router
 from api.routers.exchange_rates import router as exchange_rates_router
 from api.routers.health import router as health_router
 from api.routers.kiwoom import router as kiwoom_router
@@ -18,6 +19,7 @@ from api.routers.strategy import router as strategy_router
 __all__ = [
     "analysis_router",
     "backtest_router",
+    "broker_router",
     "exchange_rates_router",
     "health_router",
     "kiwoom_router",

--- a/api/routers/broker.py
+++ b/api/routers/broker.py
@@ -1,0 +1,236 @@
+"""
+Unified broker router.
+
+Provides broker-agnostic endpoints for order management, connection
+status, and kill-switch activation.  Works with any adapter registered
+in the :class:`BrokerRegistry` (kiwoom, ibkr, tiger, ...).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, HTTPException
+
+from brokers.base import AmendRequest, OrderRequest
+from brokers.exceptions import (
+    BrokerConnectionError,
+    BrokerSafetyError,
+    BrokerValidationError,
+    OrderNotFoundError,
+)
+
+from api.schemas.broker import (
+    BrokerAmendRequest,
+    BrokerConnectionResponse,
+    BrokerKillSwitchResponse,
+    BrokerListResponse,
+    BrokerOrderRequest,
+    BrokerOrderResponse,
+)
+from api.services.broker_service import BrokerService
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/api/brokers",
+    tags=["Unified Broker"],
+    responses={
+        404: {"description": "Broker or order not found"},
+        503: {"description": "Broker connection unavailable"},
+    },
+)
+
+_service = BrokerService()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_adapter_or_404(broker: str):
+    """Validate that *broker* is registered; raise 404 otherwise."""
+    try:
+        return _service.get_adapter(broker)
+    except KeyError:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Broker '{broker}' is not registered",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Broker list
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/",
+    response_model=BrokerListResponse,
+    summary="List Brokers",
+    description="Return all registered broker names.",
+)
+def list_brokers() -> BrokerListResponse:
+    return BrokerListResponse(brokers=_service.list_brokers())
+
+
+# ---------------------------------------------------------------------------
+# Connection status
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/{broker}/status",
+    response_model=BrokerConnectionResponse,
+    summary="Get Connection Status",
+    description="Return the connection status for a specific broker.",
+)
+def get_connection_status(broker: str) -> BrokerConnectionResponse:
+    _get_adapter_or_404(broker)
+    try:
+        status = _service.get_connection_status(broker)
+        return BrokerConnectionResponse(
+            broker=status.broker,
+            status=status.status,
+            is_paper_trading=status.is_paper_trading,
+            accounts=status.accounts,
+            updated_at=status.updated_at,
+        )
+    except BrokerConnectionError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.exception("Failed to get connection status for %s", broker)
+        raise HTTPException(status_code=500, detail="Internal server error") from exc
+
+
+# ---------------------------------------------------------------------------
+# Orders
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/{broker}/orders",
+    response_model=BrokerOrderResponse,
+    summary="Place Order",
+    description="Submit a new order through the specified broker.",
+    status_code=201,
+)
+def place_order(
+    broker: str, request: BrokerOrderRequest
+) -> BrokerOrderResponse:
+    _get_adapter_or_404(broker)
+    try:
+        order_request = OrderRequest(
+            ticker=request.ticker,
+            side=request.side,
+            quantity=request.quantity,
+            order_type=request.order_type,
+            price=request.price,
+            account_id=request.account_id,
+        )
+        snapshot = _service.place_order(broker, order_request)
+        return BrokerOrderResponse(**snapshot.model_dump())
+    except (BrokerValidationError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except BrokerConnectionError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except BrokerSafetyError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.exception("Failed to place order on %s", broker)
+        raise HTTPException(status_code=500, detail="Internal server error") from exc
+
+
+@router.get(
+    "/{broker}/orders",
+    response_model=list[BrokerOrderResponse],
+    summary="List Orders",
+    description="Retrieve all tracked orders for the specified broker.",
+)
+def get_orders(broker: str) -> list[BrokerOrderResponse]:
+    _get_adapter_or_404(broker)
+    try:
+        snapshots = _service.get_orders(broker)
+        return [BrokerOrderResponse(**s.model_dump()) for s in snapshots]
+    except BrokerConnectionError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.exception("Failed to get orders for %s", broker)
+        raise HTTPException(status_code=500, detail="Internal server error") from exc
+
+
+@router.delete(
+    "/{broker}/orders/{order_id}",
+    status_code=204,
+    summary="Cancel Order",
+    description="Cancel an open order by its ID.",
+)
+def cancel_order(broker: str, order_id: str) -> None:
+    _get_adapter_or_404(broker)
+    try:
+        _service.cancel_order(broker, order_id)
+    except OrderNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except BrokerConnectionError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except BrokerSafetyError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.exception("Failed to cancel order %s on %s", order_id, broker)
+        raise HTTPException(status_code=500, detail="Internal server error") from exc
+
+
+@router.patch(
+    "/{broker}/orders/{order_id}",
+    status_code=204,
+    summary="Amend Order",
+    description="Modify quantity and/or price of an open order.",
+)
+def amend_order(
+    broker: str, order_id: str, request: BrokerAmendRequest
+) -> None:
+    _get_adapter_or_404(broker)
+    try:
+        amend_req = AmendRequest(
+            quantity=request.quantity,
+            price=request.price,
+        )
+        _service.amend_order(broker, order_id, amend_req)
+    except OrderNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except (BrokerValidationError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except BrokerConnectionError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except BrokerSafetyError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.exception("Failed to amend order %s on %s", order_id, broker)
+        raise HTTPException(status_code=500, detail="Internal server error") from exc
+
+
+# ---------------------------------------------------------------------------
+# Kill switch
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/{broker}/kill-switch",
+    response_model=BrokerKillSwitchResponse,
+    summary="Activate Kill Switch",
+    description="Emergency stop: cancel all open orders and block new ones.",
+)
+def activate_kill_switch(broker: str) -> BrokerKillSwitchResponse:
+    _get_adapter_or_404(broker)
+    try:
+        result = _service.activate_kill_switch(broker)
+        return BrokerKillSwitchResponse(
+            activated=result.activated,
+            cancelled_orders=result.cancelled_orders,
+        )
+    except BrokerConnectionError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.exception("Failed to activate kill switch on %s", broker)
+        raise HTTPException(status_code=500, detail="Internal server error") from exc

--- a/api/schemas/broker.py
+++ b/api/schemas/broker.py
@@ -1,0 +1,101 @@
+"""
+Unified broker API schemas for request/response validation.
+
+Provides Pydantic models for broker-agnostic order management.
+Reuses enums from ``brokers.base`` to stay in sync with the adapter layer.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+from brokers.base import ConnectionState, OrderSide, OrderStatus, OrderType
+
+
+# ---------------------------------------------------------------------------
+# Requests
+# ---------------------------------------------------------------------------
+
+
+class BrokerOrderRequest(BaseModel):
+    """Order placement request body."""
+
+    ticker: str = Field(..., description="Instrument symbol")
+    side: OrderSide = Field(..., description="Order direction")
+    quantity: int = Field(..., gt=0, description="Number of shares/contracts")
+    order_type: OrderType = Field(
+        OrderType.MARKET, description="Market or limit"
+    )
+    price: Optional[float] = Field(
+        None, description="Limit price (required for LIMIT orders)"
+    )
+    account_id: Optional[str] = Field(
+        None, description="Target account (None = broker default)"
+    )
+
+
+class BrokerAmendRequest(BaseModel):
+    """Order amendment request body."""
+
+    quantity: Optional[int] = Field(None, gt=0, description="New quantity")
+    price: Optional[float] = Field(None, description="New limit price")
+
+
+# ---------------------------------------------------------------------------
+# Responses
+# ---------------------------------------------------------------------------
+
+
+class BrokerOrderResponse(BaseModel):
+    """Order snapshot returned by the API."""
+
+    order_id: str = Field(..., description="Broker-assigned order identifier")
+    broker: str = Field(..., description="Originating broker name")
+    ticker: str = Field(..., description="Instrument symbol")
+    side: OrderSide = Field(..., description="Order direction")
+    quantity: int = Field(..., description="Originally requested quantity")
+    filled_quantity: int = Field(0, description="Quantity filled so far")
+    unfilled_quantity: int = Field(0, description="Remaining unfilled quantity")
+    order_type: OrderType = Field(..., description="Market or limit")
+    price: Optional[float] = Field(None, description="Limit price")
+    filled_price: Optional[float] = Field(None, description="Average fill price")
+    status: OrderStatus = Field(..., description="Current lifecycle status")
+    created_at: str = Field(..., description="Creation timestamp (ISO 8601)")
+    updated_at: Optional[str] = Field(
+        None, description="Last modification timestamp"
+    )
+
+
+class BrokerConnectionResponse(BaseModel):
+    """Broker connection status response."""
+
+    broker: str = Field(..., description="Broker identifier")
+    status: ConnectionState = Field(..., description="Connection state")
+    is_paper_trading: Optional[bool] = Field(
+        None, description="Whether running in paper-trading mode"
+    )
+    accounts: List[str] = Field(
+        default_factory=list, description="Accessible account numbers"
+    )
+    updated_at: Optional[str] = Field(
+        None, description="Last status change timestamp"
+    )
+
+
+class BrokerKillSwitchResponse(BaseModel):
+    """Kill switch activation response."""
+
+    activated: bool = Field(
+        ..., description="Whether the kill switch was activated"
+    )
+    cancelled_orders: int = Field(0, description="Number of orders cancelled")
+
+
+class BrokerListResponse(BaseModel):
+    """List of registered brokers."""
+
+    brokers: List[str] = Field(
+        default_factory=list, description="Registered broker names"
+    )

--- a/api/services/broker_service.py
+++ b/api/services/broker_service.py
@@ -1,0 +1,73 @@
+"""
+Unified broker service layer.
+
+Wraps :func:`brokers.get_broker` / :func:`brokers.list_brokers` behind a
+thin service that API routers consume.  Adapter instances are cached by
+the underlying :class:`BrokerRegistry` singleton, so this service itself
+is stateless and safe to instantiate per-request or as a module-level
+singleton.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import List
+
+from brokers import get_broker, list_brokers
+from brokers.base import (
+    AmendRequest,
+    BrokerAdapter,
+    ConnectionStatus,
+    KillSwitchResult,
+    OrderRequest,
+    OrderSnapshot,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class BrokerService:
+    """Broker-agnostic service exposing the common trading operations."""
+
+    def get_adapter(self, broker: str) -> BrokerAdapter:
+        """Return the cached adapter for *broker*.
+
+        Raises ``KeyError`` if the broker name is not registered.
+        """
+        return get_broker(broker)
+
+    def list_brokers(self) -> List[str]:
+        """Return registered broker names."""
+        return list_brokers()
+
+    def get_connection_status(self, broker: str) -> ConnectionStatus:
+        """Return the connection status for *broker*."""
+        adapter = self.get_adapter(broker)
+        return adapter.get_connection_status()
+
+    def place_order(self, broker: str, request: OrderRequest) -> OrderSnapshot:
+        """Place a new order through *broker*."""
+        adapter = self.get_adapter(broker)
+        return adapter.place_order(request)
+
+    def get_orders(self, broker: str) -> List[OrderSnapshot]:
+        """Return all tracked orders for *broker*."""
+        adapter = self.get_adapter(broker)
+        return adapter.get_orders()
+
+    def cancel_order(self, broker: str, order_id: str) -> None:
+        """Cancel an open order on *broker*."""
+        adapter = self.get_adapter(broker)
+        adapter.cancel_order(order_id)
+
+    def amend_order(
+        self, broker: str, order_id: str, request: AmendRequest
+    ) -> None:
+        """Amend an open order on *broker*."""
+        adapter = self.get_adapter(broker)
+        adapter.amend_order(order_id, request)
+
+    def activate_kill_switch(self, broker: str) -> KillSwitchResult:
+        """Activate the kill switch on *broker*."""
+        adapter = self.get_adapter(broker)
+        return adapter.activate_kill_switch()

--- a/tests/test_broker_router.py
+++ b/tests/test_broker_router.py
@@ -1,0 +1,549 @@
+"""Unit tests for the unified broker router (``api/routers/broker.py``).
+
+All adapter interactions are mocked -- no live broker connection is needed.
+The ``api.routers.kiwoom`` module initialises ``KiwoomService`` and
+WebSocket bridges at import time, which would fail in test environments.
+We patch those before ``api.main`` (and thus the kiwoom router) is imported.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from brokers.base import (
+    ConnectionState,
+    ConnectionStatus,
+    KillSwitchResult,
+    OrderSide,
+    OrderSnapshot,
+    OrderStatus,
+    OrderType,
+)
+from brokers.exceptions import (
+    BrokerConnectionError,
+    BrokerSafetyError,
+    BrokerValidationError,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def mock_service():
+    """Patch ``BrokerService`` at module level in the broker router.
+
+    The broker router creates ``_service = BrokerService()`` at import time,
+    so we must patch the *instance* methods used by the route handlers.  We
+    achieve this by patching the class in ``api.routers.broker`` before
+    the test runs, and then replace the module-level ``_service`` object.
+    """
+    mock_svc = MagicMock()
+    with patch("api.routers.broker._service", mock_svc):
+        yield mock_svc
+
+
+@pytest.fixture()
+def client(mock_service):
+    """Return a ``TestClient`` wired to the real FastAPI app.
+
+    The kiwoom router performs eager initialisation at import time
+    (``KiwoomService.get_instance()`` and ``_setup_ws_bridges``).  We
+    patch those *before* importing ``api.main`` to prevent ImportError
+    on platforms without the Kiwoom COM library.
+    """
+    # We need to patch the kiwoom service singleton that runs at import
+    # time.  Since api.main imports api.routers.kiwoom (directly *and*
+    # via the __init__), we patch right on the service module.
+    with (
+        patch(
+            "api.services.kiwoom_service.KiwoomService.get_instance",
+            return_value=MagicMock(),
+        ),
+        patch("api.services.kiwoom_service.KiwoomConnection", MagicMock()),
+        patch("api.services.kiwoom_service.KiwoomOrderManager", MagicMock()),
+        patch("api.services.kiwoom_service.ChejanHandler", MagicMock()),
+        patch("api.services.kiwoom_service.ConditionSearchManager", MagicMock()),
+        patch("api.services.kiwoom_service.KiwoomSafetyManager", MagicMock()),
+        patch("api.services.kiwoom_service.AuditLogger", MagicMock()),
+    ):
+        from fastapi.testclient import TestClient
+
+        from api.main import app
+
+        yield TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Shared test data helpers
+# ---------------------------------------------------------------------------
+
+
+def _sample_order_snapshot(**overrides) -> OrderSnapshot:
+    """Return a realistic ``OrderSnapshot`` with optional field overrides."""
+    defaults = dict(
+        order_id="ORD-001",
+        broker="tiger",
+        ticker="AAPL",
+        side=OrderSide.BUY,
+        quantity=100,
+        filled_quantity=0,
+        unfilled_quantity=100,
+        order_type=OrderType.MARKET,
+        price=None,
+        filled_price=None,
+        status=OrderStatus.RECEIVED,
+        created_at="2026-02-25T10:00:00Z",
+        updated_at=None,
+    )
+    defaults.update(overrides)
+    return OrderSnapshot(**defaults)
+
+
+def _sample_connection_status(**overrides) -> ConnectionStatus:
+    defaults = dict(
+        broker="tiger",
+        status=ConnectionState.CONNECTED,
+        is_paper_trading=True,
+        accounts=["ACCT-1"],
+        updated_at="2026-02-25T10:00:00Z",
+    )
+    defaults.update(overrides)
+    return ConnectionStatus(**defaults)
+
+
+# =========================================================================
+# 1. GET /api/brokers/ -- list brokers
+# =========================================================================
+
+
+class TestListBrokers:
+    def test_list_brokers(self, client, mock_service) -> None:
+        mock_service.list_brokers.return_value = ["ibkr", "kiwoom", "tiger"]
+
+        resp = client.get("/api/brokers/")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["brokers"] == ["ibkr", "kiwoom", "tiger"]
+
+    def test_list_brokers_empty(self, client, mock_service) -> None:
+        mock_service.list_brokers.return_value = []
+
+        resp = client.get("/api/brokers/")
+        assert resp.status_code == 200
+        assert resp.json()["brokers"] == []
+
+
+# =========================================================================
+# 2. GET /api/brokers/{broker}/status -- connection status
+# =========================================================================
+
+
+class TestConnectionStatus:
+    def test_connection_status(self, client, mock_service) -> None:
+        mock_service.get_adapter.return_value = MagicMock()
+        mock_service.get_connection_status.return_value = _sample_connection_status()
+
+        resp = client.get("/api/brokers/tiger/status")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["broker"] == "tiger"
+        assert body["status"] == "connected"
+        assert body["is_paper_trading"] is True
+        assert body["accounts"] == ["ACCT-1"]
+
+    def test_connection_error_503(self, client, mock_service) -> None:
+        """Adapter raises BrokerConnectionError => 503."""
+        mock_service.get_adapter.return_value = MagicMock()
+        mock_service.get_connection_status.side_effect = BrokerConnectionError(
+            "Gateway unreachable"
+        )
+
+        resp = client.get("/api/brokers/tiger/status")
+        assert resp.status_code == 503
+        assert "Gateway unreachable" in resp.json()["detail"]
+
+
+# =========================================================================
+# 3. POST /api/brokers/{broker}/orders -- place order
+# =========================================================================
+
+
+class TestPlaceOrder:
+    def test_place_market_order(self, client, mock_service) -> None:
+        snapshot = _sample_order_snapshot()
+        mock_service.get_adapter.return_value = MagicMock()
+        mock_service.place_order.return_value = snapshot
+
+        resp = client.post(
+            "/api/brokers/tiger/orders",
+            json={
+                "ticker": "AAPL",
+                "side": "BUY",
+                "quantity": 100,
+                "order_type": "MARKET",
+            },
+        )
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["order_id"] == "ORD-001"
+        assert body["broker"] == "tiger"
+        assert body["ticker"] == "AAPL"
+        assert body["side"] == "BUY"
+        assert body["quantity"] == 100
+        assert body["order_type"] == "MARKET"
+        assert body["status"] == "RECEIVED"
+
+    def test_place_limit_order(self, client, mock_service) -> None:
+        snapshot = _sample_order_snapshot(
+            order_type=OrderType.LIMIT,
+            price=150.50,
+            status=OrderStatus.CONFIRMED,
+        )
+        mock_service.get_adapter.return_value = MagicMock()
+        mock_service.place_order.return_value = snapshot
+
+        resp = client.post(
+            "/api/brokers/tiger/orders",
+            json={
+                "ticker": "AAPL",
+                "side": "BUY",
+                "quantity": 50,
+                "order_type": "LIMIT",
+                "price": 150.50,
+            },
+        )
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["order_type"] == "LIMIT"
+        assert body["price"] == 150.50
+        assert body["status"] == "CONFIRMED"
+
+    def test_place_order_with_account_id(self, client, mock_service) -> None:
+        snapshot = _sample_order_snapshot()
+        mock_service.get_adapter.return_value = MagicMock()
+        mock_service.place_order.return_value = snapshot
+
+        resp = client.post(
+            "/api/brokers/tiger/orders",
+            json={
+                "ticker": "AAPL",
+                "side": "BUY",
+                "quantity": 10,
+                "order_type": "MARKET",
+                "account_id": "ACCT-1",
+            },
+        )
+        assert resp.status_code == 201
+
+    def test_place_order_safety_error_409(self, client, mock_service) -> None:
+        mock_service.get_adapter.return_value = MagicMock()
+        mock_service.place_order.side_effect = BrokerSafetyError(
+            "Kill switch is active"
+        )
+
+        resp = client.post(
+            "/api/brokers/tiger/orders",
+            json={
+                "ticker": "AAPL",
+                "side": "BUY",
+                "quantity": 100,
+                "order_type": "MARKET",
+            },
+        )
+        assert resp.status_code == 409
+        assert "Kill switch" in resp.json()["detail"]
+
+    def test_place_order_connection_error_503(self, client, mock_service) -> None:
+        mock_service.get_adapter.return_value = MagicMock()
+        mock_service.place_order.side_effect = BrokerConnectionError(
+            "Broker unreachable"
+        )
+
+        resp = client.post(
+            "/api/brokers/tiger/orders",
+            json={
+                "ticker": "AAPL",
+                "side": "BUY",
+                "quantity": 100,
+                "order_type": "MARKET",
+            },
+        )
+        assert resp.status_code == 503
+
+    def test_place_order_validation_error_400(self, client, mock_service) -> None:
+        mock_service.get_adapter.return_value = MagicMock()
+        mock_service.place_order.side_effect = BrokerValidationError(
+            "Insufficient funds"
+        )
+
+        resp = client.post(
+            "/api/brokers/tiger/orders",
+            json={
+                "ticker": "AAPL",
+                "side": "BUY",
+                "quantity": 100,
+                "order_type": "MARKET",
+            },
+        )
+        assert resp.status_code == 400
+        assert "Insufficient funds" in resp.json()["detail"]
+
+
+# =========================================================================
+# 4. GET /api/brokers/{broker}/orders -- list orders
+# =========================================================================
+
+
+class TestGetOrders:
+    def test_get_orders(self, client, mock_service) -> None:
+        snapshots = [
+            _sample_order_snapshot(order_id="ORD-001"),
+            _sample_order_snapshot(
+                order_id="ORD-002",
+                ticker="TSLA",
+                side=OrderSide.SELL,
+                status=OrderStatus.FILLED,
+                filled_quantity=50,
+                unfilled_quantity=0,
+                filled_price=200.0,
+            ),
+        ]
+        mock_service.get_adapter.return_value = MagicMock()
+        mock_service.get_orders.return_value = snapshots
+
+        resp = client.get("/api/brokers/tiger/orders")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body) == 2
+        assert body[0]["order_id"] == "ORD-001"
+        assert body[1]["order_id"] == "ORD-002"
+        assert body[1]["ticker"] == "TSLA"
+        assert body[1]["side"] == "SELL"
+        assert body[1]["status"] == "FILLED"
+
+    def test_get_orders_empty(self, client, mock_service) -> None:
+        mock_service.get_adapter.return_value = MagicMock()
+        mock_service.get_orders.return_value = []
+
+        resp = client.get("/api/brokers/tiger/orders")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_get_orders_connection_error_503(self, client, mock_service) -> None:
+        mock_service.get_adapter.return_value = MagicMock()
+        mock_service.get_orders.side_effect = BrokerConnectionError("offline")
+
+        resp = client.get("/api/brokers/tiger/orders")
+        assert resp.status_code == 503
+
+
+# =========================================================================
+# 5. DELETE /api/brokers/{broker}/orders/{order_id} -- cancel order
+# =========================================================================
+
+
+class TestCancelOrder:
+    def test_cancel_order(self, client, mock_service) -> None:
+        mock_service.get_adapter.return_value = MagicMock()
+        mock_service.cancel_order.return_value = None
+
+        resp = client.delete("/api/brokers/tiger/orders/123")
+        assert resp.status_code == 204
+        mock_service.cancel_order.assert_called_once_with("tiger", "123")
+
+    def test_cancel_order_not_found(self, client, mock_service) -> None:
+        from brokers.exceptions import OrderNotFoundError
+
+        mock_service.get_adapter.return_value = MagicMock()
+        mock_service.cancel_order.side_effect = OrderNotFoundError("Order 123 not found")
+
+        resp = client.delete("/api/brokers/tiger/orders/123")
+        assert resp.status_code == 404
+
+    def test_cancel_order_safety_error_409(self, client, mock_service) -> None:
+        mock_service.get_adapter.return_value = MagicMock()
+        mock_service.cancel_order.side_effect = BrokerSafetyError("Cannot cancel")
+
+        resp = client.delete("/api/brokers/tiger/orders/123")
+        assert resp.status_code == 409
+
+
+# =========================================================================
+# 6. PATCH /api/brokers/{broker}/orders/{order_id} -- amend order
+# =========================================================================
+
+
+class TestAmendOrder:
+    def test_amend_order(self, client, mock_service) -> None:
+        mock_service.get_adapter.return_value = MagicMock()
+        mock_service.amend_order.return_value = None
+
+        resp = client.patch(
+            "/api/brokers/tiger/orders/123",
+            json={"quantity": 200},
+        )
+        assert resp.status_code == 204
+        mock_service.amend_order.assert_called_once()
+        call_args = mock_service.amend_order.call_args
+        assert call_args[0][0] == "tiger"
+        assert call_args[0][1] == "123"
+        # Third arg is the AmendRequest
+        amend_req = call_args[0][2]
+        assert amend_req.quantity == 200
+
+    def test_amend_order_price_only(self, client, mock_service) -> None:
+        mock_service.get_adapter.return_value = MagicMock()
+        mock_service.amend_order.return_value = None
+
+        resp = client.patch(
+            "/api/brokers/tiger/orders/123",
+            json={"price": 155.0},
+        )
+        assert resp.status_code == 204
+
+    def test_amend_order_both_fields(self, client, mock_service) -> None:
+        mock_service.get_adapter.return_value = MagicMock()
+        mock_service.amend_order.return_value = None
+
+        resp = client.patch(
+            "/api/brokers/tiger/orders/123",
+            json={"quantity": 50, "price": 160.0},
+        )
+        assert resp.status_code == 204
+
+    def test_validation_error_400_no_fields(self, client, mock_service) -> None:
+        """Amend with no fields triggers ValueError from AmendRequest validator."""
+        mock_service.get_adapter.return_value = MagicMock()
+        # The AmendRequest model_validator raises ValueError when both
+        # quantity and price are None.  The router catches (ValueError, BrokerValidationError) => 400.
+        mock_service.amend_order.side_effect = ValueError(
+            "at least one of quantity or price must be provided"
+        )
+
+        resp = client.patch(
+            "/api/brokers/tiger/orders/123",
+            json={},
+        )
+        assert resp.status_code == 400
+        assert "at least one" in resp.json()["detail"]
+
+    def test_amend_order_not_found(self, client, mock_service) -> None:
+        from brokers.exceptions import OrderNotFoundError
+
+        mock_service.get_adapter.return_value = MagicMock()
+        mock_service.amend_order.side_effect = OrderNotFoundError("not found")
+
+        resp = client.patch(
+            "/api/brokers/tiger/orders/999",
+            json={"quantity": 50},
+        )
+        assert resp.status_code == 404
+
+    def test_amend_order_safety_error_409(self, client, mock_service) -> None:
+        mock_service.get_adapter.return_value = MagicMock()
+        mock_service.amend_order.side_effect = BrokerSafetyError("blocked")
+
+        resp = client.patch(
+            "/api/brokers/tiger/orders/123",
+            json={"quantity": 50},
+        )
+        assert resp.status_code == 409
+
+
+# =========================================================================
+# 7. POST /api/brokers/{broker}/kill-switch
+# =========================================================================
+
+
+class TestKillSwitch:
+    def test_kill_switch(self, client, mock_service) -> None:
+        mock_service.get_adapter.return_value = MagicMock()
+        mock_service.activate_kill_switch.return_value = KillSwitchResult(
+            activated=True, cancelled_orders=3
+        )
+
+        resp = client.post("/api/brokers/tiger/kill-switch")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["activated"] is True
+        assert body["cancelled_orders"] == 3
+
+    def test_kill_switch_no_open_orders(self, client, mock_service) -> None:
+        mock_service.get_adapter.return_value = MagicMock()
+        mock_service.activate_kill_switch.return_value = KillSwitchResult(
+            activated=True, cancelled_orders=0
+        )
+
+        resp = client.post("/api/brokers/tiger/kill-switch")
+        assert resp.status_code == 200
+        assert resp.json()["cancelled_orders"] == 0
+
+    def test_kill_switch_connection_error_503(self, client, mock_service) -> None:
+        mock_service.get_adapter.return_value = MagicMock()
+        mock_service.activate_kill_switch.side_effect = BrokerConnectionError(
+            "offline"
+        )
+
+        resp = client.post("/api/brokers/tiger/kill-switch")
+        assert resp.status_code == 503
+
+
+# =========================================================================
+# 8. Unknown broker => 404
+# =========================================================================
+
+
+class TestUnknownBroker:
+    def test_unknown_broker_status_404(self, client, mock_service) -> None:
+        mock_service.get_adapter.side_effect = KeyError("unknown")
+
+        resp = client.get("/api/brokers/unknown/status")
+        assert resp.status_code == 404
+        assert "not registered" in resp.json()["detail"]
+
+    def test_unknown_broker_orders_404(self, client, mock_service) -> None:
+        mock_service.get_adapter.side_effect = KeyError("unknown")
+
+        resp = client.get("/api/brokers/unknown/orders")
+        assert resp.status_code == 404
+
+    def test_unknown_broker_place_order_404(self, client, mock_service) -> None:
+        mock_service.get_adapter.side_effect = KeyError("unknown")
+
+        resp = client.post(
+            "/api/brokers/unknown/orders",
+            json={
+                "ticker": "AAPL",
+                "side": "BUY",
+                "quantity": 1,
+                "order_type": "MARKET",
+            },
+        )
+        assert resp.status_code == 404
+
+    def test_unknown_broker_cancel_404(self, client, mock_service) -> None:
+        mock_service.get_adapter.side_effect = KeyError("unknown")
+
+        resp = client.delete("/api/brokers/unknown/orders/123")
+        assert resp.status_code == 404
+
+    def test_unknown_broker_amend_404(self, client, mock_service) -> None:
+        mock_service.get_adapter.side_effect = KeyError("unknown")
+
+        resp = client.patch(
+            "/api/brokers/unknown/orders/123",
+            json={"quantity": 10},
+        )
+        assert resp.status_code == 404
+
+    def test_unknown_broker_kill_switch_404(self, client, mock_service) -> None:
+        mock_service.get_adapter.side_effect = KeyError("unknown")
+
+        resp = client.post("/api/brokers/unknown/kill-switch")
+        assert resp.status_code == 404

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -261,7 +261,28 @@
     "orderAmendFailed": "Failed to amend order.",
     "orderTickerRequired": "Ticker is required.",
     "orderQuantityInvalid": "Quantity must be a positive number.",
-    "orderPriceInvalid": "Price must be a positive number for limit orders."
+    "orderPriceInvalid": "Price must be a positive number for limit orders.",
+    "tabKiwoom": "Kiwoom",
+    "tabUnifiedBroker": "Unified Broker"
+  },
+  "brokerOrderDesk": {
+    "title": "Broker Order Desk",
+    "selectBroker": "Select Broker",
+    "connectionStatus": "Connection Status",
+    "placeOrder": "Place Order",
+    "orderList": "Orders",
+    "killSwitch": "Emergency Kill Switch",
+    "killSwitchConfirm": "Cancel ALL open orders? This cannot be undone.",
+    "noOrders": "No orders found",
+    "noBrokers": "No brokers registered. Please configure a broker adapter.",
+    "orderPlaced": "Order placed successfully",
+    "orderCancelled": "Order cancelled",
+    "orderAmended": "Order amended",
+    "orderLoadFailed": "Failed to load orders",
+    "connected": "Connected",
+    "disconnected": "Disconnected",
+    "connecting": "Connecting",
+    "unavailable": "Unavailable"
   },
   "strategy": {
     "title": "QuantCanvas",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -261,7 +261,28 @@
     "orderAmendFailed": "주문 정정에 실패했습니다.",
     "orderTickerRequired": "종목코드를 입력해주세요.",
     "orderQuantityInvalid": "수량은 0보다 커야 합니다.",
-    "orderPriceInvalid": "지정가 주문의 가격은 0보다 커야 합니다."
+    "orderPriceInvalid": "지정가 주문의 가격은 0보다 커야 합니다.",
+    "tabKiwoom": "키움",
+    "tabUnifiedBroker": "통합 브로커"
+  },
+  "brokerOrderDesk": {
+    "title": "통합 주문 데스크",
+    "selectBroker": "브로커 선택",
+    "connectionStatus": "연결 상태",
+    "placeOrder": "주문 제출",
+    "orderList": "주문 목록",
+    "killSwitch": "긴급 정지",
+    "killSwitchConfirm": "모든 미체결 주문을 취소하시겠습니까? 이 작업은 되돌릴 수 없습니다.",
+    "noOrders": "주문 내역이 없습니다",
+    "noBrokers": "등록된 브로커가 없습니다. 브로커 어댑터를 설정해주세요.",
+    "orderPlaced": "주문이 접수되었습니다",
+    "orderCancelled": "주문이 취소되었습니다",
+    "orderAmended": "주문이 수정되었습니다",
+    "orderLoadFailed": "주문 목록을 불러오지 못했습니다",
+    "connected": "연결됨",
+    "disconnected": "연결 끊김",
+    "connecting": "연결 중",
+    "unavailable": "사용 불가"
   },
   "strategy": {
     "title": "퀀트캔버스",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -261,7 +261,28 @@
     "orderAmendFailed": "改单失败。",
     "orderTickerRequired": "请输入代码。",
     "orderQuantityInvalid": "数量必须大于 0。",
-    "orderPriceInvalid": "限价单价格必须大于 0。"
+    "orderPriceInvalid": "限价单价格必须大于 0。",
+    "tabKiwoom": "Kiwoom",
+    "tabUnifiedBroker": "统一经纪商"
+  },
+  "brokerOrderDesk": {
+    "title": "统一下单台",
+    "selectBroker": "选择经纪商",
+    "connectionStatus": "连接状态",
+    "placeOrder": "提交订单",
+    "orderList": "订单列表",
+    "killSwitch": "紧急停止",
+    "killSwitchConfirm": "取消所有未成交订单？此操作无法撤销。",
+    "noOrders": "暂无订单",
+    "noBrokers": "未注册经纪商。请配置经纪商适配器。",
+    "orderPlaced": "订单已提交",
+    "orderCancelled": "订单已取消",
+    "orderAmended": "订单已修改",
+    "orderLoadFailed": "加载订单失败",
+    "connected": "已连接",
+    "disconnected": "已断开",
+    "connecting": "连接中",
+    "unavailable": "不可用"
   },
   "strategy": {
     "title": "QuantCanvas",

--- a/web/src/app/[locale]/portfolio/page.tsx
+++ b/web/src/app/[locale]/portfolio/page.tsx
@@ -12,6 +12,7 @@ import {
   SellSignalBanner,
   CsvImportModal,
   OrderDesk,
+  BrokerOrderDesk,
 } from '@/components/portfolio';
 import {
   getHoldings,
@@ -128,6 +129,7 @@ export default function PortfolioPage() {
   const [activeFilter, setActiveFilter] = useState<FilterTab>('all');
   const [searchQuery, setSearchQuery] = useState('');
   const [orderDeskPrefill, setOrderDeskPrefill] = useState<OrderDeskPrefill | null>(null);
+  const [orderDeskTab, setOrderDeskTab] = useState<'kiwoom' | 'unified'>('unified');
   const orderDeskRef = useRef<HTMLDivElement | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
   const pollingIntervalRef = useRef<number | null>(null);
@@ -744,7 +746,35 @@ export default function PortfolioPage() {
       </Card>
 
       <div ref={orderDeskRef}>
-        <OrderDesk prefill={orderDeskPrefill} />
+        <div className="flex gap-1 rounded-lg bg-[var(--background)] p-1 mb-4 w-fit">
+          <button
+            type="button"
+            onClick={() => setOrderDeskTab('unified')}
+            className={`rounded-md px-4 py-2 text-sm font-medium transition-colors ${
+              orderDeskTab === 'unified'
+                ? 'bg-[var(--background-secondary)] text-[var(--foreground)] shadow-sm'
+                : 'text-[var(--foreground-muted)] hover:text-[var(--foreground)]'
+            }`}
+          >
+            {t('tabUnifiedBroker')}
+          </button>
+          <button
+            type="button"
+            onClick={() => setOrderDeskTab('kiwoom')}
+            className={`rounded-md px-4 py-2 text-sm font-medium transition-colors ${
+              orderDeskTab === 'kiwoom'
+                ? 'bg-[var(--background-secondary)] text-[var(--foreground)] shadow-sm'
+                : 'text-[var(--foreground-muted)] hover:text-[var(--foreground)]'
+            }`}
+          >
+            {t('tabKiwoom')}
+          </button>
+        </div>
+        {orderDeskTab === 'kiwoom' ? (
+          <OrderDesk prefill={orderDeskPrefill} />
+        ) : (
+          <BrokerOrderDesk />
+        )}
       </div>
 
       {/* Add Holding Modal */}

--- a/web/src/components/portfolio/BrokerOrderDesk.tsx
+++ b/web/src/components/portfolio/BrokerOrderDesk.tsx
@@ -1,0 +1,595 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useLocale, useTranslations } from 'next-intl';
+import { AlertTriangle, Pencil, RefreshCw, ShieldAlert, XCircle } from 'lucide-react';
+import { Button, Card } from '@/components/ui';
+import {
+  amendBrokerOrder,
+  cancelBrokerOrder,
+  getBrokerConnectionStatus,
+  getBrokerOrders,
+  listBrokers,
+  placeBrokerOrder,
+  triggerBrokerKillSwitch,
+} from '@/lib/api';
+import type {
+  BrokerConnectionState,
+  BrokerOrder,
+  BrokerOrderRequest,
+  BrokerOrderStatus,
+} from '@/lib/types';
+import { formatCurrency as formatCurrencyUtil } from '@/lib/format';
+
+const ORDER_STATUSES: BrokerOrderStatus[] = [
+  'RECEIVED',
+  'CONFIRMED',
+  'PARTIAL',
+  'FILLED',
+  'CANCELED',
+  'REJECTED',
+];
+
+export default function BrokerOrderDesk() {
+  const t = useTranslations('brokerOrderDesk');
+  const tPortfolio = useTranslations('portfolio');
+  const tCommon = useTranslations('common');
+  const locale = useLocale();
+  const formatCurrency = (value: number | null, currency: string = 'USD') =>
+    formatCurrencyUtil(value, currency, locale);
+
+  // Broker selection
+  const [brokers, setBrokers] = useState<string[]>([]);
+  const [selectedBroker, setSelectedBroker] = useState<string>('');
+  const [connectionState, setConnectionState] = useState<BrokerConnectionState>('unavailable');
+  const [isPaperTrading, setIsPaperTrading] = useState<boolean | null>(null);
+
+  // Orders
+  const [orders, setOrders] = useState<BrokerOrder[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  // Form state
+  const [ticker, setTicker] = useState('');
+  const [side, setSide] = useState<'BUY' | 'SELL'>('BUY');
+  const [quantity, setQuantity] = useState('1');
+  const [orderType, setOrderType] = useState<'MARKET' | 'LIMIT'>('MARKET');
+  const [price, setPrice] = useState('');
+
+  // Confirm dialog
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [pendingOrderRequest, setPendingOrderRequest] = useState<BrokerOrderRequest | null>(null);
+
+  // Amend dialog
+  const [amendTarget, setAmendTarget] = useState<BrokerOrder | null>(null);
+  const [amendQty, setAmendQty] = useState('');
+  const [amendPrice, setAmendPrice] = useState('');
+
+  // Polling
+  const pollRef = useRef<number | null>(null);
+
+  // Load available brokers
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const list = await listBrokers();
+        if (mounted && list.length > 0) {
+          setBrokers(list);
+          setSelectedBroker(list[0]);
+        }
+      } catch {
+        // Broker list unavailable
+      }
+    })();
+    return () => { mounted = false; };
+  }, []);
+
+  // Load connection status when broker changes
+  useEffect(() => {
+    if (!selectedBroker) return;
+    let mounted = true;
+    (async () => {
+      try {
+        const status = await getBrokerConnectionStatus(selectedBroker);
+        if (mounted) {
+          setConnectionState(status.status);
+          setIsPaperTrading(status.is_paper_trading);
+        }
+      } catch {
+        if (mounted) {
+          setConnectionState('unavailable');
+          setIsPaperTrading(null);
+        }
+      }
+    })();
+    return () => { mounted = false; };
+  }, [selectedBroker]);
+
+  const loadOrders = useCallback(async () => {
+    if (!selectedBroker) return;
+    try {
+      const data = await getBrokerOrders(selectedBroker);
+      setOrders(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('orderLoadFailed'));
+    }
+  }, [selectedBroker, t]);
+
+  // Load orders when broker changes
+  useEffect(() => {
+    if (!selectedBroker) return;
+    let mounted = true;
+    (async () => {
+      setIsLoading(true);
+      setOrders([]);
+      setError(null);
+      try {
+        const data = await getBrokerOrders(selectedBroker);
+        if (mounted) {
+          setOrders(data);
+        }
+      } catch (err) {
+        if (mounted) {
+          setError(err instanceof Error ? err.message : t('orderLoadFailed'));
+        }
+      } finally {
+        if (mounted) {
+          setIsLoading(false);
+        }
+      }
+    })();
+    return () => { mounted = false; };
+  }, [selectedBroker, t]);
+
+  // HTTP polling for order updates
+  useEffect(() => {
+    if (!selectedBroker) return;
+    pollRef.current = window.setInterval(loadOrders, 5000);
+    return () => {
+      if (pollRef.current) {
+        window.clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+    };
+  }, [selectedBroker, loadOrders]);
+
+  const showSuccess = useCallback((msg: string) => {
+    setSuccessMessage(msg);
+    setTimeout(() => setSuccessMessage(null), 3000);
+  }, []);
+
+  const handleSubmit = useCallback(async () => {
+    const qty = Number(quantity);
+    const px = Number(price);
+
+    if (!selectedBroker) {
+      setError(t('selectBroker'));
+      return;
+    }
+    if (!ticker.trim()) {
+      setError(tPortfolio('orderTickerRequired'));
+      return;
+    }
+    if (!Number.isFinite(qty) || qty <= 0) {
+      setError(tPortfolio('orderQuantityInvalid'));
+      return;
+    }
+    if (orderType === 'LIMIT' && (!Number.isFinite(px) || px <= 0)) {
+      setError(tPortfolio('orderPriceInvalid'));
+      return;
+    }
+
+    const request: BrokerOrderRequest = {
+      ticker: ticker.trim().toUpperCase(),
+      side,
+      quantity: qty,
+      order_type: orderType,
+      price: orderType === 'LIMIT' ? px : null,
+    };
+
+    // If not paper trading, require confirmation
+    if (isPaperTrading === false) {
+      setPendingOrderRequest(request);
+      setConfirmOpen(true);
+      return;
+    }
+
+    await submitOrder(request);
+  }, [isPaperTrading, orderType, price, quantity, selectedBroker, side, t, tPortfolio, ticker]);
+
+  const submitOrder = useCallback(
+    async (request: BrokerOrderRequest) => {
+      setIsSubmitting(true);
+      setError(null);
+      try {
+        await placeBrokerOrder(selectedBroker, request);
+        setTicker('');
+        setQuantity('1');
+        setOrderType('MARKET');
+        setPrice('');
+        showSuccess(t('orderPlaced'));
+        await loadOrders();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : tPortfolio('orderSubmitFailed'));
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [loadOrders, selectedBroker, showSuccess, t, tPortfolio]
+  );
+
+  const confirmRealOrder = useCallback(async () => {
+    if (!pendingOrderRequest) return;
+    setConfirmOpen(false);
+    await submitOrder(pendingOrderRequest);
+    setPendingOrderRequest(null);
+  }, [pendingOrderRequest, submitOrder]);
+
+  const handleCancelOrder = useCallback(
+    async (orderId: string) => {
+      setIsSubmitting(true);
+      setError(null);
+      try {
+        await cancelBrokerOrder(selectedBroker, orderId);
+        showSuccess(t('orderCancelled'));
+        await loadOrders();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : tPortfolio('orderCancelFailed'));
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [loadOrders, selectedBroker, showSuccess, t, tPortfolio]
+  );
+
+  const openAmend = useCallback((order: BrokerOrder) => {
+    setAmendTarget(order);
+    setAmendQty(String(order.unfilled_quantity || order.quantity));
+    setAmendPrice(order.price ? String(order.price) : '');
+  }, []);
+
+  const submitAmend = useCallback(async () => {
+    if (!amendTarget) return;
+    const qtyNum = Number(amendQty);
+    const priceNum = amendPrice ? Number(amendPrice) : null;
+
+    if (!Number.isFinite(qtyNum) || qtyNum <= 0) {
+      setError(tPortfolio('orderQuantityInvalid'));
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      await amendBrokerOrder(selectedBroker, amendTarget.order_id, {
+        quantity: qtyNum,
+        price: Number.isFinite(priceNum as number) ? (priceNum as number) : undefined,
+      });
+      setAmendTarget(null);
+      showSuccess(t('orderAmended'));
+      await loadOrders();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : tPortfolio('orderAmendFailed'));
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [amendPrice, amendQty, amendTarget, loadOrders, selectedBroker, showSuccess, t, tPortfolio]);
+
+  const handleKillSwitch = useCallback(async () => {
+    if (!window.confirm(t('killSwitchConfirm'))) return;
+
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      const result = await triggerBrokerKillSwitch(selectedBroker);
+      showSuccess(
+        `Kill switch activated. ${result.cancelled_orders} order(s) cancelled.`
+      );
+      await loadOrders();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : tPortfolio('killSwitchFailed'));
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [loadOrders, selectedBroker, showSuccess, t, tPortfolio]);
+
+  const connectionBadge = useMemo(() => {
+    const label = t(connectionState);
+    const cls =
+      connectionState === 'connected'
+        ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300'
+        : connectionState === 'disconnected'
+        ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300'
+        : 'bg-slate-100 text-slate-700 dark:bg-slate-800/80 dark:text-slate-200';
+    return { label, cls };
+  }, [connectionState, t]);
+
+  const statusBadgeClass = (status: BrokerOrderStatus) => {
+    if (status === 'FILLED')
+      return 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300';
+    if (status === 'CANCELED' || status === 'REJECTED')
+      return 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300';
+    if (status === 'PARTIAL')
+      return 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300';
+    return 'bg-slate-100 text-slate-700 dark:bg-slate-800/80 dark:text-slate-200';
+  };
+
+  if (brokers.length === 0) {
+    return (
+      <Card title={t('title')}>
+        <p className="text-sm text-[var(--foreground-muted)]">
+          {t('noBrokers')}
+        </p>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <Card title={t('title')}>
+        <div className="space-y-4">
+          {/* Broker selector + connection status */}
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div className="flex items-center gap-3">
+              <label htmlFor="broker-select" className="text-sm text-[var(--foreground-muted)]">
+                {t('selectBroker')}
+              </label>
+              <select
+                id="broker-select"
+                value={selectedBroker}
+                onChange={(e) => setSelectedBroker(e.target.value)}
+                className="rounded-lg border border-[var(--border)] bg-[var(--background-secondary)] px-3 py-2 text-sm"
+              >
+                {brokers.map((b) => (
+                  <option key={b} value={b}>
+                    {b.charAt(0).toUpperCase() + b.slice(1)}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <span className={`rounded-full px-2 py-1 text-xs ${connectionBadge.cls}`}>
+              {connectionBadge.label}
+              {isPaperTrading === true && ' (Paper)'}
+            </span>
+          </div>
+
+          {/* Order form */}
+          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-6">
+            <input
+              type="text"
+              value={ticker}
+              onChange={(e) => setTicker(e.target.value)}
+              placeholder={tPortfolio('orderTicker')}
+              className="rounded-lg border border-[var(--border)] bg-[var(--background-secondary)] px-3 py-2 text-sm"
+            />
+            <select
+              value={side}
+              onChange={(e) => setSide(e.target.value === 'SELL' ? 'SELL' : 'BUY')}
+              className="rounded-lg border border-[var(--border)] bg-[var(--background-secondary)] px-3 py-2 text-sm"
+            >
+              <option value="BUY">{tPortfolio('orderSideBuy')}</option>
+              <option value="SELL">{tPortfolio('orderSideSell')}</option>
+            </select>
+            <input
+              type="number"
+              min={1}
+              value={quantity}
+              onChange={(e) => setQuantity(e.target.value)}
+              placeholder={tPortfolio('orderQuantity')}
+              className="rounded-lg border border-[var(--border)] bg-[var(--background-secondary)] px-3 py-2 text-sm"
+            />
+            <select
+              value={orderType}
+              onChange={(e) => setOrderType(e.target.value === 'LIMIT' ? 'LIMIT' : 'MARKET')}
+              className="rounded-lg border border-[var(--border)] bg-[var(--background-secondary)] px-3 py-2 text-sm"
+            >
+              <option value="MARKET">{tPortfolio('orderTypeMarket')}</option>
+              <option value="LIMIT">{tPortfolio('orderTypeLimit')}</option>
+            </select>
+            <input
+              type="number"
+              min={0}
+              value={price}
+              onChange={(e) => setPrice(e.target.value)}
+              placeholder={tPortfolio('orderPrice')}
+              disabled={orderType === 'MARKET'}
+              className="rounded-lg border border-[var(--border)] bg-[var(--background-secondary)] px-3 py-2 text-sm disabled:opacity-50"
+            />
+            <Button onClick={handleSubmit} disabled={isSubmitting}>
+              {t('placeOrder')}
+            </Button>
+          </div>
+
+          {/* Actions */}
+          <div className="flex flex-wrap items-center gap-2">
+            <Button variant="outline" onClick={loadOrders} disabled={isSubmitting || isLoading}>
+              <RefreshCw className="mr-2 h-4 w-4" />
+              {tPortfolio('orderRefresh')}
+            </Button>
+            <Button variant="outline" onClick={handleKillSwitch} disabled={isSubmitting}>
+              <ShieldAlert className="mr-2 h-4 w-4" />
+              {t('killSwitch')}
+            </Button>
+          </div>
+
+          {/* Success message */}
+          {successMessage && (
+            <div className="rounded-lg border border-green-300 bg-green-50 px-3 py-2 text-sm text-green-700 dark:border-green-900/50 dark:bg-green-900/20 dark:text-green-200">
+              {successMessage}
+            </div>
+          )}
+
+          {/* Error message */}
+          {error && (
+            <div className="rounded-lg border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-900/20 dark:text-red-200">
+              {error}
+            </div>
+          )}
+        </div>
+      </Card>
+
+      {/* Order list */}
+      <Card title={t('orderList')}>
+        {isLoading ? (
+          <p className="text-sm text-[var(--foreground-muted)]">{tPortfolio('orderLoading')}</p>
+        ) : orders.length === 0 ? (
+          <p className="text-sm text-[var(--foreground-muted)]">{t('noOrders')}</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[940px] text-sm">
+              <thead>
+                <tr className="border-b border-[var(--border)] text-left text-[var(--foreground-muted)]">
+                  <th className="px-2 py-2 font-medium">{tPortfolio('orderId')}</th>
+                  <th className="px-2 py-2 font-medium">{tPortfolio('ticker')}</th>
+                  <th className="px-2 py-2 font-medium">{tPortfolio('orderSide')}</th>
+                  <th className="px-2 py-2 text-right font-medium">{tPortfolio('orderQuantity')}</th>
+                  <th className="px-2 py-2 text-right font-medium">{tPortfolio('orderFilledPrice')}</th>
+                  <th className="px-2 py-2 text-right font-medium">{tPortfolio('orderUnfilledQty')}</th>
+                  <th className="px-2 py-2 font-medium">{tPortfolio('orderStatus')}</th>
+                  <th className="px-2 py-2 text-right font-medium">{tPortfolio('actions')}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {orders.map((order) => {
+                  const canChange = ['RECEIVED', 'CONFIRMED', 'PARTIAL'].includes(order.status);
+                  return (
+                    <tr key={order.order_id} className="border-b border-[var(--border)]/70">
+                      <td className="px-2 py-2 font-mono text-xs text-[var(--foreground)]">
+                        {order.order_id}
+                      </td>
+                      <td className="px-2 py-2 font-mono text-[var(--color-primary)]">
+                        {order.ticker}
+                      </td>
+                      <td className="px-2 py-2">
+                        {order.side === 'BUY' ? tPortfolio('orderSideBuy') : tPortfolio('orderSideSell')}
+                      </td>
+                      <td className="px-2 py-2 text-right font-mono">
+                        {order.quantity.toLocaleString(locale)}
+                      </td>
+                      <td className="px-2 py-2 text-right font-mono">
+                        {formatCurrency(order.filled_price ?? order.price, 'USD')}
+                      </td>
+                      <td className="px-2 py-2 text-right font-mono">
+                        {order.unfilled_quantity.toLocaleString(locale)}
+                      </td>
+                      <td className="px-2 py-2">
+                        <span className={`rounded-full px-2 py-0.5 text-xs ${statusBadgeClass(order.status)}`}>
+                          {tPortfolio(`orderStatus_${order.status}`)}
+                        </span>
+                      </td>
+                      <td className="px-2 py-2">
+                        <div className="flex items-center justify-end gap-1">
+                          <button
+                            type="button"
+                            disabled={!canChange || isSubmitting}
+                            onClick={() => openAmend(order)}
+                            className="rounded p-1.5 text-[var(--foreground-muted)] hover:bg-[var(--border)] disabled:opacity-40"
+                            aria-label={`amend-${order.order_id}`}
+                          >
+                            <Pencil className="h-4 w-4" />
+                          </button>
+                          <button
+                            type="button"
+                            disabled={!canChange || isSubmitting}
+                            onClick={() => handleCancelOrder(order.order_id)}
+                            className="rounded p-1.5 text-[var(--foreground-muted)] hover:bg-red-100 hover:text-red-700 disabled:opacity-40 dark:hover:bg-red-900/30"
+                            aria-label={`cancel-${order.order_id}`}
+                          >
+                            <XCircle className="h-4 w-4" />
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Card>
+
+      {/* Confirm dialog for live trading */}
+      {confirmOpen && pendingOrderRequest && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+          <div className="w-full max-w-lg rounded-xl border border-[var(--border)] bg-[var(--background-secondary)] p-5 shadow-xl">
+            <div className="mb-3 flex items-center gap-2 text-red-600 dark:text-red-300">
+              <AlertTriangle className="h-5 w-5" />
+              <h3 className="font-semibold">{tPortfolio('orderConfirmTitle')}</h3>
+            </div>
+            <p className="text-sm text-[var(--foreground-muted)]">
+              {tPortfolio('orderConfirmLiveWarning')}
+            </p>
+            <div className="mt-4 rounded-lg border border-[var(--border)] p-3 text-sm">
+              <p>Broker: <span className="font-mono">{selectedBroker}</span></p>
+              <p>{tPortfolio('ticker')}: <span className="font-mono">{pendingOrderRequest.ticker}</span></p>
+              <p>{tPortfolio('orderSide')}: {pendingOrderRequest.side === 'BUY' ? tPortfolio('orderSideBuy') : tPortfolio('orderSideSell')}</p>
+              <p>{tPortfolio('orderQuantity')}: {pendingOrderRequest.quantity.toLocaleString(locale)}</p>
+              <p>{tPortfolio('orderType')}: {pendingOrderRequest.order_type === 'MARKET' ? tPortfolio('orderTypeMarket') : tPortfolio('orderTypeLimit')}</p>
+              <p>{tPortfolio('orderPrice')}: {pendingOrderRequest.order_type === 'MARKET' ? '-' : formatCurrency(pendingOrderRequest.price ?? null, 'USD')}</p>
+            </div>
+            <div className="mt-4 flex justify-end gap-2">
+              <Button
+                variant="outline"
+                onClick={() => {
+                  setConfirmOpen(false);
+                  setPendingOrderRequest(null);
+                }}
+              >
+                {tCommon('cancel')}
+              </Button>
+              <Button onClick={confirmRealOrder}>
+                {tCommon('confirm')}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Amend dialog */}
+      {amendTarget && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+          <div className="w-full max-w-md rounded-xl border border-[var(--border)] bg-[var(--background-secondary)] p-5 shadow-xl">
+            <h3 className="font-semibold text-[var(--foreground)]">{tPortfolio('orderAmendTitle')}</h3>
+            <p className="mt-1 text-sm text-[var(--foreground-muted)]">{amendTarget.order_id}</p>
+            <div className="mt-4 grid gap-3">
+              <input
+                type="number"
+                min={1}
+                value={amendQty}
+                onChange={(e) => setAmendQty(e.target.value)}
+                placeholder={tPortfolio('orderQuantity')}
+                className="rounded-lg border border-[var(--border)] bg-[var(--background-secondary)] px-3 py-2 text-sm"
+              />
+              <input
+                type="number"
+                min={0}
+                value={amendPrice}
+                onChange={(e) => setAmendPrice(e.target.value)}
+                placeholder={tPortfolio('orderPrice')}
+                className="rounded-lg border border-[var(--border)] bg-[var(--background-secondary)] px-3 py-2 text-sm"
+              />
+            </div>
+            <div className="mt-4 flex justify-end gap-2">
+              <Button variant="outline" onClick={() => setAmendTarget(null)}>
+                {tCommon('cancel')}
+              </Button>
+              <Button onClick={submitAmend} disabled={isSubmitting}>
+                {tCommon('save')}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Preload order status translations */}
+      <div className="sr-only">
+        {ORDER_STATUSES.map((status) => (
+          <span key={status}>{tPortfolio(`orderStatus_${status}`)}</span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/portfolio/index.ts
+++ b/web/src/components/portfolio/index.ts
@@ -5,3 +5,4 @@ export { default as DeleteConfirmModal } from './DeleteConfirmModal';
 export { default as SellSignalBanner } from './SellSignalBanner';
 export { default as CsvImportModal } from './CsvImportModal';
 export { default as OrderDesk } from './OrderDesk';
+export { default as BrokerOrderDesk } from './BrokerOrderDesk';

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -20,6 +20,10 @@ import type {
   KiwoomConditionMatch,
   KiwoomOrder,
   KiwoomOrderRequest,
+  BrokerConnectionStatus,
+  BrokerKillSwitchResult,
+  BrokerOrder,
+  BrokerOrderRequest,
 } from './types';
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
@@ -517,6 +521,73 @@ export async function triggerKiwoomKillSwitch(): Promise<void> {
   await fetchApi<void>('/api/kiwoom/orders/kill-switch', {
     method: 'POST',
   });
+}
+
+// Unified Broker API functions
+
+export async function listBrokers(): Promise<string[]> {
+  const data = await fetchApi<{ brokers: string[] }>('/api/brokers/');
+  return data.brokers;
+}
+
+export async function getBrokerConnectionStatus(
+  broker: string
+): Promise<BrokerConnectionStatus> {
+  return fetchApi<BrokerConnectionStatus>(
+    `/api/brokers/${encodeURIComponent(broker)}/status`
+  );
+}
+
+export async function placeBrokerOrder(
+  broker: string,
+  order: BrokerOrderRequest
+): Promise<BrokerOrder> {
+  return fetchApi<BrokerOrder>(
+    `/api/brokers/${encodeURIComponent(broker)}/orders`,
+    {
+      method: 'POST',
+      body: JSON.stringify(order),
+    }
+  );
+}
+
+export async function getBrokerOrders(broker: string): Promise<BrokerOrder[]> {
+  return fetchApi<BrokerOrder[]>(
+    `/api/brokers/${encodeURIComponent(broker)}/orders`
+  );
+}
+
+export async function cancelBrokerOrder(
+  broker: string,
+  orderId: string
+): Promise<void> {
+  await fetchApi<void>(
+    `/api/brokers/${encodeURIComponent(broker)}/orders/${encodeURIComponent(orderId)}`,
+    { method: 'DELETE' }
+  );
+}
+
+export async function amendBrokerOrder(
+  broker: string,
+  orderId: string,
+  amend: { quantity?: number; price?: number | null }
+): Promise<void> {
+  await fetchApi<void>(
+    `/api/brokers/${encodeURIComponent(broker)}/orders/${encodeURIComponent(orderId)}`,
+    {
+      method: 'PATCH',
+      body: JSON.stringify(amend),
+    }
+  );
+}
+
+export async function triggerBrokerKillSwitch(
+  broker: string
+): Promise<BrokerKillSwitchResult> {
+  return fetchApi<BrokerKillSwitchResult>(
+    `/api/brokers/${encodeURIComponent(broker)}/kill-switch`,
+    { method: 'POST' }
+  );
 }
 
 // Strategy API functions

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -270,3 +270,57 @@ export interface AnalysisStatus {
   };
   data_dir: string | null;
 }
+
+// Broker-agnostic types (unified broker router)
+export type BrokerOrderSide = 'BUY' | 'SELL';
+export type BrokerOrderType = 'MARKET' | 'LIMIT';
+export type BrokerOrderStatus =
+  | 'RECEIVED'
+  | 'CONFIRMED'
+  | 'PARTIAL'
+  | 'FILLED'
+  | 'CANCELED'
+  | 'REJECTED';
+export type BrokerConnectionState =
+  | 'connected'
+  | 'disconnected'
+  | 'connecting'
+  | 'unavailable';
+
+export interface BrokerOrderRequest {
+  ticker: string;
+  side: BrokerOrderSide;
+  quantity: number;
+  order_type: BrokerOrderType;
+  price?: number | null;
+  account_id?: string | null;
+}
+
+export interface BrokerOrder {
+  order_id: string;
+  broker: string;
+  ticker: string;
+  side: BrokerOrderSide;
+  quantity: number;
+  filled_quantity: number;
+  unfilled_quantity: number;
+  order_type: BrokerOrderType;
+  price: number | null;
+  filled_price: number | null;
+  status: BrokerOrderStatus;
+  created_at: string;
+  updated_at?: string | null;
+}
+
+export interface BrokerConnectionStatus {
+  broker: string;
+  status: BrokerConnectionState;
+  is_paper_trading: boolean | null;
+  accounts: string[];
+  updated_at: string | null;
+}
+
+export interface BrokerKillSwitchResult {
+  activated: boolean;
+  cancelled_orders: number;
+}


### PR DESCRIPTION
## Summary

- Add broker-agnostic API layer at `/api/brokers/{broker}/...` supporting any registered adapter (kiwoom, ibkr, tiger)
- Create `BrokerOrderDesk` frontend component with broker selector, connection status, order form, order list, and kill switch
- Add tabbed UI on portfolio page to switch between Unified Broker and Kiwoom (legacy) order desks
- Existing Kiwoom router preserved for Kiwoom-specific features (condition monitoring, WebSocket)

### Backend
| File | Description |
|------|-------------|
| `api/schemas/broker.py` | Pydantic schemas reusing `brokers.base` enums |
| `api/services/broker_service.py` | Thin wrapper around `BrokerRegistry` |
| `api/routers/broker.py` | 7 endpoints with exception→HTTP mapping |
| `tests/test_broker_router.py` | 31 test cases (all passing) |

### API Endpoints
| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/brokers/` | List registered brokers |
| GET | `/api/brokers/{broker}/status` | Connection status |
| POST | `/api/brokers/{broker}/orders` | Place order |
| GET | `/api/brokers/{broker}/orders` | List orders |
| DELETE | `/api/brokers/{broker}/orders/{id}` | Cancel order |
| PATCH | `/api/brokers/{broker}/orders/{id}` | Amend order |
| POST | `/api/brokers/{broker}/kill-switch` | Kill switch |

### Frontend
- Broker-agnostic TypeScript types and API functions (`types.ts`, `api.ts`)
- `BrokerOrderDesk.tsx` component with HTTP polling
- Portfolio page tabbed UI (Unified Broker / Kiwoom)
- i18n keys in en/ko/zh

## Test plan
- [x] `python -m pytest tests/test_broker_router.py -v` — 31/31 passed
- [x] Full test suite — no regressions (10 pre-existing failures unrelated)
- [x] TypeScript type check — no new errors
- [x] Codex code review — LGTM (medium: catch-all error messages fixed, auth noted for future)
- [ ] Manual: `curl http://localhost:8002/api/brokers/`
- [ ] Manual: Portfolio page → Unified Broker tab → verify BrokerOrderDesk renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)