### PR TITLE
feat(screening): integrate strategy sample presets into screening page

### DIFF
--- a/api/routers/screening.py
+++ b/api/routers/screening.py
@@ -118,6 +118,7 @@ def run_screening(request: ScreeningRequest) -> ScreeningResponse:
             universes=request.universes,
             params=request.params,
             reference_date=request.reference_date,
+            graph=request.graph,
         )
 
         return ScreeningResponse(
@@ -188,6 +189,7 @@ def run_screening_stream(request: ScreeningRequest):
                 params=request.params,
                 reference_date=request.reference_date,
                 progress_callback=_progress_cb,
+                graph=request.graph,
             )
             if cancel_event.is_set():
                 return

--- a/api/schemas/screening.py
+++ b/api/schemas/screening.py
@@ -135,6 +135,10 @@ class ScreeningRequest(BaseModel):
         default=None,
         description="Optional parameters to override preset defaults"
     )
+    graph: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="Inline strategy graph for sample: presets (StrategyGraph shape)",
+    )
 
     @model_validator(mode="before")
     @classmethod
@@ -236,7 +240,7 @@ class PresetInfo(BaseModel):
         default_factory=list,
         description="List of condition names"
     )
-    source: str = Field(default="static", description="'static' or 'custom'")
+    source: str = Field(default="static", description="'static', 'custom', or 'sample'")
 
 
 class UniverseInfo(BaseModel):

--- a/api/services/screening_service.py
+++ b/api/services/screening_service.py
@@ -374,8 +374,23 @@ class ScreeningService:
         self._universe_combo_count_cache[cache_key] = (time.time(), count)
         return count
 
-    def _resolve_conditions(self, preset: str, params: Optional[Dict[str, Any]] = None) -> list:
-        """Resolve conditions from a static preset or custom strategy."""
+    def _resolve_conditions(self, preset: str, params: Optional[Dict[str, Any]] = None, graph=None) -> list:
+        """Resolve conditions from a static preset, custom strategy, or sample graph."""
+        if preset.startswith("sample:"):
+            from api.services.strategy_service import build_conditions_from_graph
+            from api.schemas.strategy import StrategyGraph as StrategyGraphModel
+
+            if graph is None:
+                raise ValueError("graph payload is required for sample: presets")
+            if isinstance(graph, dict):
+                if len(graph.get("nodes", [])) > 50 or len(graph.get("edges", [])) > 100:
+                    raise ValueError("Sample graph too large (max 50 nodes, 100 edges)")
+                graph = StrategyGraphModel(**graph)
+            cond_list, _ = build_conditions_from_graph(graph)
+            if not cond_list:
+                raise ValueError("No conditions in sample strategy graph")
+            return cond_list
+
         if preset.startswith("custom:"):
             strategy_id = preset[len("custom:"):]
             from api.services.strategy_save_service import get_strategy_save_service
@@ -407,22 +422,24 @@ class ScreeningService:
         universes: Optional[List[str]] = None,
         reference_date: Optional[date] = None,
         progress_callback: Optional[Callable[[int, int, int], None]] = None,
+        graph=None,
     ) -> Dict[str, Any]:
         """
         Run stock screening with the given preset and universe.
 
         Args:
-            preset: Preset name (static name or 'custom:{strategy_id}')
+            preset: Preset name (static name, 'custom:{strategy_id}', or 'sample:{name}')
             universe: Universe name (backward-compatible single value)
             params: Optional parameters to override preset defaults
             universes: Universe list (preferred for multi-market)
             reference_date: Reference date for screening (defaults to today)
+            graph: Inline strategy graph for sample: presets
 
         Returns:
             Dict with results, total_count, matched_count, and resolved universes
         """
         started_at = time.perf_counter()
-        conditions = self._resolve_conditions(preset, params)
+        conditions = self._resolve_conditions(preset, params, graph=graph)
 
         requested_universes: Any = universes if universes is not None else universe
 

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -106,6 +106,7 @@
     "noUniverses": "No universes available",
     "builtInPresets": "Built-in Presets",
     "myStrategies": "My Strategies",
+    "sampleStrategies": "Strategy Samples",
     "failedToLoadPresets": "Failed to load presets",
     "failedToLoadUniverses": "Failed to load universes",
     "presetTab": "Preset Screening",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -106,6 +106,7 @@
     "noUniverses": "사용 가능한 유니버스가 없습니다",
     "builtInPresets": "기본 프리셋",
     "myStrategies": "내 전략",
+    "sampleStrategies": "샘플 전략",
     "failedToLoadPresets": "프리셋 로드 실패",
     "failedToLoadUniverses": "유니버스 로드 실패",
     "presetTab": "프리셋 스크리닝",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -106,6 +106,7 @@
     "noUniverses": "暂无可用股票池",
     "builtInPresets": "内置预设",
     "myStrategies": "我的策略",
+    "sampleStrategies": "策略样本",
     "failedToLoadPresets": "加载预设失败",
     "failedToLoadUniverses": "加载股票池失败",
     "presetTab": "预设筛选",

--- a/web/src/app/[locale]/screening/page.tsx
+++ b/web/src/app/[locale]/screening/page.tsx
@@ -32,6 +32,7 @@ export default function ScreeningPage() {
     elapsedMs: number | null;
   } | null>(null);
   const [saveDialogOpen, setSaveDialogOpen] = useState(false);
+  const [selectedGraph, setSelectedGraph] = useState<Record<string, unknown> | null>(null);
 
   const handleRunScreening = async () => {
     if (!selectedPreset || selectedUniverses.length === 0) {
@@ -97,7 +98,7 @@ export default function ScreeningPage() {
               }
         );
       },
-    });
+    }, selectedGraph);
   };
 
   const handleLoadSavedResult = (data: {
@@ -123,6 +124,7 @@ export default function ScreeningPage() {
     });
     setProgress(null);
     setError(null);
+    setSelectedGraph(null);
     setActiveMode('preset');
   };
 
@@ -189,6 +191,7 @@ export default function ScreeningPage() {
                 onUniverseChange={setSelectedUniverses}
                 onReferenceDateChange={setReferenceDate}
                 onRun={handleRunScreening}
+                onGraphChange={setSelectedGraph}
               />
             </div>
 

--- a/web/src/components/screening/FilterPanel.tsx
+++ b/web/src/components/screening/FilterPanel.tsx
@@ -6,6 +6,7 @@ import { useTranslations } from 'next-intl';
 import { Button } from '@/components/ui';
 import { getPresets, getUniverses } from '@/lib/api';
 import type { PresetInfo, UniverseInfo } from '@/lib/types';
+import { SAMPLE_STRATEGY_PRESETS } from '@/lib/strategy/sampleStrategies';
 import UniverseCheckboxGroup from './UniverseCheckboxGroup';
 import DateSelector from './DateSelector';
 
@@ -18,6 +19,7 @@ interface FilterPanelProps {
   onUniverseChange: (universes: string[]) => void;
   onReferenceDateChange: (date: string | null) => void;
   onRun: () => void;
+  onGraphChange?: (graph: Record<string, unknown> | null) => void;
 }
 
 export default function FilterPanel({
@@ -29,6 +31,7 @@ export default function FilterPanel({
   onUniverseChange,
   onReferenceDateChange,
   onRun,
+  onGraphChange,
 }: FilterPanelProps) {
   const t = useTranslations('screening');
   const tConditions = useTranslations('conditions');
@@ -72,10 +75,21 @@ export default function FilterPanel({
     loadUniverses();
   }, [onPresetChange, selectedPreset, t]);
 
-  const { staticPresets, customPresets } = useMemo(() => {
+  const { staticPresets, customPresets, samplePresets } = useMemo(() => {
     const staticGroup = presets.filter((p) => p.source === 'static');
     const customGroup = presets.filter((p) => p.source === 'custom');
-    return { staticPresets: staticGroup, customPresets: customGroup };
+
+    // Convert SAMPLE_STRATEGY_PRESETS to PresetInfo format
+    const sampleGroup: PresetInfo[] = SAMPLE_STRATEGY_PRESETS.map((s) => ({
+      name: `sample:${s.key}`,
+      description: s.description,
+      conditions: s.graph.nodes
+        .filter((n) => n.data.node_type === 'condition' && n.data.condition_type)
+        .map((n) => n.data.condition_type!),
+      source: 'sample' as const,
+    }));
+
+    return { staticPresets: staticGroup, customPresets: customGroup, samplePresets: sampleGroup };
   }, [presets]);
 
   const stockCounts = useMemo(() => {
@@ -86,7 +100,8 @@ export default function FilterPanel({
     return counts;
   }, [universes]);
 
-  const selectedPresetInfo = presets.find((p) => p.name === selectedPreset);
+  const selectedPresetInfo = presets.find((p) => p.name === selectedPreset)
+    || samplePresets.find((p) => p.name === selectedPreset);
   const canRun = selectedPreset && selectedUniverses.length > 0 && !isLoading;
 
   const toTitleCaseFromKey = (value: string) =>
@@ -102,6 +117,7 @@ export default function FilterPanel({
     const i18nKey = `presetNames.${preset.name}`;
     if (t.has(i18nKey)) return t(i18nKey as never);
     if (preset.source === 'custom') return preset.description || toTitleCaseFromKey(preset.name);
+    if (preset.source === 'sample') return preset.description || toTitleCaseFromKey(preset.name);
     return toTitleCaseFromKey(preset.name);
   };
 
@@ -136,7 +152,17 @@ export default function FilterPanel({
           <select
             id="preset-select"
             value={selectedPreset}
-            onChange={(e) => onPresetChange(e.target.value)}
+            onChange={(e) => {
+              const value = e.target.value;
+              onPresetChange(value);
+              if (value.startsWith('sample:')) {
+                const sampleKey = value.slice('sample:'.length);
+                const sample = SAMPLE_STRATEGY_PRESETS.find((s) => s.key === sampleKey);
+                onGraphChange?.(sample ? (sample.graph as unknown as Record<string, unknown>) : null);
+              } else {
+                onGraphChange?.(null);
+              }
+            }}
             disabled={loadingPresets || isLoading}
             className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[var(--foreground)] focus:border-[var(--color-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)] focus:ring-opacity-20 disabled:cursor-not-allowed disabled:opacity-50"
           >
@@ -149,6 +175,15 @@ export default function FilterPanel({
                 {staticPresets.length > 0 && (
                   <optgroup label={t('builtInPresets')}>
                     {staticPresets.map((preset) => (
+                      <option key={preset.name} value={preset.name}>
+                        {presetLabel(preset)}
+                      </option>
+                    ))}
+                  </optgroup>
+                )}
+                {samplePresets.length > 0 && (
+                  <optgroup label={t('sampleStrategies')}>
+                    {samplePresets.map((preset) => (
                       <option key={preset.name} value={preset.name}>
                         {presetLabel(preset)}
                       </option>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -77,7 +77,8 @@ export async function runScreening(
   preset: string,
   universes: string[],
   referenceDate?: string | null,
-  params?: Record<string, unknown>
+  params?: Record<string, unknown>,
+  graph?: Record<string, unknown> | null,
 ): Promise<ScreeningResponse> {
   return fetchApi<ScreeningResponse>('/api/screening/run', {
     method: 'POST',
@@ -86,6 +87,7 @@ export async function runScreening(
       universes,
       reference_date: referenceDate ?? null,
       params,
+      ...(graph ? { graph } : {}),
     }),
   });
 }
@@ -102,7 +104,8 @@ export function runScreeningStream(
     onProgress?: (event: ScreeningProgressEvent) => void;
     onResult?: (data: ScreeningResponse) => void;
     onError?: (error: string) => void;
-  }
+  },
+  graph?: Record<string, unknown> | null,
 ): { abort: () => void } {
   const controller = new AbortController();
 
@@ -117,6 +120,7 @@ export function runScreeningStream(
           universe: universes[0] ?? 'KOSPI',
           reference_date: referenceDate ?? null,
           params,
+          ...(graph ? { graph } : {}),
         }),
         signal: controller.signal,
       });

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -31,7 +31,7 @@ export interface PresetInfo {
   name: string;
   description: string;
   conditions: string[];
-  source: 'static' | 'custom';
+  source: 'static' | 'custom' | 'sample';
 }
 
 export interface UniverseInfo {


### PR DESCRIPTION
## Summary
- Enable 34 sample strategies from Strategy page to be selected and executed in the Screening page
- Frontend sends inline graph payload with `sample:` prefix; backend resolves conditions via `build_conditions_from_graph()`
- No backend sample duplication — frontend-driven approach using existing graph infrastructure

## Changes

### Backend
- **`api/schemas/screening.py`**: Add optional `graph` field to `ScreeningRequest`; update `PresetInfo.source` description
- **`api/services/screening_service.py`**: Handle `sample:` prefix in `_resolve_conditions()` with node/edge size guard (50/100 limit); pass `graph` through `run_screening()`
- **`api/routers/screening.py`**: Forward `request.graph` in both `/run` and `/run/stream` endpoints

### Frontend
- **`web/src/lib/types.ts`**: Extend `PresetInfo.source` with `'sample'`
- **`web/src/lib/api.ts`**: Add `graph` parameter to both `runScreening()` and `runScreeningStream()`
- **`web/src/components/screening/FilterPanel.tsx`**: Import `SAMPLE_STRATEGY_PRESETS`, render in "Strategy Samples" optgroup, fire `onGraphChange` callback on selection
- **`web/src/app/[locale]/screening/page.tsx`**: Add `selectedGraph` state, wire to FilterPanel and API call
- **`web/messages/{en,ko,zh}.json`**: Add `screening.sampleStrategies` i18n key

## Test plan
- [ ] Navigate to `/screening` → verify "Strategy Samples" optgroup appears in preset dropdown with 34 entries
- [ ] Select a sample strategy → verify conditions preview displays correctly
- [ ] Run screening with a sample strategy → verify results appear (graph sent inline)
- [ ] Select a static preset → verify existing behavior unchanged
- [ ] Select a custom (saved) strategy → verify existing behavior unchanged
- [ ] Backend: `python -c "from api.schemas.screening import ScreeningRequest; print('OK')"` passes
- [ ] Frontend: `npm run build` passes with zero errors

Closes #909

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*Reviewed by: Codex MCP (LGTM)*