### PR TITLE
Fix raw i18n key rendering in analysis and screening

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -544,6 +544,7 @@
     "loadFailed": "Failed to Load Data",
     "noChartData": "No chart data available",
     "retry": "Retry",
+    "refresh": "Refresh",
     "loadingConditions": "Loading conditions...",
     "aiDescription": "AI-powered analysis with valuation score, risk assessment, and entry recommendation.",
     "low": "Low",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -544,6 +544,7 @@
     "loadFailed": "데이터 로드 실패",
     "noChartData": "차트 데이터가 없습니다",
     "retry": "다시 시도",
+    "refresh": "새로고침",
     "loadingConditions": "조건 로딩 중...",
     "aiDescription": "밸류에이션 점수, 리스크 평가, 진입 추천을 포함한 AI 기반 분석입니다.",
     "low": "최저",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -544,6 +544,7 @@
     "loadFailed": "数据加载失败",
     "noChartData": "没有图表数据",
     "retry": "重试",
+    "refresh": "刷新",
     "loadingConditions": "正在加载条件...",
     "aiDescription": "基于 AI 的分析，包含估值评分、风险评估和入场建议。",
     "low": "最低",

--- a/web/src/app/[locale]/analysis/[ticker]/page.tsx
+++ b/web/src/app/[locale]/analysis/[ticker]/page.tsx
@@ -57,7 +57,11 @@ const LOCALE_SYNC_KEY = 'quant-investment:locale-sync';
 
 function toTitleCaseFromKey(value: string): string {
   return value
+    .replace(/^screening\.presetNames\./, '')
+    .replace(/^conditions\./, '')
+    .replace(/^custom:/, '')
     .replace(/_/g, ' ')
+    .replace(/\./g, ' ')
     .replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
@@ -825,11 +829,14 @@ export default function TickerAnalysisPage() {
                   {presets.map((p) => (
                     <option key={p.name} value={p.name}>
                       {(() => {
-                        try {
-                          return `${tScreening(`presetNames.${p.name}` as never)} (${p.conditions.length})`;
-                        } catch {
-                          return `${toTitleCaseFromKey(p.name)} (${p.conditions.length})`;
+                        const key = `presetNames.${p.name}`;
+                        if (tScreening.has(key)) {
+                          return `${tScreening(key as never)} (${p.conditions.length})`;
                         }
+                        const fallback = p.name.startsWith('custom:')
+                          ? p.description || toTitleCaseFromKey(p.name)
+                          : toTitleCaseFromKey(p.name);
+                        return `${fallback} (${p.conditions.length})`;
                       })()}
                     </option>
                   ))}
@@ -892,11 +899,10 @@ export default function TickerAnalysisPage() {
                             {getConditionIcon(condition)}
                             <span className="text-sm text-[var(--foreground)]">
                               {(() => {
-                                try {
-                                  return tConditions(`${condition.condition_name}.label` as never);
-                                } catch {
-                                  return toTitleCaseFromKey(condition.condition_name);
-                                }
+                                const key = `${condition.condition_name}.label`;
+                                return tConditions.has(key)
+                                  ? tConditions(key as never)
+                                  : toTitleCaseFromKey(condition.condition_name);
                               })()}
                             </span>
                           </div>

--- a/web/src/components/screening/ConditionDetails.tsx
+++ b/web/src/components/screening/ConditionDetails.tsx
@@ -53,6 +53,7 @@ export default function ConditionDetails({
   ticker,
 }: ConditionDetailsProps) {
   const t = useTranslations('screening');
+  const tConditions = useTranslations('conditions');
   const locale = useLocale();
 
   if (conditions.length === 0) {
@@ -104,6 +105,13 @@ export default function ConditionDetails({
         {conditions.map((condition, index) => {
           const actual = extractActualValue(condition.details);
           const threshold = extractThreshold(condition.details);
+          const conditionI18nKey = `${condition.condition_name}.label`;
+          const conditionLabel = tConditions.has(conditionI18nKey)
+            ? tConditions(conditionI18nKey as never)
+            : condition.condition_name
+                .replace(/_/g, ' ')
+                .replace(/\./g, ' ')
+                .replace(/\b\w/g, (char) => char.toUpperCase());
 
           return (
             <div
@@ -118,7 +126,7 @@ export default function ConditionDetails({
                   <XCircle className="h-4 w-4 shrink-0 text-red-600 dark:text-red-400" />
                 )}
                 <span className="truncate text-sm font-medium text-[var(--foreground)]">
-                  {condition.condition_name}
+                  {conditionLabel}
                 </span>
               </div>
 

--- a/web/src/components/screening/FilterPanel.tsx
+++ b/web/src/components/screening/FilterPanel.tsx
@@ -31,6 +31,7 @@ export default function FilterPanel({
   onRun,
 }: FilterPanelProps) {
   const t = useTranslations('screening');
+  const tConditions = useTranslations('conditions');
   const [presets, setPresets] = useState<PresetInfo[]>([]);
   const [universes, setUniverses] = useState<UniverseInfo[]>([]);
   const [loadingPresets, setLoadingPresets] = useState(true);
@@ -88,6 +89,28 @@ export default function FilterPanel({
   const selectedPresetInfo = presets.find((p) => p.name === selectedPreset);
   const canRun = selectedPreset && selectedUniverses.length > 0 && !isLoading;
 
+  const toTitleCaseFromKey = (value: string) =>
+    value
+      .replace(/^screening\.presetNames\./, '')
+      .replace(/^conditions\./, '')
+      .replace(/^custom:/, '')
+      .replace(/_/g, ' ')
+      .replace(/\./g, ' ')
+      .replace(/\b\w/g, (char) => char.toUpperCase());
+
+  const presetLabel = (preset: PresetInfo): string => {
+    const i18nKey = `presetNames.${preset.name}`;
+    if (t.has(i18nKey)) return t(i18nKey as never);
+    if (preset.source === 'custom') return preset.description || toTitleCaseFromKey(preset.name);
+    return toTitleCaseFromKey(preset.name);
+  };
+
+  const conditionLabel = (condition: string): string => {
+    const i18nKey = `${condition}.label`;
+    if (tConditions.has(i18nKey)) return tConditions(i18nKey as never);
+    return toTitleCaseFromKey(condition);
+  };
+
   return (
     <div className="rounded-lg border border-[var(--border)] bg-[var(--background-secondary)] p-6">
       <h2 className="mb-4 text-lg font-semibold text-[var(--foreground)]">
@@ -127,7 +150,7 @@ export default function FilterPanel({
                   <optgroup label={t('builtInPresets')}>
                     {staticPresets.map((preset) => (
                       <option key={preset.name} value={preset.name}>
-                        {preset.name}
+                        {presetLabel(preset)}
                       </option>
                     ))}
                   </optgroup>
@@ -136,7 +159,7 @@ export default function FilterPanel({
                   <optgroup label={t('myStrategies')}>
                     {customPresets.map((preset) => (
                       <option key={preset.name} value={preset.name}>
-                        {preset.description}
+                        {presetLabel(preset)}
                       </option>
                     ))}
                   </optgroup>
@@ -190,7 +213,7 @@ export default function FilterPanel({
               {selectedPresetInfo.conditions.map((condition, index) => (
                 <li key={index} className="flex items-start gap-2">
                   <span className="text-[var(--color-primary)]">-</span>
-                  <span>{condition}</span>
+                  <span>{conditionLabel(condition)}</span>
                 </li>
               ))}
             </ul>


### PR DESCRIPTION
## Summary
- replace try/catch-based translation fallback with explicit `t.has(...)` checks in ticker analysis strategy context
- add robust fallback labels for screening preset/condition names in `FilterPanel`
- translate condition names in screening `ConditionDetails` with `conditions.*.label` fallback
- add missing `stockDetail.refresh` keys to `en/ko/zh` messages

## Test plan
- [x] `cd web && npm run lint -- \"src/app/[locale]/analysis/[ticker]/page.tsx\" \"src/components/screening/FilterPanel.tsx\" \"src/components/screening/ConditionDetails.tsx\"`