### PR TITLE
fix(settings): persist language preference across sessions (#901)

### DIFF
--- a/web/src/app/[locale]/settings/page.tsx
+++ b/web/src/app/[locale]/settings/page.tsx
@@ -32,6 +32,9 @@ export default function SettingsPage() {
 
   const handleLocaleSave = () => {
     if (selectedLocale === locale) return;
+    // Set cookie so next-intl middleware remembers the preference on refresh
+    document.cookie = `NEXT_LOCALE=${selectedLocale}; path=/; max-age=31536000; SameSite=Lax`;
+    // Sync across tabs via localStorage
     window.localStorage.setItem(
       LOCALE_SYNC_KEY,
       JSON.stringify({ locale: selectedLocale })

--- a/web/src/components/layout/LocaleSwitcher.tsx
+++ b/web/src/components/layout/LocaleSwitcher.tsx
@@ -27,6 +27,9 @@ export default function LocaleSwitcher({ variant = 'default' }: LocaleSwitcherPr
   const nextLocale = localeOrder[(currentIndex + 1) % localeOrder.length];
 
   const handleSwitch = () => {
+    // Set cookie so next-intl middleware remembers the preference on refresh
+    document.cookie = `NEXT_LOCALE=${nextLocale}; path=/; max-age=31536000; SameSite=Lax`;
+    // Sync across tabs via localStorage
     window.localStorage.setItem(
       LOCALE_SYNC_KEY,
       JSON.stringify({ locale: nextLocale })

--- a/web/src/i18n/routing.ts
+++ b/web/src/i18n/routing.ts
@@ -3,7 +3,6 @@ import { defineRouting } from 'next-intl/routing';
 export const routing = defineRouting({
   locales: ['en', 'ko', 'zh'],
   defaultLocale: 'en',
-  localeDetection: false,
 });
 
 export type Locale = (typeof routing.locales)[number];


### PR DESCRIPTION
## Summary
- Remove `localeDetection: false` from next-intl routing config — this was disabling cookie-based locale detection in the proxy middleware, causing language preferences to be lost on page refresh
- Set `NEXT_LOCALE` cookie explicitly when user changes locale in Settings page and LocaleSwitcher — ensures the preference takes effect immediately without waiting for a middleware round-trip

## Root Cause
`localeDetection: false` in `defineRouting()` disables **both** `Accept-Language` header and `NEXT_LOCALE` cookie detection. With this disabled, the proxy middleware only used the URL prefix to determine locale, so visiting `/` always redirected to `/en/` regardless of stored preference.

## Test plan
- [x] `npm run build` — clean
- [x] `npx eslint` on changed files — clean  
- [x] `curl -b "NEXT_LOCALE=ko" http://localhost:3001/` → 307 redirect to `/ko` 
- [x] `curl -b "NEXT_LOCALE=zh" http://localhost:3001/` → 307 redirect to `/zh`
- [x] `curl http://localhost:3001/` (no cookie) → 307 redirect to `/en` + sets `NEXT_LOCALE=en` cookie

Closes #901

🤖 Generated with [Claude Code](https://claude.com/claude-code)