### PR TITLE
feat(screening): redesign page with multi-universe, date selector, and guide cards

### DIFF
--- a/api/routers/screening.py
+++ b/api/routers/screening.py
@@ -106,7 +106,8 @@ def run_screening(request: ScreeningRequest) -> ScreeningResponse:
             preset=request.preset,
             universe=request.universe,
             universes=request.universes,
-            params=request.params
+            params=request.params,
+            reference_date=request.reference_date,
         )
 
         return ScreeningResponse(
@@ -115,6 +116,7 @@ def run_screening(request: ScreeningRequest) -> ScreeningResponse:
             matched_count=result["matched_count"],
             universe=request.universe,
             universes=request.universes,
+            reference_date=request.reference_date,
         )
 
     except ValueError as e:

--- a/api/schemas/screening.py
+++ b/api/schemas/screening.py
@@ -4,6 +4,7 @@ Screening API schemas.
 Pydantic models for stock screening request/response validation.
 """
 
+from datetime import date
 from typing import List, Optional, Dict, Any
 
 from pydantic import BaseModel, Field, model_validator
@@ -118,6 +119,10 @@ class ScreeningRequest(BaseModel):
         default_factory=list,
         description="Multi-market universes (backward-compatible with `universe`)",
     )
+    reference_date: Optional[date] = Field(
+        default=None,
+        description="Reference date for screening (defaults to today). Data is truncated at this date.",
+    )
     params: Optional[Dict[str, Any]] = Field(
         default=None,
         description="Optional parameters to override preset defaults"
@@ -183,6 +188,10 @@ class ScreeningResponse(BaseModel):
     universes: List[str] = Field(
         default_factory=list,
         description="Normalized universe list used by the request",
+    )
+    reference_date: Optional[date] = Field(
+        default=None,
+        description="Reference date used for screening",
     )
 
 

--- a/api/services/screening_service.py
+++ b/api/services/screening_service.py
@@ -7,6 +7,7 @@ Bridges the API layer with the screener module.
 
 import logging
 import time
+from datetime import date
 from typing import List, Dict, Any, Optional
 
 from api.schemas.screening import (
@@ -401,6 +402,7 @@ class ScreeningService:
         universe: Optional[str] = None,
         params: Optional[Dict[str, Any]] = None,
         universes: Optional[List[str]] = None,
+        reference_date: Optional[date] = None,
     ) -> Dict[str, Any]:
         """
         Run stock screening with the given preset and universe.
@@ -410,6 +412,7 @@ class ScreeningService:
             universe: Universe name (backward-compatible single value)
             params: Optional parameters to override preset defaults
             universes: Universe list (preferred for multi-market)
+            reference_date: Reference date for screening (defaults to today)
 
         Returns:
             Dict with results, total_count, matched_count, and resolved universes
@@ -458,6 +461,7 @@ class ScreeningService:
             use_full_universe=False,
             use_cache=True,
             stock_names=symbols_dict,
+            reference_date=reference_date,
         )
 
         # Run screening (show_progress=False for API)

--- a/api/tests/test_screening.py
+++ b/api/tests/test_screening.py
@@ -126,6 +126,7 @@ class TestRunScreening:
             universe="KOSPI",
             universes=["KOSPI"],
             params=None,
+            reference_date=None,
         )
 
     def test_run_screening_with_invalid_preset_returns_400(
@@ -201,6 +202,7 @@ class TestRunScreening:
             universe="KOSPI",
             universes=["KOSPI", "KOSDAQ"],
             params=None,
+            reference_date=None,
         )
 
     def test_run_screening_invalid_universe_uses_standard_message(
@@ -247,6 +249,7 @@ class TestRunScreening:
             universe="SP500",
             universes=["SP500", "NASDAQ100"],
             params=None,
+            reference_date=None,
         )
 
     def test_run_screening_with_mixed_universe_and_duplicates(self, client, mock_screening_service):
@@ -271,6 +274,7 @@ class TestRunScreening:
             universe="KOSPI",
             universes=["KOSPI", "SP500"],
             params=None,
+            reference_date=None,
         )
 
     def test_run_screening_with_params(self, client, mock_screening_service):

--- a/screener/stock_screener.py
+++ b/screener/stock_screener.py
@@ -26,7 +26,7 @@ Usage:
 
 from typing import Callable, List, Dict, Any, Optional
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 import time
 import pandas as pd
 import yfinance as yf
@@ -155,6 +155,7 @@ class StockScreener:
         request_delay: float = 0.2,
         use_cache: bool = True,
         stock_names: Optional[Dict[str, str]] = None,
+        reference_date: Optional[date] = None,
     ):
         """
         Args:
@@ -165,6 +166,8 @@ class StockScreener:
             use_cache: 데이터 캐시 사용 여부 (기본 True)
             stock_names: Pre-fetched {ticker: name} mapping to avoid
                          per-stock yfinance info calls (N+1 problem).
+            reference_date: Reference date for screening (defaults to today).
+                            Data is truncated at this date.
         """
         self.conditions: List[BaseCondition] = conditions or []
         self.max_workers = max_workers
@@ -175,6 +178,7 @@ class StockScreener:
         self._cache = get_cache() if self.use_cache else None
         self._stock_names: Dict[str, str] = stock_names or {}
         self._korean_names: Optional[Dict[str, str]] = None  # 한국어 종목명 캐시
+        self.reference_date: Optional[date] = reference_date
 
     def add_condition(self, condition: BaseCondition) -> "StockScreener":
         """조건 추가 (체이닝 지원)"""
@@ -233,9 +237,7 @@ class StockScreener:
             code = ticker.split('.')[0]
 
             # 최근 거래일 찾기
-            from datetime import date
-            today = date.today()
-            end_date = today
+            end_date = self.reference_date or date.today()
 
             start_date = end_date - timedelta(days=days * 2)
 
@@ -282,7 +284,16 @@ class StockScreener:
 
             stock = yf.Ticker(ticker)
             # 여유있게 데이터 가져오기 (주말/휴장일 고려)
-            data = stock.history(period=f"{days * 2}d")
+            if self.reference_date:
+                end_dt = self.reference_date
+                start_dt = end_dt - timedelta(days=days * 2)
+                # yfinance `end` is exclusive, so add 1 day to include the reference date
+                data = stock.history(
+                    start=start_dt.isoformat(),
+                    end=(end_dt + timedelta(days=1)).isoformat(),
+                )
+            else:
+                data = stock.history(period=f"{days * 2}d")
             if data.empty:
                 return None
 

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -140,6 +140,18 @@
     "noConditions": "No conditions to display",
     "yes": "Yes",
     "no": "No",
+    "stocks": "stocks",
+    "referenceDate": "Reference Date",
+    "resetToToday": "Reset to today",
+    "usingLatestData": "Using latest available data",
+    "latestData": "Latest",
+    "emptyGuideTitle": "Get started with stock screening",
+    "guideCreateStrategy": "Create a Strategy",
+    "guideCreateStrategyDesc": "Build custom screening conditions in the Strategy Builder, then run them here.",
+    "guideSelectUniverse": "Select Universes",
+    "guideSelectUniverseDesc": "Choose one or more markets — KOSPI, KOSDAQ, S&P 500, or NASDAQ 100.",
+    "guideRunScreening": "Run Screening",
+    "guideRunScreeningDesc": "Pick a preset or your saved strategy, then hit Run to find matching stocks.",
     "presetNames": {
       "deep_value_accumulation": "Deep Value Accumulation",
       "deep_value_accumulation_divergence": "Deep Value + Divergence"

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -140,6 +140,18 @@
     "noConditions": "표시할 조건이 없습니다",
     "yes": "예",
     "no": "아니오",
+    "stocks": "종목",
+    "referenceDate": "기준일",
+    "resetToToday": "오늘로 초기화",
+    "usingLatestData": "최신 데이터를 사용합니다",
+    "latestData": "최신",
+    "emptyGuideTitle": "종목 스크리닝 시작하기",
+    "guideCreateStrategy": "전략 만들기",
+    "guideCreateStrategyDesc": "전략 빌더에서 나만의 스크리닝 조건을 만들고 여기서 실행하세요.",
+    "guideSelectUniverse": "유니버스 선택",
+    "guideSelectUniverseDesc": "KOSPI, KOSDAQ, S&P 500, NASDAQ 100 중 하나 이상의 시장을 선택하세요.",
+    "guideRunScreening": "스크리닝 실행",
+    "guideRunScreeningDesc": "프리셋이나 저장된 전략을 선택한 후 실행 버튼을 눌러 조건에 맞는 종목을 찾으세요.",
     "presetNames": {
       "deep_value_accumulation": "딥 밸류 매집",
       "deep_value_accumulation_divergence": "딥 밸류 + 다이버전스"

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -140,6 +140,18 @@
     "noConditions": "无条件可显示",
     "yes": "是",
     "no": "否",
+    "stocks": "只股票",
+    "referenceDate": "基准日期",
+    "resetToToday": "重置为今天",
+    "usingLatestData": "使用最新可用数据",
+    "latestData": "最新",
+    "emptyGuideTitle": "开始股票筛选",
+    "guideCreateStrategy": "创建策略",
+    "guideCreateStrategyDesc": "在策略构建器中创建自定义筛选条件，然后在此运行。",
+    "guideSelectUniverse": "选择股票池",
+    "guideSelectUniverseDesc": "选择一个或多个市场——KOSPI、KOSDAQ、标普500或纳斯达克100。",
+    "guideRunScreening": "运行筛选",
+    "guideRunScreeningDesc": "选择一个预设或已保存的策略，然后点击运行以查找匹配的股票。",
     "presetNames": {
       "deep_value_accumulation": "深度价值吸筹",
       "deep_value_accumulation_divergence": "深度价值 + 背离"

--- a/web/src/app/[locale]/screening/page.tsx
+++ b/web/src/app/[locale]/screening/page.tsx
@@ -14,17 +14,20 @@ export default function ScreeningPage() {
   const t = useTranslations('screening');
   const [activeMode, setActiveMode] = useState<'preset' | 'condition'>('preset');
   const [selectedPreset, setSelectedPreset] = useState<string>('');
-  const [selectedUniverse, setSelectedUniverse] = useState<string>('');
+  const [selectedUniverses, setSelectedUniverses] = useState<string[]>(['KOSPI']);
+  const [referenceDate, setReferenceDate] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [results, setResults] = useState<ScreeningResult[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [stats, setStats] = useState<{
     total: number;
     matched: number;
+    universes: string[];
+    referenceDate: string | null;
   } | null>(null);
 
   const handleRunScreening = async () => {
-    if (!selectedPreset || !selectedUniverse) {
+    if (!selectedPreset || selectedUniverses.length === 0) {
       setError(t('selectPresetAndUniverse'));
       return;
     }
@@ -35,11 +38,13 @@ export default function ScreeningPage() {
     setStats(null);
 
     try {
-      const response = await runScreening(selectedPreset, selectedUniverse);
+      const response = await runScreening(selectedPreset, selectedUniverses, referenceDate);
       setResults(response.results);
       setStats({
         total: response.total_count,
         matched: response.matched_count,
+        universes: response.universes ?? selectedUniverses,
+        referenceDate: response.reference_date ?? referenceDate,
       });
     } catch (err) {
       console.error('Screening failed:', err);
@@ -98,10 +103,12 @@ export default function ScreeningPage() {
             <div className="lg:sticky lg:top-6 lg:self-start">
               <FilterPanel
                 selectedPreset={selectedPreset}
-                selectedUniverse={selectedUniverse}
+                selectedUniverses={selectedUniverses}
+                referenceDate={referenceDate}
                 isLoading={isLoading}
                 onPresetChange={setSelectedPreset}
-                onUniverseChange={setSelectedUniverse}
+                onUniverseChange={setSelectedUniverses}
+                onReferenceDateChange={setReferenceDate}
                 onRun={handleRunScreening}
               />
             </div>
@@ -116,9 +123,25 @@ export default function ScreeningPage() {
                 </div>
               )}
 
-              {/* Stats Bar */}
+              {/* Stats Bar with Universe/Date Badges */}
               {stats && (
-                <div className="flex flex-wrap items-center gap-4 rounded-lg border border-[var(--border)] bg-[var(--background-secondary)] px-4 py-3">
+                <div className="flex flex-wrap items-center gap-3 rounded-lg border border-[var(--border)] bg-[var(--background-secondary)] px-4 py-3">
+                  {/* Universe badges */}
+                  <div className="flex flex-wrap items-center gap-1.5">
+                    {stats.universes.map((universe) => (
+                      <span
+                        key={universe}
+                        className="inline-flex items-center rounded-full bg-[var(--color-primary)]/10 px-2.5 py-0.5 text-xs font-medium text-[var(--color-primary)]"
+                      >
+                        {universe}
+                      </span>
+                    ))}
+                  </div>
+                  {/* Reference date badge */}
+                  <span className="inline-flex items-center rounded-full bg-[var(--background)] border border-[var(--border)] px-2.5 py-0.5 text-xs text-[var(--foreground-muted)]">
+                    {stats.referenceDate ?? t('latestData')}
+                  </span>
+                  <div className="h-4 w-px bg-[var(--border)]" />
                   <div className="flex items-center gap-2">
                     <span className="text-sm text-[var(--foreground-muted)]">
                       {t('totalScreened')}

--- a/web/src/components/screening/DateSelector.tsx
+++ b/web/src/components/screening/DateSelector.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useCallback, useMemo } from 'react';
+import { RotateCcw } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+
+interface DateSelectorProps {
+  /** null means "today" (latest available data) */
+  value: string | null;
+  onChange: (date: string | null) => void;
+  disabled?: boolean;
+}
+
+function getTodayString(): string {
+  const now = new Date();
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, '0');
+  const d = String(now.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+export default function DateSelector({
+  value,
+  onChange,
+  disabled = false,
+}: DateSelectorProps) {
+  const t = useTranslations('screening');
+  const today = useMemo(() => getTodayString(), []);
+  const isToday = value === null;
+
+  const handleDateChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const newDate = e.target.value;
+      // If the selected date equals today, treat as null (latest)
+      onChange(newDate === today ? null : newDate || null);
+    },
+    [onChange, today]
+  );
+
+  const handleResetToToday = useCallback(() => {
+    onChange(null);
+  }, [onChange]);
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center gap-2">
+        <input
+          type="date"
+          value={value ?? today}
+          max={today}
+          onChange={handleDateChange}
+          disabled={disabled}
+          className="flex-1 rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)] focus:border-[var(--color-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/20 disabled:cursor-not-allowed disabled:opacity-50"
+        />
+        {!isToday && (
+          <button
+            type="button"
+            onClick={handleResetToToday}
+            disabled={disabled}
+            className="flex items-center gap-1 rounded-lg border border-[var(--border)] bg-[var(--background)] px-2.5 py-2 text-sm text-[var(--foreground-muted)] hover:text-[var(--foreground)] hover:border-[var(--color-primary)]/50 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+            title={t('resetToToday')}
+          >
+            <RotateCcw className="h-3.5 w-3.5" />
+          </button>
+        )}
+      </div>
+      {isToday && (
+        <p className="text-xs text-[var(--foreground-muted)]">
+          {t('usingLatestData')}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/screening/FilterPanel.tsx
+++ b/web/src/components/screening/FilterPanel.tsx
@@ -6,22 +6,28 @@ import { useTranslations } from 'next-intl';
 import { Button } from '@/components/ui';
 import { getPresets, getUniverses } from '@/lib/api';
 import type { PresetInfo, UniverseInfo } from '@/lib/types';
+import UniverseCheckboxGroup from './UniverseCheckboxGroup';
+import DateSelector from './DateSelector';
 
 interface FilterPanelProps {
   selectedPreset: string;
-  selectedUniverse: string;
+  selectedUniverses: string[];
+  referenceDate: string | null;
   isLoading: boolean;
   onPresetChange: (preset: string) => void;
-  onUniverseChange: (universe: string) => void;
+  onUniverseChange: (universes: string[]) => void;
+  onReferenceDateChange: (date: string | null) => void;
   onRun: () => void;
 }
 
 export default function FilterPanel({
   selectedPreset,
-  selectedUniverse,
+  selectedUniverses,
+  referenceDate,
   isLoading,
   onPresetChange,
   onUniverseChange,
+  onReferenceDateChange,
   onRun,
 }: FilterPanelProps) {
   const t = useTranslations('screening');
@@ -53,9 +59,6 @@ export default function FilterPanel({
         setLoadingUniverses(true);
         const data = await getUniverses();
         setUniverses(data);
-        if (data.length > 0 && !selectedUniverse) {
-          onUniverseChange(data[0].name);
-        }
       } catch (err) {
         console.error('Failed to load universes:', err);
         setError(t('failedToLoadUniverses'));
@@ -66,7 +69,7 @@ export default function FilterPanel({
 
     loadPresets();
     loadUniverses();
-  }, [onPresetChange, onUniverseChange, selectedPreset, selectedUniverse, t]);
+  }, [onPresetChange, selectedPreset, t]);
 
   const { staticPresets, customPresets } = useMemo(() => {
     const staticGroup = presets.filter((p) => p.source === 'static');
@@ -74,8 +77,16 @@ export default function FilterPanel({
     return { staticPresets: staticGroup, customPresets: customGroup };
   }, [presets]);
 
+  const stockCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const u of universes) {
+      counts[u.name] = u.stock_count;
+    }
+    return counts;
+  }, [universes]);
+
   const selectedPresetInfo = presets.find((p) => p.name === selectedPreset);
-  const canRun = selectedPreset && selectedUniverse && !isLoading;
+  const canRun = selectedPreset && selectedUniverses.length > 0 && !isLoading;
 
   return (
     <div className="rounded-lg border border-[var(--border)] bg-[var(--background-secondary)] p-6">
@@ -140,33 +151,33 @@ export default function FilterPanel({
           )}
         </div>
 
-        {/* Universe Selector */}
+        {/* Universe Multi-Select */}
         <div>
-          <label
-            htmlFor="universe-select"
-            className="mb-1.5 block text-sm font-medium text-[var(--foreground)]"
-          >
+          <label className="mb-1.5 block text-sm font-medium text-[var(--foreground)]">
             {t('universe')}
           </label>
-          <select
-            id="universe-select"
-            value={selectedUniverse}
-            onChange={(e) => onUniverseChange(e.target.value)}
-            disabled={loadingUniverses || isLoading}
-            className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[var(--foreground)] focus:border-[var(--color-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)] focus:ring-opacity-20 disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            {loadingUniverses ? (
-              <option value="">{t('loadingUniverses')}</option>
-            ) : universes.length === 0 ? (
-              <option value="">{t('noUniverses')}</option>
-            ) : (
-              universes.map((universe) => (
-                <option key={universe.name} value={universe.name}>
-                  {universe.name} ({universe.stock_count.toLocaleString()} stocks)
-                </option>
-              ))
-            )}
-          </select>
+          {loadingUniverses ? (
+            <p className="text-sm text-[var(--foreground-muted)]">{t('loadingUniverses')}</p>
+          ) : (
+            <UniverseCheckboxGroup
+              selectedUniverses={selectedUniverses}
+              onChange={onUniverseChange}
+              stockCounts={stockCounts}
+              disabled={isLoading}
+            />
+          )}
+        </div>
+
+        {/* Reference Date Selector */}
+        <div>
+          <label className="mb-1.5 block text-sm font-medium text-[var(--foreground)]">
+            {t('referenceDate')}
+          </label>
+          <DateSelector
+            value={referenceDate}
+            onChange={onReferenceDateChange}
+            disabled={isLoading}
+          />
         </div>
 
         {/* Conditions Preview */}

--- a/web/src/components/screening/ResultTable.tsx
+++ b/web/src/components/screening/ResultTable.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useMemo, useCallback } from 'react';
 import { useTranslations } from 'next-intl';
-import { ChevronDown, ChevronUp, CheckCircle, XCircle, Search, ArrowUpDown } from 'lucide-react';
+import { ChevronDown, ChevronUp, CheckCircle, XCircle, ArrowUpDown, Lightbulb, Globe, Play } from 'lucide-react';
 import type { ScreeningResult } from '@/lib/types';
 import ConditionDetails from './ConditionDetails';
 
@@ -117,18 +117,30 @@ export default function ResultTable({ results, isLoading }: ResultTableProps) {
     );
   }
 
-  // Empty state
+  // Empty state — quick-guide cards
   if (results.length === 0) {
     return (
-      <div className="rounded-lg border border-[var(--border)] bg-[var(--background-secondary)]">
-        <div className="flex h-64 flex-col items-center justify-center gap-4">
-          <Search className="h-12 w-12 text-[var(--foreground-muted)]" />
-          <div className="text-center">
-            <p className="font-medium text-[var(--foreground)]">{t('noResults')}</p>
-            <p className="mt-1 text-sm text-[var(--foreground-muted)]">
-              {t('noResultsDesc')}
-            </p>
-          </div>
+      <div className="rounded-lg border border-[var(--border)] bg-[var(--background-secondary)] p-6">
+        <p className="mb-4 text-center text-lg font-semibold text-[var(--foreground)]">
+          {t('emptyGuideTitle')}
+        </p>
+        <div className="grid gap-4 sm:grid-cols-3">
+          <GuideCard
+            icon={<Lightbulb className="h-6 w-6 text-amber-500" />}
+            title={t('guideCreateStrategy')}
+            description={t('guideCreateStrategyDesc')}
+            href="/strategy"
+          />
+          <GuideCard
+            icon={<Globe className="h-6 w-6 text-blue-500" />}
+            title={t('guideSelectUniverse')}
+            description={t('guideSelectUniverseDesc')}
+          />
+          <GuideCard
+            icon={<Play className="h-6 w-6 text-green-500" />}
+            title={t('guideRunScreening')}
+            description={t('guideRunScreeningDesc')}
+          />
         </div>
       </div>
     );
@@ -189,6 +201,31 @@ export default function ResultTable({ results, isLoading }: ResultTableProps) {
         ))}
       </div>
     </div>
+  );
+}
+
+interface GuideCardProps {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  href?: string;
+}
+
+function GuideCard({ icon, title, description, href }: GuideCardProps) {
+  const Wrapper = href ? 'a' : 'div';
+  return (
+    <Wrapper
+      {...(href ? { href } : {})}
+      className={`flex flex-col items-center gap-3 rounded-lg border border-[var(--border)] bg-[var(--background)] p-5 text-center transition-colors ${
+        href ? 'hover:border-[var(--color-primary)]/50 hover:bg-[var(--color-primary)]/5 cursor-pointer' : ''
+      }`}
+    >
+      {icon}
+      <div>
+        <p className="font-medium text-[var(--foreground)]">{title}</p>
+        <p className="mt-1 text-xs text-[var(--foreground-muted)]">{description}</p>
+      </div>
+    </Wrapper>
   );
 }
 

--- a/web/src/components/screening/UniverseCheckboxGroup.tsx
+++ b/web/src/components/screening/UniverseCheckboxGroup.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useCallback } from 'react';
+import { useTranslations } from 'next-intl';
+import {
+  SUPPORTED_UNIVERSES,
+  type SupportedUniverse,
+} from '@/lib/strategy/graphSerializer';
+
+interface UniverseCheckboxGroupProps {
+  selectedUniverses: string[];
+  onChange: (universes: string[]) => void;
+  stockCounts?: Record<string, number>;
+  disabled?: boolean;
+}
+
+export default function UniverseCheckboxGroup({
+  selectedUniverses,
+  onChange,
+  stockCounts,
+  disabled = false,
+}: UniverseCheckboxGroupProps) {
+  const t = useTranslations('screening');
+
+  const handleToggle = useCallback(
+    (universe: SupportedUniverse) => {
+      const exists = selectedUniverses.includes(universe);
+      if (exists) {
+        // Enforce "at least one selected"
+        if (selectedUniverses.length === 1) return;
+        onChange(selectedUniverses.filter((u) => u !== universe));
+      } else {
+        onChange([...selectedUniverses, universe]);
+      }
+    },
+    [selectedUniverses, onChange]
+  );
+
+  return (
+    <div className="space-y-1.5">
+      {SUPPORTED_UNIVERSES.map((universe) => {
+        const isSelected = selectedUniverses.includes(universe);
+        const count = stockCounts?.[universe];
+
+        return (
+          <label
+            key={universe}
+            className={`flex items-center gap-2.5 rounded-md border px-3 py-2 text-sm transition-colors cursor-pointer ${
+              isSelected
+                ? 'border-[var(--color-primary)] bg-[var(--color-primary)]/5 text-[var(--foreground)]'
+                : 'border-[var(--border)] bg-[var(--background)] text-[var(--foreground-muted)]'
+            } ${disabled ? 'cursor-not-allowed opacity-50' : 'hover:border-[var(--color-primary)]/50'}`}
+          >
+            <input
+              type="checkbox"
+              checked={isSelected}
+              onChange={() => handleToggle(universe)}
+              disabled={disabled}
+              className="rounded border-[var(--border)] text-[var(--color-primary)] focus:ring-[var(--color-primary)]/20"
+            />
+            <span className="flex-1 font-medium">{universe}</span>
+            {count !== undefined && (
+              <span className="text-xs text-[var(--foreground-muted)]">
+                {count.toLocaleString()} {t('stocks')}
+              </span>
+            )}
+          </label>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/src/components/screening/index.ts
+++ b/web/src/components/screening/index.ts
@@ -2,3 +2,5 @@ export { default as FilterPanel } from './FilterPanel';
 export { default as ResultTable } from './ResultTable';
 export { default as ConditionDetails } from './ConditionDetails';
 export { default as ConditionMonitorPanel } from './ConditionMonitorPanel';
+export { default as UniverseCheckboxGroup } from './UniverseCheckboxGroup';
+export { default as DateSelector } from './DateSelector';

--- a/web/src/hooks/useScreening.ts
+++ b/web/src/hooks/useScreening.ts
@@ -24,12 +24,14 @@ export function useRunScreening() {
   return useMutation({
     mutationFn: ({
       preset,
-      universe,
+      universes,
+      referenceDate,
       params,
     }: {
       preset: string;
-      universe: string;
+      universes: string[];
+      referenceDate?: string | null;
       params?: Record<string, unknown>;
-    }) => runScreening(preset, universe, params),
+    }) => runScreening(preset, universes, referenceDate, params),
   });
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -57,18 +57,20 @@ export async function getUniverses(): Promise<UniverseInfo[]> {
 }
 
 /**
- * Run screening with specified preset and universe
+ * Run screening with specified preset and universes
  */
 export async function runScreening(
   preset: string,
-  universe: string,
+  universes: string[],
+  referenceDate?: string | null,
   params?: Record<string, unknown>
 ): Promise<ScreeningResponse> {
   return fetchApi<ScreeningResponse>('/api/screening/run', {
     method: 'POST',
     body: JSON.stringify({
       preset,
-      universe,
+      universes,
+      reference_date: referenceDate ?? null,
       params,
     }),
   });

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -58,6 +58,8 @@ export interface ScreeningResponse {
   results: ScreeningResult[];
   total_count: number;
   matched_count: number;
+  universes?: string[];
+  reference_date?: string | null;
 }
 
 export interface KiwoomCondition {


### PR DESCRIPTION
## Summary

- **Multi-universe selection**: Replace single `<select>` dropdown with checkbox multi-select (`UniverseCheckboxGroup`) — KOSPI, KOSDAQ, S&P 500, NASDAQ 100
- **Reference date selector**: Add `DateSelector` component (native `<input type="date">`, no new deps) — defaults to "Today", supports custom date for historical screening
- **Empty state UX**: Replace blank Search icon with 3 actionable guide cards (Create Strategy → /strategy, Select Universes, Run Screening)
- **Stats bar badges**: Show universe badge chips + reference date ("Latest" or date string) after screening
- **Backend**: Thread `reference_date` from API → service → screener → data fetch (pykrx `end_date`, yfinance `start/end`)

### Files changed (17)

| Layer | Files |
|-------|-------|
| Backend | `api/schemas/screening.py`, `api/routers/screening.py`, `api/services/screening_service.py`, `screener/stock_screener.py`, `api/tests/test_screening.py` |
| Components | `UniverseCheckboxGroup.tsx` (new), `DateSelector.tsx` (new), `FilterPanel.tsx`, `ResultTable.tsx`, `index.ts` |
| Page/API | `screening/page.tsx`, `api.ts`, `types.ts`, `useScreening.ts` |
| i18n | `en.json`, `ko.json`, `zh.json` |

## Test plan

- [x] `npm run build` — passes (type check clean)
- [x] `npm run lint` — 0 errors on changed files
- [x] `pytest api/tests/test_screening.py` — 15/15 passed
- [ ] Manual: navigate to `/ko/screening`, verify multi-universe checkboxes render
- [ ] Manual: verify date selector with custom date + reset to today
- [ ] Manual: verify empty state guide cards render and "Create Strategy" links to `/strategy`
- [ ] Manual: run screening, verify stats bar shows universe badges + date

🤖 Generated with [Claude Code](https://claude.com/claude-code)