### PR TITLE
feat(screening): enhance ConditionDetails with Stitch design

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -184,7 +184,14 @@
     "presetDescriptions": {
       "deep_value_accumulation": "Stocks down 50%+ from highs with accumulation signals (BB squeeze, low volume, price consolidation)",
       "deep_value_accumulation_divergence": "Deep value accumulation with OBV/Stochastic/VPCI divergence confirmation"
-    }
+    },
+    "conditionMatchSummary": "Match: {passed}/{total} ({rate}%)",
+    "actualValue": "Actual",
+    "targetValue": "Target",
+    "viewFullDetail": "View Full Detail",
+    "addToWatchlist": "Add to Watchlist",
+    "passLabel": "PASS",
+    "failLabel": "FAIL"
   },
   "portfolio": {
     "title": "Portfolio",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -184,7 +184,14 @@
     "presetDescriptions": {
       "deep_value_accumulation": "고점 대비 50% 이상 하락 후 매집 신호 (BB 수축, 거래량 감소, 가격 횡보)",
       "deep_value_accumulation_divergence": "딥 밸류 매집 + OBV/Stochastic/VPCI 다이버전스 확인"
-    }
+    },
+    "conditionMatchSummary": "매칭: {passed}/{total} ({rate}%)",
+    "actualValue": "실제값",
+    "targetValue": "기준값",
+    "viewFullDetail": "상세 분석 보기",
+    "addToWatchlist": "관심종목 추가",
+    "passLabel": "통과",
+    "failLabel": "미달"
   },
   "portfolio": {
     "title": "포트폴리오",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -184,7 +184,14 @@
     "presetDescriptions": {
       "deep_value_accumulation": "从高点下跌50%以上并显示吸筹信号（布林带收窄、成交量萎缩、价格横盘）",
       "deep_value_accumulation_divergence": "深度价值吸筹 + OBV/随机指标/VPCI背离确认"
-    }
+    },
+    "conditionMatchSummary": "匹配: {passed}/{total} ({rate}%)",
+    "actualValue": "实际值",
+    "targetValue": "目标值",
+    "viewFullDetail": "查看详细分析",
+    "addToWatchlist": "添加自选股",
+    "passLabel": "通过",
+    "failLabel": "未通过"
   },
   "portfolio": {
     "title": "投资组合",

--- a/web/src/components/screening/ConditionDetails.tsx
+++ b/web/src/components/screening/ConditionDetails.tsx
@@ -1,19 +1,59 @@
 'use client';
 
 import { useTranslations } from 'next-intl';
-import { CheckCircle, XCircle } from 'lucide-react';
+import { useLocale } from 'next-intl';
+import { CheckCircle2, XCircle, ExternalLink, Star } from 'lucide-react';
 import type { ConditionResult } from '@/lib/types';
 
 interface ConditionDetailsProps {
   /** List of condition results to display */
   conditions: ConditionResult[];
+  /** Ticker symbol for action buttons */
+  ticker?: string;
+}
+
+/** Keys to exclude when looking for the "actual" value in details */
+const THRESHOLD_KEY_PREFIXES = ['min_', 'max_'];
+const EXCLUDED_KEYS = ['error', 'timestamp', 'matched'];
+
+/**
+ * Extract the first numeric "actual" value from a condition's details map,
+ * ignoring threshold keys (min_*, max_*) and metadata keys.
+ */
+function extractActualValue(details: Record<string, unknown>): number | null {
+  for (const [key, value] of Object.entries(details)) {
+    if (EXCLUDED_KEYS.includes(key)) continue;
+    if (THRESHOLD_KEY_PREFIXES.some((p) => key.startsWith(p))) continue;
+    if (typeof value === 'number') return value;
+  }
+  return null;
 }
 
 /**
- * Displays detailed condition results with pass/fail indicators
+ * Extract threshold information from details (min_* or max_* keys).
+ * Returns { operator, value } or null.
  */
-export default function ConditionDetails({ conditions }: ConditionDetailsProps) {
+function extractThreshold(
+  details: Record<string, unknown>,
+): { operator: string; value: number } | null {
+  for (const [key, value] of Object.entries(details)) {
+    if (typeof value !== 'number') continue;
+    if (key.startsWith('min_')) return { operator: '\u2265', value }; // >=
+    if (key.startsWith('max_')) return { operator: '\u2264', value }; // <=
+  }
+  return null;
+}
+
+/**
+ * Displays detailed condition results with pass/fail indicators,
+ * a summary progress bar, and action buttons.
+ */
+export default function ConditionDetails({
+  conditions,
+  ticker,
+}: ConditionDetailsProps) {
   const t = useTranslations('screening');
+  const locale = useLocale();
 
   if (conditions.length === 0) {
     return (
@@ -23,59 +63,119 @@ export default function ConditionDetails({ conditions }: ConditionDetailsProps) 
     );
   }
 
-  return (
-    <div className="space-y-3">
-      {conditions.map((condition, index) => (
-        <div
-          key={`${condition.condition_name}-${index}`}
-          className={`
-            rounded-lg border p-3
-            ${
-              condition.matched
-                ? 'border-green-200 bg-green-50 dark:border-green-900 dark:bg-green-950'
-                : 'border-red-200 bg-red-50 dark:border-red-900 dark:bg-red-950'
-            }
-          `}
-        >
-          <div className="flex items-center gap-2">
-            {condition.matched ? (
-              <CheckCircle className="h-5 w-5 flex-shrink-0 text-green-600 dark:text-green-400" />
-            ) : (
-              <XCircle className="h-5 w-5 flex-shrink-0 text-red-600 dark:text-red-400" />
-            )}
-            <span
-              className={`font-medium ${
-                condition.matched
-                  ? 'text-green-800 dark:text-green-200'
-                  : 'text-red-800 dark:text-red-200'
-              }`}
-            >
-              {condition.condition_name}
-            </span>
-          </div>
+  const total = conditions.length;
+  const passed = conditions.filter((c) => c.matched).length;
+  const rate = Math.round((passed / total) * 100);
 
-          {Object.keys(condition.details).length > 0 && (
-            <div className="mt-2 ml-7">
-              <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
-                {Object.entries(condition.details).map(([key, value]) => (
-                  <div key={key} className="contents">
-                    <dt className="text-[var(--foreground-muted)]">{key}:</dt>
-                    <dd
-                      className={`font-mono ${
-                        condition.matched
-                          ? 'text-green-700 dark:text-green-300'
-                          : 'text-red-700 dark:text-red-300'
-                      }`}
-                    >
-                      {formatValue(value, t('yes'), t('no'))}
-                    </dd>
-                  </div>
-                ))}
-              </dl>
-            </div>
-          )}
+  function handleViewFullDetail() {
+    if (!ticker) return;
+    const width = 900;
+    const height = 700;
+    const left = Math.round(window.screenX + (window.outerWidth - width) / 2);
+    const top = Math.round(window.screenY + (window.outerHeight - height) / 2);
+    window.open(
+      `/${locale}/analysis/${ticker}?popup=true`,
+      `analysis_${ticker}`,
+      `width=${width},height=${height},left=${left},top=${top},resizable=yes,scrollbars=yes`,
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-[var(--border)] bg-[var(--background-secondary)] p-4">
+      {/* --- Summary bar --- */}
+      <div className="mb-4 flex items-center gap-3">
+        <span className="shrink-0 text-sm font-medium text-[var(--foreground)]">
+          {t('conditionMatchSummary', {
+            passed: String(passed),
+            total: String(total),
+            rate: String(rate),
+          })}
+        </span>
+        <div className="relative h-2 flex-1 overflow-hidden rounded-full bg-[var(--border)]">
+          <div
+            className="absolute inset-y-0 left-0 rounded-full bg-green-500 transition-all duration-300"
+            style={{ width: `${rate}%` }}
+          />
         </div>
-      ))}
+      </div>
+
+      {/* --- Condition rows --- */}
+      <div className="divide-y divide-[var(--border)]">
+        {conditions.map((condition, index) => {
+          const actual = extractActualValue(condition.details);
+          const threshold = extractThreshold(condition.details);
+
+          return (
+            <div
+              key={`${condition.condition_name}-${index}`}
+              className="flex items-center justify-between gap-3 py-2.5 first:pt-0 last:pb-0"
+            >
+              {/* Left: icon + name */}
+              <div className="flex min-w-0 items-center gap-2">
+                {condition.matched ? (
+                  <CheckCircle2 className="h-4 w-4 shrink-0 text-green-600 dark:text-green-400" />
+                ) : (
+                  <XCircle className="h-4 w-4 shrink-0 text-red-600 dark:text-red-400" />
+                )}
+                <span className="truncate text-sm font-medium text-[var(--foreground)]">
+                  {condition.condition_name}
+                </span>
+              </div>
+
+              {/* Center: actual vs threshold */}
+              <div className="hidden items-center gap-2 text-xs text-[var(--foreground-muted)] sm:flex">
+                {actual !== null && (
+                  <span className="font-mono">
+                    {t('actualValue')}: {formatValue(actual, t('yes'), t('no'))}
+                  </span>
+                )}
+                {actual !== null && threshold !== null && (
+                  <span className="text-[var(--border)]">/</span>
+                )}
+                {threshold !== null && (
+                  <span className="font-mono">
+                    {t('targetValue')}: {threshold.operator}{' '}
+                    {formatValue(threshold.value, t('yes'), t('no'))}
+                  </span>
+                )}
+              </div>
+
+              {/* Right: pass/fail badge */}
+              {condition.matched ? (
+                <span className="shrink-0 rounded-full bg-green-100 px-2 py-0.5 text-[10px] font-bold text-green-700 dark:bg-green-500/10 dark:text-green-400">
+                  {t('passLabel')}
+                </span>
+              ) : (
+                <span className="shrink-0 rounded-full bg-red-100 px-2 py-0.5 text-[10px] font-bold text-red-700 dark:bg-red-500/10 dark:text-red-400">
+                  {t('failLabel')}
+                </span>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* --- Action buttons --- */}
+      {ticker && (
+        <div className="mt-4 flex items-center gap-2 border-t border-[var(--border)] pt-3">
+          <button
+            type="button"
+            onClick={handleViewFullDetail}
+            className="inline-flex items-center gap-1.5 rounded-md border border-[var(--border)] px-3 py-1.5 text-xs font-medium text-[var(--foreground)] transition-colors hover:bg-[var(--background-hover)]"
+          >
+            <ExternalLink className="h-3.5 w-3.5" />
+            {t('viewFullDetail')}
+          </button>
+          <button
+            type="button"
+            disabled
+            className="inline-flex cursor-not-allowed items-center gap-1.5 rounded-md border border-[var(--border)] px-3 py-1.5 text-xs font-medium text-[var(--foreground-muted)] opacity-50"
+          >
+            <Star className="h-3.5 w-3.5" />
+            {t('addToWatchlist')}
+          </button>
+        </div>
+      )}
     </div>
   );
 }
@@ -83,7 +183,11 @@ export default function ConditionDetails({ conditions }: ConditionDetailsProps) 
 /**
  * Format a value for display
  */
-function formatValue(value: unknown, yesLabel: string, noLabel: string): string {
+function formatValue(
+  value: unknown,
+  yesLabel: string,
+  noLabel: string,
+): string {
   if (value === null || value === undefined) {
     return '-';
   }

--- a/web/src/components/screening/ResultTable.tsx
+++ b/web/src/components/screening/ResultTable.tsx
@@ -564,7 +564,7 @@ function TableRow({ result, rank, colCount = 9, isExpanded, onToggle, onOpen }: 
             colSpan={colCount}
             className="border-b border-[var(--border)] bg-[var(--background)] px-4 py-4"
           >
-            <ConditionDetails conditions={result.conditions} />
+            <ConditionDetails conditions={result.conditions} ticker={result.ticker} />
           </td>
         </tr>
       )}
@@ -635,7 +635,7 @@ function MobileCard({ result, rank, isExpanded, onToggle, onOpen }: RowProps) {
 
       {isExpanded && (
         <div className="mt-3">
-          <ConditionDetails conditions={result.conditions} />
+          <ConditionDetails conditions={result.conditions} ticker={result.ticker} />
         </div>
       )}
     </div>
@@ -674,7 +674,7 @@ function ResultDetailModal({ result, onClose }: ResultDetailModalProps) {
             </span>
             <ScoreBadge score={result.score} />
           </div>
-          <ConditionDetails conditions={result.conditions} />
+          <ConditionDetails conditions={result.conditions} ticker={result.ticker} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Rewrite `ConditionDetails` component to match Stitch design "Stock Row Condition Expansion Detail"
- Add **match rate summary bar** with progress indicator (e.g., "Match: 3/4 (75%)")
- Show **actual value vs threshold** comparison for each condition (e.g., "Actual: 8.42 / Target: <= 10.0")
- Add **PASS/FAIL pill badges** on each condition row
- Add **action buttons**: "View Full Detail" (opens analysis popup) + "Add to Watchlist" (placeholder)
- Pass `ticker` prop from `ResultTable` to `ConditionDetails` for action button links

## Changes
| Area | Files | What |
|------|-------|------|
| Component | `ConditionDetails.tsx` | Full rewrite with summary bar, value comparison, action buttons |
| Integration | `ResultTable.tsx` | Pass `ticker` prop to all 3 ConditionDetails usages |
| i18n | `{en,ko,zh}.json` | 7 new keys per locale |

## Test plan
- [x] `npm run build` — clean
- [x] `npx eslint` — 0 errors, 0 warnings
- [x] JSON validation — all 3 locale files valid
- [ ] Manual verification: expand screening result row → see enhanced conditions

Closes #916

🤖 Generated with [Claude Code](https://claude.com/claude-code)