### PR TITLE
fix(portfolio): add realtime ws endpoint to stop 403 retry loop

### DIFF
--- a/api/routers/portfolio.py
+++ b/api/routers/portfolio.py
@@ -6,10 +6,11 @@ Provides endpoints for portfolio management operations.
 
 import io
 import logging
+import asyncio
 from pathlib import Path
 from typing import List, Optional
 
-from fastapi import APIRouter, Form, HTTPException, Query, UploadFile
+from fastapi import APIRouter, Form, HTTPException, Query, UploadFile, WebSocket, WebSocketDisconnect
 from fastapi.responses import StreamingResponse
 
 from api.schemas.portfolio import (
@@ -33,6 +34,21 @@ MAX_UPLOAD_SIZE = 1_048_576  # 1 MB
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/portfolio", tags=["Portfolio"])
+WS_PUSH_INTERVAL_SECONDS = 10
+
+
+def _parse_ticker_query(raw: str | None) -> List[str]:
+    """Parse comma-separated ticker query into deduplicated list."""
+    if not raw:
+        return []
+    seen: set[str] = set()
+    tickers: List[str] = []
+    for token in raw.split(","):
+        ticker = token.strip().upper()
+        if ticker and ticker not in seen:
+            seen.add(ticker)
+            tickers.append(ticker)
+    return tickers
 
 
 @router.get(
@@ -462,6 +478,46 @@ async def get_sell_signals(
             status_code=500,
             detail=f"Failed to get sell signals: {str(e)}"
         )
+
+
+# ── Realtime websocket ─────────────────────────────────────────────
+
+
+@router.websocket("/realtime/ws")
+async def portfolio_realtime_websocket(websocket: WebSocket) -> None:
+    """Stream periodic portfolio price updates for selected tickers."""
+    await websocket.accept()
+    service = get_portfolio_service()
+    subscribed = _parse_ticker_query(websocket.query_params.get("tickers"))
+
+    try:
+        while True:
+            holdings = await asyncio.to_thread(service.get_all_holdings, False)
+            currency_by_ticker = {h.ticker.upper(): h.currency for h in holdings if h.ticker}
+
+            tickers = subscribed or list(currency_by_ticker.keys())
+            if not tickers:
+                await websocket.send_json({"updates": []})
+                await asyncio.sleep(WS_PUSH_INTERVAL_SECONDS)
+                continue
+
+            prices = await asyncio.to_thread(service._get_current_prices, tickers)
+            updates = [
+                {
+                    "ticker": ticker,
+                    "current_price": float(price),
+                    "currency": currency_by_ticker.get(ticker.upper()),
+                }
+                for ticker, price in prices.items()
+                if price is not None
+            ]
+
+            await websocket.send_json({"updates": updates})
+            await asyncio.sleep(WS_PUSH_INTERVAL_SECONDS)
+    except WebSocketDisconnect:
+        logger.info("Portfolio realtime websocket disconnected")
+    except Exception as e:
+        logger.warning("Portfolio realtime websocket terminated: %s", e)
 
 
 # ── Trade (sell recording + history) ──────────────────────────────

--- a/api/tests/test_portfolio_realtime_ws.py
+++ b/api/tests/test_portfolio_realtime_ws.py
@@ -1,0 +1,29 @@
+"""Tests for portfolio realtime websocket endpoint."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+class _FakePortfolioService:
+    def get_all_holdings(self, with_prices=True):
+        return [
+            SimpleNamespace(ticker="AAPL", currency="USD"),
+            SimpleNamespace(ticker="005930.KS", currency="KRW"),
+        ]
+
+    def _get_current_prices(self, tickers):
+        return {ticker: 100.0 + idx for idx, ticker in enumerate(tickers)}
+
+
+def test_portfolio_realtime_websocket_emits_updates(client):
+    """Websocket should accept and emit updates in expected payload shape."""
+    fake_service = _FakePortfolioService()
+
+    with patch("api.routers.portfolio.get_portfolio_service", return_value=fake_service):
+        with client.websocket_connect("/api/portfolio/realtime/ws?tickers=AAPL,005930.KS") as ws:
+            payload = ws.receive_json()
+
+    assert "updates" in payload
+    assert isinstance(payload["updates"], list)
+    assert {u["ticker"] for u in payload["updates"]} == {"AAPL", "005930.KS"}
+    assert all("current_price" in u for u in payload["updates"])


### PR DESCRIPTION
## Summary
- add `/api/portfolio/realtime/ws` websocket endpoint in portfolio router
- stream periodic updates as `{ updates: [{ ticker, current_price, currency }] }` compatible with existing frontend parser
- keep ticker subscription via `?tickers=AAPL,005930.KS`; fallback to all holdings when omitted
- add websocket test to verify connection and update payload shape

## Verification
- `source venv/bin/activate && pytest -q api/tests/test_portfolio_realtime_ws.py`

Closes #943