### PR TITLE
[Infra] Standardize shared Docker DB setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,9 +6,20 @@ API_HOST=0.0.0.0
 API_PORT=8000
 DEBUG=false
 
-# Database (SQLite by default, zero-config)
+# Docker Compose project name (keeps service/volume naming stable)
+COMPOSE_PROJECT_NAME=quant-investment
+
+# Shared DB (PostgreSQL via Docker)
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=quant
+DB_USER=quant
+DB_PASSWORD=quant
+
+# App DB connection
+# - Default: SQLite (zero-config local)
 DATABASE_URL=sqlite:///data/quant.db
-# For PostgreSQL (via Docker):
+# - Shared Docker DB (recommended for team/common data)
 # DATABASE_URL=postgresql://quant:quant@localhost:5432/quant
 
 # CORS - allowed frontend origins (must match your frontend URL)

--- a/README.md
+++ b/README.md
@@ -58,6 +58,49 @@ cd web && PORT=3002 npm run dev
 - Web UI: `http://localhost:3002`
 - API Docs: `http://localhost:8002/docs`
 
+## Shared DB via Docker (Location/Port Independent)
+
+Use this when you want one persistent local DB regardless of where you run API/web.
+
+### 1) Configure env
+
+```bash
+cp .env.example .env
+```
+
+Set these in `.env`:
+- `DB_PORT` (default `5432`, change if conflict)
+- `DB_NAME`, `DB_USER`, `DB_PASSWORD`
+- `DATABASE_URL=postgresql://<DB_USER>:<DB_PASSWORD>@localhost:<DB_PORT>/<DB_NAME>`
+
+### 2) Start DB only
+
+```bash
+docker compose up -d db
+docker compose ps db
+```
+
+The DB data is persisted in named volume `quant-investment-pgdata`.
+
+### 3) Initialize schema/migrations entrypoint
+
+```bash
+source venv/bin/activate
+python -c "from api.database import init_db; init_db()"
+```
+
+### 4) Port conflict policy
+
+If `5432` is already in use, set:
+- `DB_PORT=55432` in `.env`
+- update `DATABASE_URL` to use `55432`
+
+Then restart DB:
+
+```bash
+docker compose up -d db
+```
+
 ## Core Workflows
 
 ### Workflow A: Build And Execute A Strategy

--- a/README_KO.md
+++ b/README_KO.md
@@ -58,6 +58,49 @@ cd web && PORT=3002 npm run dev
 - Web UI: `http://localhost:3002`
 - API 문서: `http://localhost:8002/docs`
 
+## Docker 공용 DB (실행 위치/포트 독립)
+
+API/Web를 어디서 실행해도 동일한 로컬 DB를 쓰고 싶을 때 사용합니다.
+
+### 1) env 설정
+
+```bash
+cp .env.example .env
+```
+
+`.env`에서 아래 값을 설정하세요.
+- `DB_PORT` (기본 `5432`, 충돌 시 변경)
+- `DB_NAME`, `DB_USER`, `DB_PASSWORD`
+- `DATABASE_URL=postgresql://<DB_USER>:<DB_PASSWORD>@localhost:<DB_PORT>/<DB_NAME>`
+
+### 2) DB만 기동
+
+```bash
+docker compose up -d db
+docker compose ps db
+```
+
+데이터는 named volume `quant-investment-pgdata`에 영속 저장됩니다.
+
+### 3) 스키마 초기화(마이그레이션 진입점)
+
+```bash
+source venv/bin/activate
+python -c "from api.database import init_db; init_db()"
+```
+
+### 4) 포트 충돌 정책
+
+`5432`가 이미 사용 중이면:
+- `.env`에서 `DB_PORT=55432`
+- `DATABASE_URL`도 `55432`로 변경
+
+이후 DB 재기동:
+
+```bash
+docker compose up -d db
+```
+
 ## 핵심 작업 시나리오
 
 ### 시나리오 A: 전략 생성 후 실행

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,21 @@
 services:
-  postgres:
+  db:
     image: postgres:16-alpine
-    container_name: quant-postgres
+    container_name: quant-db
     ports:
-      - "5432:5432"
+      - "${DB_PORT:-5432}:5432"
     environment:
-      POSTGRES_USER: quant
-      POSTGRES_PASSWORD: quant
-      POSTGRES_DB: quant
+      POSTGRES_USER: ${DB_USER:-quant}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-quant}
+      POSTGRES_DB: ${DB_NAME:-quant}
     volumes:
       - pgdata:/var/lib/postgresql/data
+    env_file:
+      - path: .env
+        required: false
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U quant"]
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-quant} -d ${DB_NAME:-quant}"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -33,12 +36,12 @@ services:
       - API_HOST=0.0.0.0
       - API_PORT=8000
       - DEBUG=false
-      - DATABASE_URL=postgresql://quant:quant@postgres:5432/quant
+      - DATABASE_URL=postgresql://${DB_USER:-quant}:${DB_PASSWORD:-quant}@db:5432/${DB_NAME:-quant}
     env_file:
       - path: .env
         required: false
     depends_on:
-      postgres:
+      db:
         condition: service_healthy
     restart: unless-stopped
     healthcheck:
@@ -65,6 +68,7 @@ services:
 
 volumes:
   pgdata:
+    name: quant-investment-pgdata
 
 networks:
   default:


### PR DESCRIPTION
## Summary
- standardize Compose DB service as `db` with env-driven credentials and host-port override (`DB_PORT`)
- use a fixed named volume (`quant-investment-pgdata`) so DB data persists across restarts/recreates
- document shared DB workflow in `README.md`/`README_KO.md` including schema init entrypoint and port-conflict policy
- add root `.env.example` defaults for DB_HOST/DB_PORT/DB_NAME/DB_USER/DB_PASSWORD and compose project name

## Verification
- `docker compose config`

Closes #509