### PR TITLE
fix(i18n): resolve raw translation keys in screening/analysis (#903)

### DIFF
--- a/api/schemas/screening.py
+++ b/api/schemas/screening.py
@@ -68,6 +68,7 @@ class ConditionResultItem(BaseModel):
     """
 
     condition_name: str = Field(..., description="Name of the condition")
+    condition_key: str = Field(default="", description="Registry key for i18n lookup")
     matched: bool = Field(..., description="Whether the condition was satisfied")
     details: Dict[str, Any] = Field(
         default_factory=dict,

--- a/api/services/screening_service.py
+++ b/api/services/screening_service.py
@@ -90,7 +90,7 @@ class ScreeningService:
                 description = (preset_func.__doc__ or "").strip()
                 try:
                     condition_instances = preset_func()
-                    conditions = [c.name for c in condition_instances]
+                    conditions = [c.registry_key for c in condition_instances]
                 except Exception as e:
                     logger.warning(f"Failed to get conditions for preset {name}: {e}")
 
@@ -476,6 +476,7 @@ class ScreeningService:
             conditions_list = [
                 ConditionResultItem(
                     condition_name=cr.condition_name,
+                    condition_key=cr.condition_key,
                     matched=cr.matched,
                     details=cr.details
                 )
@@ -555,6 +556,7 @@ class ScreeningService:
         conditions_list = [
             ConditionResultItem(
                 condition_name=cr.condition_name,
+                condition_key=cr.condition_key,
                 matched=cr.matched,
                 details=cr.details
             )

--- a/screener/conditions/base.py
+++ b/screener/conditions/base.py
@@ -19,6 +19,7 @@ class ConditionResult:
     """조건 평가 결과"""
     matched: bool
     condition_name: str
+    condition_key: str = ""
     details: Dict[str, Any] = field(default_factory=dict)
     timestamp: str = field(default_factory=lambda: datetime.now().isoformat())
 
@@ -38,6 +39,11 @@ class BaseCondition(ABC):
     def name(self) -> str:
         """조건 이름"""
         pass
+
+    @property
+    def registry_key(self) -> str:
+        """Registry key for i18n lookup. Set by @register_condition decorator."""
+        return getattr(self.__class__, '_registry_key', self.name)
 
     @property
     @abstractmethod

--- a/screener/conditions/registry.py
+++ b/screener/conditions/registry.py
@@ -35,6 +35,7 @@ def register_condition(
     """Decorator to register a condition class with its metadata."""
 
     def decorator(cls: Type) -> Type:
+        cls._registry_key = key
         _CLASS_MAP[key] = cls
         _METADATA[key] = {
             "label": label,

--- a/screener/stock_screener.py
+++ b/screener/stock_screener.py
@@ -75,6 +75,7 @@ class ScreeningResult:
             "conditions": [
                 {
                     "name": r.condition_name,
+                    "condition_key": r.condition_key,
                     "matched": r.matched,
                     "details": r.details
                 }
@@ -364,6 +365,8 @@ class StockScreener:
 
         for condition in self.conditions:
             result = condition.evaluate(ticker, data)
+            if not result.condition_key:
+                result.condition_key = condition.registry_key
             results.append(result)
             if not result.matched:
                 all_matched = False

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -154,11 +154,39 @@
     "guideRunScreeningDesc": "Pick a preset or your saved strategy, then hit Run to find matching stocks.",
     "presetNames": {
       "deep_value_accumulation": "Deep Value Accumulation",
-      "deep_value_accumulation_divergence": "Deep Value + Divergence"
+      "deep_value_accumulation_divergence": "Deep Value + Divergence",
+      "ma_touch_160": "MA Touch 160D",
+      "ma_touch_120": "MA Touch 120D",
+      "ma_touch_200": "MA Touch 200D",
+      "oversold_bounce": "Oversold Bounce",
+      "golden_cross": "Golden Cross",
+      "dead_cross": "Dead Cross",
+      "volume_breakout": "Volume Breakout",
+      "ma_touch_with_oversold": "MA Touch + RSI Oversold",
+      "trend_following": "Trend Following",
+      "value_dip": "Value Dip",
+      "momentum_breakout": "Momentum Breakout",
+      "accumulation_basic": "Accumulation (Basic)",
+      "accumulation_obv": "Accumulation (OBV)",
+      "accumulation_full": "Accumulation (Full)"
     },
     "presetDescriptions": {
       "deep_value_accumulation": "Stocks down 50%+ from highs with accumulation signals (BB squeeze, low volume, price consolidation)",
-      "deep_value_accumulation_divergence": "Deep value accumulation with OBV/Stochastic/VPCI divergence confirmation"
+      "deep_value_accumulation_divergence": "Deep value accumulation with OBV/Stochastic/VPCI divergence confirmation",
+      "ma_touch_160": "Stocks touching 160-day moving average support",
+      "ma_touch_120": "Stocks touching 120-day moving average support",
+      "ma_touch_200": "Stocks touching 200-day moving average (long-term trend line)",
+      "oversold_bounce": "RSI oversold bounce strategy",
+      "golden_cross": "Short-term MA crossing above long-term MA",
+      "dead_cross": "Short-term MA crossing below long-term MA (short/liquidation)",
+      "volume_breakout": "Volume surge breakout strategy",
+      "ma_touch_with_oversold": "MA touch combined with RSI oversold signal",
+      "trend_following": "Trend following with MA alignment and momentum",
+      "value_dip": "Value investing dip buying strategy",
+      "momentum_breakout": "Momentum breakout with volume confirmation",
+      "accumulation_basic": "Quiet accumulation zone - basic (BB squeeze + low volume)",
+      "accumulation_obv": "Quiet accumulation zone with OBV divergence",
+      "accumulation_full": "Quiet accumulation zone - comprehensive (BB + OBV + divergence)"
     }
   },
   "portfolio": {

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -154,11 +154,39 @@
     "guideRunScreeningDesc": "프리셋이나 저장된 전략을 선택한 후 실행 버튼을 눌러 조건에 맞는 종목을 찾으세요.",
     "presetNames": {
       "deep_value_accumulation": "딥 밸류 매집",
-      "deep_value_accumulation_divergence": "딥 밸류 + 다이버전스"
+      "deep_value_accumulation_divergence": "딥 밸류 + 다이버전스",
+      "ma_touch_160": "160일선 터치",
+      "ma_touch_120": "120일선 터치",
+      "ma_touch_200": "200일선 터치",
+      "oversold_bounce": "과매도 반등",
+      "golden_cross": "골든크로스",
+      "dead_cross": "데드크로스",
+      "volume_breakout": "거래량 돌파",
+      "ma_touch_with_oversold": "이평선 터치 + RSI 과매도",
+      "trend_following": "추세 추종",
+      "value_dip": "가치 저점 매수",
+      "momentum_breakout": "모멘텀 돌파",
+      "accumulation_basic": "매집 구간 (기본)",
+      "accumulation_obv": "매집 구간 (OBV)",
+      "accumulation_full": "매집 구간 (종합)"
     },
     "presetDescriptions": {
       "deep_value_accumulation": "고점 대비 50% 이상 하락 후 매집 신호 (BB 수축, 거래량 감소, 가격 횡보)",
-      "deep_value_accumulation_divergence": "딥 밸류 매집 + OBV/Stochastic/VPCI 다이버전스 확인"
+      "deep_value_accumulation_divergence": "딥 밸류 매집 + OBV/Stochastic/VPCI 다이버전스 확인",
+      "ma_touch_160": "160일 이동평균선 지지 터치 종목",
+      "ma_touch_120": "120일 이동평균선 지지 터치 종목",
+      "ma_touch_200": "200일 이동평균선 (장기 추세선) 터치 종목",
+      "oversold_bounce": "RSI 과매도 반등 전략",
+      "golden_cross": "단기 이평선이 장기 이평선 상향 돌파",
+      "dead_cross": "단기 이평선이 장기 이평선 하향 돌파 (공매도/청산용)",
+      "volume_breakout": "거래량 급증 돌파 전략",
+      "ma_touch_with_oversold": "이평선 터치 + RSI 과매도 복합 신호",
+      "trend_following": "이평선 정배열 + 모멘텀 추세 추종",
+      "value_dip": "가치 투자 저점 매수 전략",
+      "momentum_breakout": "거래량 확인된 모멘텀 돌파",
+      "accumulation_basic": "조용한 매집 구간 — 기본 (볼린저 스퀴즈 + 저거래량)",
+      "accumulation_obv": "조용한 매집 구간 — OBV 다이버전스 확인",
+      "accumulation_full": "조용한 매집 구간 — 종합 (볼린저 + OBV + 다이버전스)"
     }
   },
   "portfolio": {

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -154,11 +154,39 @@
     "guideRunScreeningDesc": "选择一个预设或已保存的策略，然后点击运行以查找匹配的股票。",
     "presetNames": {
       "deep_value_accumulation": "深度价值吸筹",
-      "deep_value_accumulation_divergence": "深度价值 + 背离"
+      "deep_value_accumulation_divergence": "深度价值 + 背离",
+      "ma_touch_160": "160日均线触碰",
+      "ma_touch_120": "120日均线触碰",
+      "ma_touch_200": "200日均线触碰",
+      "oversold_bounce": "超卖反弹",
+      "golden_cross": "金叉",
+      "dead_cross": "死叉",
+      "volume_breakout": "放量突破",
+      "ma_touch_with_oversold": "均线触碰 + RSI超卖",
+      "trend_following": "趋势跟踪",
+      "value_dip": "价值低吸",
+      "momentum_breakout": "动量突破",
+      "accumulation_basic": "吸筹区间 (基础)",
+      "accumulation_obv": "吸筹区间 (OBV)",
+      "accumulation_full": "吸筹区间 (综合)"
     },
     "presetDescriptions": {
       "deep_value_accumulation": "从高点下跌50%以上并显示吸筹信号（布林带收窄、成交量萎缩、价格横盘）",
-      "deep_value_accumulation_divergence": "深度价值吸筹 + OBV/随机指标/VPCI背离确认"
+      "deep_value_accumulation_divergence": "深度价值吸筹 + OBV/随机指标/VPCI背离确认",
+      "ma_touch_160": "触碰160日均线支撑的股票",
+      "ma_touch_120": "触碰120日均线支撑的股票",
+      "ma_touch_200": "触碰200日均线（长期趋势线）的股票",
+      "oversold_bounce": "RSI超卖反弹策略",
+      "golden_cross": "短期均线上穿长期均线",
+      "dead_cross": "短期均线下穿长期均线（做空/平仓用）",
+      "volume_breakout": "放量突破策略",
+      "ma_touch_with_oversold": "均线触碰 + RSI超卖复合信号",
+      "trend_following": "均线多头排列 + 动量趋势跟踪",
+      "value_dip": "价值投资低吸策略",
+      "momentum_breakout": "成交量确认的动量突破",
+      "accumulation_basic": "安静吸筹区间 — 基础（布林带收缩 + 低成交量）",
+      "accumulation_obv": "安静吸筹区间 — OBV背离确认",
+      "accumulation_full": "安静吸筹区间 — 综合（布林带 + OBV + 背离）"
     }
   },
   "portfolio": {

--- a/web/src/app/[locale]/analysis/[ticker]/page.tsx
+++ b/web/src/app/[locale]/analysis/[ticker]/page.tsx
@@ -511,7 +511,7 @@ export default function TickerAnalysisPage() {
                 onClick={() => fetchData(selectedPeriod)}
               >
                 <RefreshCw className="h-4 w-4 mr-1.5" />
-                {t('refresh')}
+                {tCommon('refresh')}
               </Button>
               <Button
                 variant="outline"

--- a/web/src/components/screening/ConditionDetails.tsx
+++ b/web/src/components/screening/ConditionDetails.tsx
@@ -14,6 +14,7 @@ interface ConditionDetailsProps {
  */
 export default function ConditionDetails({ conditions }: ConditionDetailsProps) {
   const t = useTranslations('screening');
+  const tConditions = useTranslations('conditions');
 
   if (conditions.length === 0) {
     return (
@@ -50,7 +51,7 @@ export default function ConditionDetails({ conditions }: ConditionDetailsProps) 
                   : 'text-red-800 dark:text-red-200'
               }`}
             >
-              {condition.condition_name}
+              {condition.condition_key && tConditions.has(`${condition.condition_key}.label`) ? tConditions(`${condition.condition_key}.label`) : condition.condition_name}
             </span>
           </div>
 

--- a/web/src/components/screening/FilterPanel.tsx
+++ b/web/src/components/screening/FilterPanel.tsx
@@ -31,6 +31,7 @@ export default function FilterPanel({
   onRun,
 }: FilterPanelProps) {
   const t = useTranslations('screening');
+  const tConditions = useTranslations('conditions');
   const [presets, setPresets] = useState<PresetInfo[]>([]);
   const [universes, setUniverses] = useState<UniverseInfo[]>([]);
   const [loadingPresets, setLoadingPresets] = useState(true);
@@ -127,7 +128,7 @@ export default function FilterPanel({
                   <optgroup label={t('builtInPresets')}>
                     {staticPresets.map((preset) => (
                       <option key={preset.name} value={preset.name}>
-                        {preset.name}
+                        {t.has(`presetNames.${preset.name}`) ? t(`presetNames.${preset.name}`) : preset.description || preset.name}
                       </option>
                     ))}
                   </optgroup>
@@ -146,7 +147,7 @@ export default function FilterPanel({
           </select>
           {selectedPresetInfo && (
             <p className="mt-1.5 text-sm text-[var(--foreground-muted)]">
-              {selectedPresetInfo.description}
+              {t.has(`presetDescriptions.${selectedPresetInfo.name}`) ? t(`presetDescriptions.${selectedPresetInfo.name}`) : selectedPresetInfo.description}
             </p>
           )}
         </div>
@@ -190,7 +191,7 @@ export default function FilterPanel({
               {selectedPresetInfo.conditions.map((condition, index) => (
                 <li key={index} className="flex items-start gap-2">
                   <span className="text-[var(--color-primary)]">-</span>
-                  <span>{condition}</span>
+                  <span>{tConditions.has(`${condition}.label`) ? tConditions(`${condition}.label`) : condition}</span>
                 </li>
               ))}
             </ul>

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -42,6 +42,7 @@ export interface UniverseInfo {
 
 export interface ConditionResult {
   condition_name: string;
+  condition_key: string;
   matched: boolean;
   details: Record<string, unknown>;
 }


### PR DESCRIPTION
## Summary
- Fix `stockDetail.refresh` key using wrong i18n namespace (`t` → `tCommon`)
- Add `condition_key` field to backend `ConditionResult` for i18n lookup
- `@register_condition` decorator now injects `_registry_key` on condition classes
- Preset conditions return registry keys (i18n-compatible) instead of instance names
- FilterPanel displays translated preset names, descriptions, and condition labels
- ConditionDetails uses `condition_key` for translated labels with graceful fallback
- Add 14 missing preset translations (presetNames + presetDescriptions) to en/ko/zh

## Test plan
- [x] 29 screening API tests pass
- [x] TypeScript compilation (no new errors in modified files)
- [x] Codex review passed (2 issues found and fixed)
- [ ] Visual check: screening page preset dropdown shows translated names
- [ ] Visual check: condition list shows translated labels
- [ ] Visual check: analysis page refresh button displays correctly

Closes #903

🤖 Generated with [Claude Code](https://claude.com/claude-code)