### PR TITLE
feat(reports): execution_history model + CRUD API (#941, #942)

### DIFF
--- a/api/database.py
+++ b/api/database.py
@@ -49,6 +49,7 @@ def get_db():
 def init_db() -> None:
     """Create tables and migrate legacy JSON data if present."""
     import api.models.agent_task  # noqa: F401 — register model with Base
+    import api.models.execution_history  # noqa: F401 — register model with Base
     import api.models.portfolio  # noqa: F401 — register model with Base
     import api.models.screening_result  # noqa: F401 — register model with Base
     import api.models.strategy  # noqa: F401 — register model with Base
@@ -58,6 +59,7 @@ def init_db() -> None:
 
     _migrate_json_data()
     _migrate_portfolio_json()
+    _migrate_saved_screening_to_execution_history()
 
 
 def _migrate_json_data() -> None:
@@ -215,3 +217,70 @@ def _migrate_portfolio_json() -> None:
             logger.info("Renamed %s → %s", json_path, migrated_path)
         except OSError as e:
             logger.warning("Could not rename migrated file: %s", e)
+
+
+def _migrate_saved_screening_to_execution_history() -> None:
+    """One-time migration: copy saved_screening_results rows into execution_history."""
+    from api.models.execution_history import ExecutionHistory
+    from api.models.screening_result import SavedScreeningResult
+    from api.schemas.execution_history import compute_fingerprint
+
+    db = SessionLocal()
+    migrated = 0
+    skipped = 0
+    try:
+        saved_count = db.query(SavedScreeningResult).count()
+        if saved_count == 0:
+            return
+
+        existing_fps = {
+            row[0]
+            for row in db.query(ExecutionHistory.fingerprint).all()
+        }
+
+        rows = db.query(SavedScreeningResult).all()
+        for row in rows:
+            fp = compute_fingerprint(
+                execution_type="screening",
+                preset=row.preset,
+                universes=row.universes or [],
+                reference_date=row.reference_date,
+                params=None,
+            )
+            if fp in existing_fps:
+                skipped += 1
+                continue
+
+            eh = ExecutionHistory(
+                id=row.id,
+                execution_type="screening",
+                preset=row.preset,
+                universes=row.universes or [],
+                reference_date=row.reference_date,
+                params=None,
+                graph=None,
+                total_count=row.total_count,
+                matched_count=row.matched_count,
+                elapsed_ms=row.elapsed_ms,
+                results=row.results or [],
+                name=row.name,
+                description=row.description,
+                strategy_id=None,
+                fingerprint=fp,
+                created_at=row.created_at,
+            )
+            db.add(eh)
+            existing_fps.add(fp)
+            migrated += 1
+
+        if migrated > 0:
+            db.commit()
+        logger.info(
+            "Saved screening → execution_history migration: %d migrated, %d skipped",
+            migrated, skipped,
+        )
+    except Exception as e:
+        db.rollback()
+        logger.error("Saved screening migration failed: %s", e)
+    finally:
+        db.close()

--- a/api/main.py
+++ b/api/main.py
@@ -12,7 +12,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from api.config import get_settings
 from api.database import init_db
-from api.routers import analysis_router, broker_router, exchange_rates_router, health_router, portfolio_router, screening_router, settings_router
+from api.routers import analysis_router, broker_router, exchange_rates_router, execution_history_router, health_router, portfolio_router, screening_router, settings_router
 from api.routers.backtest import router as backtest_router
 from api.routers.market import router as market_router
 from api.routers.search import router as search_router
@@ -96,6 +96,7 @@ def create_app() -> FastAPI:
     app.include_router(agent_task_router)
     app.include_router(kiwoom_router)
     app.include_router(broker_router)
+    app.include_router(execution_history_router)
 
     # Future routers (추후 추가될 라우터)
     # app.include_router(news_router, prefix="/api/v1")

--- a/api/models/execution_history.py
+++ b/api/models/execution_history.py
@@ -1,0 +1,34 @@
+"""
+SQLAlchemy model for the execution_history table.
+
+Tracks every screening or strategy execution for auditing,
+duplicate detection (via fingerprint), and result retrieval.
+"""
+
+from datetime import datetime
+
+from sqlalchemy import Column, DateTime, Float, Integer, JSON, String, Text
+from sqlalchemy.dialects.postgresql import JSONB
+
+from api.database import Base
+
+
+class ExecutionHistory(Base):
+    __tablename__ = "execution_history"
+
+    id = Column(String(32), primary_key=True)
+    execution_type = Column(String(20), nullable=False)
+    preset = Column(String(100), nullable=False)
+    universes = Column(JSON().with_variant(JSONB, "postgresql"), nullable=False)
+    reference_date = Column(String(20), nullable=True)
+    params = Column(JSON().with_variant(JSONB, "postgresql"), nullable=True)
+    graph = Column(JSON().with_variant(JSONB, "postgresql"), nullable=True)
+    total_count = Column(Integer, nullable=False)
+    matched_count = Column(Integer, nullable=False)
+    elapsed_ms = Column(Float, nullable=True)
+    results = Column(JSON().with_variant(JSONB, "postgresql"), nullable=False)
+    name = Column(String(255), nullable=True)
+    description = Column(Text, nullable=True)
+    strategy_id = Column(String(32), nullable=True)
+    fingerprint = Column(String(64), nullable=False, index=True)
+    created_at = Column(DateTime, default=datetime.utcnow)

--- a/api/routers/__init__.py
+++ b/api/routers/__init__.py
@@ -7,6 +7,7 @@ Export all routers for registration in the main application.
 from api.routers.analysis import router as analysis_router
 from api.routers.broker import router as broker_router
 from api.routers.exchange_rates import router as exchange_rates_router
+from api.routers.execution_history import router as execution_history_router
 from api.routers.health import router as health_router
 from api.routers.kiwoom import router as kiwoom_router
 from api.routers.market import router as market_router
@@ -22,6 +23,7 @@ __all__ = [
     "backtest_router",
     "broker_router",
     "exchange_rates_router",
+    "execution_history_router",
     "health_router",
     "kiwoom_router",
     "market_router",

--- a/api/routers/execution_history.py
+++ b/api/routers/execution_history.py
@@ -1,0 +1,116 @@
+"""
+Execution History router.
+
+Provides endpoints for execution history (screening & strategy results).
+Mounted at /api/reports/executions.
+"""
+
+import json
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Path, Query
+
+from api.schemas.execution_history import (
+    ExecutionHistoryCreate,
+    ExecutionHistoryDetail,
+    ExecutionHistoryListResponse,
+    DuplicateCheckResponse,
+)
+from api.services.execution_history_service import get_execution_history_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/reports/executions", tags=["Execution History"])
+
+_ID_PATH = Path(..., min_length=1, max_length=32, pattern=r"^[a-f0-9]{1,32}$")
+
+
+@router.get(
+    "",
+    response_model=ExecutionHistoryListResponse,
+    summary="List Execution History",
+    description="List execution history records with optional filtering by type.",
+)
+def list_executions(
+    execution_type: Optional[str] = Query(
+        None, description="Filter by execution type: 'screening' or 'strategy'"
+    ),
+    limit: int = Query(50, ge=1, le=200, description="Max records to return"),
+    offset: int = Query(0, ge=0, description="Number of records to skip"),
+) -> ExecutionHistoryListResponse:
+    """List execution history with pagination and optional type filter."""
+    svc = get_execution_history_service()
+    return svc.list_executions(execution_type=execution_type, limit=limit, offset=offset)
+
+
+@router.get(
+    "/check-duplicate",
+    response_model=DuplicateCheckResponse,
+    summary="Check Duplicate Execution",
+    description="Check if an execution with the same parameters already exists.",
+)
+def check_duplicate(
+    execution_type: str = Query(..., description="'screening' or 'strategy'"),
+    preset: str = Query(..., description="Preset name"),
+    universes: str = Query(..., description="Comma-separated universe list"),
+    reference_date: Optional[str] = Query(None, description="Reference date"),
+    params: Optional[str] = Query(None, description="JSON-encoded params dict"),
+) -> DuplicateCheckResponse:
+    """Check if a duplicate execution exists based on fingerprint."""
+    universe_list = [u.strip() for u in universes.split(",") if u.strip()]
+    parsed_params = None
+    if params:
+        try:
+            parsed_params = json.loads(params)
+        except json.JSONDecodeError:
+            raise HTTPException(status_code=400, detail="Invalid JSON in params")
+    svc = get_execution_history_service()
+    return svc.check_duplicate(
+        execution_type=execution_type,
+        preset=preset,
+        universes=universe_list,
+        reference_date=reference_date,
+        params=parsed_params,
+    )
+
+
+@router.post(
+    "",
+    response_model=ExecutionHistoryDetail,
+    status_code=201,
+    summary="Save Execution Result",
+    description="Save an execution result (screening or strategy) to history.",
+)
+def save_execution(data: ExecutionHistoryCreate) -> ExecutionHistoryDetail:
+    """Save a new execution result to history."""
+    svc = get_execution_history_service()
+    return svc.save_execution(data)
+
+
+@router.get(
+    "/{execution_id}",
+    response_model=ExecutionHistoryDetail,
+    summary="Get Execution Detail",
+    description="Get a single execution history record with full results.",
+)
+def get_execution(execution_id: str = _ID_PATH) -> ExecutionHistoryDetail:
+    """Get execution detail by ID."""
+    svc = get_execution_history_service()
+    result = svc.get_execution(execution_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Execution not found")
+    return result
+
+
+@router.delete(
+    "/{execution_id}",
+    status_code=204,
+    summary="Delete Execution",
+    description="Delete an execution history record.",
+)
+def delete_execution(execution_id: str = _ID_PATH):
+    """Delete an execution history record by ID."""
+    svc = get_execution_history_service()
+    if not svc.delete_execution(execution_id):
+        raise HTTPException(status_code=404, detail="Execution not found")

--- a/api/schemas/execution_history.py
+++ b/api/schemas/execution_history.py
@@ -1,0 +1,109 @@
+"""
+Execution history API schemas.
+
+Pydantic models for execution history request/response validation
+and a fingerprint utility for duplicate detection.
+"""
+
+import hashlib
+import json
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+def compute_fingerprint(
+    execution_type: str,
+    preset: str,
+    universes: List[str],
+    reference_date: Optional[str],
+    params: Optional[Dict[str, Any]],
+) -> str:
+    """Compute a SHA-256 fingerprint for duplicate detection.
+
+    Builds a canonical JSON string from the execution parameters
+    and returns its hex digest.
+    """
+    canonical = {
+        "execution_type": execution_type,
+        "preset": preset,
+        "universes": sorted(universes),
+        "reference_date": reference_date,
+        "params": params,
+    }
+    raw = json.dumps(canonical, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+class ExecutionHistoryCreate(BaseModel):
+    """Request payload for recording an execution history entry."""
+
+    execution_type: Literal["screening", "strategy"] = Field(
+        ..., description="Type of execution: 'screening' or 'strategy'"
+    )
+    preset: str = Field(..., description="Preset name used for execution")
+    universes: List[str] = Field(..., description="List of universe identifiers")
+    reference_date: Optional[str] = Field(
+        None, description="Reference date string (e.g. '2025-01-15')"
+    )
+    params: Optional[Dict[str, Any]] = Field(
+        None, description="Optional override parameters"
+    )
+    graph: Optional[Dict[str, Any]] = Field(
+        None, description="Inline strategy graph for sample: presets"
+    )
+    total_count: int = Field(..., ge=0, description="Total number of stocks evaluated")
+    matched_count: int = Field(..., ge=0, description="Number of matched stocks")
+    elapsed_ms: Optional[float] = Field(
+        None, description="Execution time in milliseconds"
+    )
+    results: List[Dict[str, Any]] = Field(
+        ..., description="Full results array"
+    )
+    name: Optional[str] = Field(
+        None, max_length=255, description="Optional user-given name"
+    )
+    description: Optional[str] = Field(
+        None, max_length=1000, description="Optional description"
+    )
+    strategy_id: Optional[str] = Field(
+        None, description="Linked strategy ID if applicable"
+    )
+
+
+class ExecutionHistorySummary(BaseModel):
+    """Lightweight summary of an execution history entry (excludes results)."""
+
+    id: str
+    execution_type: str
+    preset: str
+    universes: List[str]
+    reference_date: Optional[str] = None
+    total_count: int
+    matched_count: int
+    elapsed_ms: Optional[float] = None
+    name: Optional[str] = None
+    description: Optional[str] = None
+    strategy_id: Optional[str] = None
+    created_at: str
+
+
+class ExecutionHistoryDetail(ExecutionHistorySummary):
+    """Full execution history entry including results data."""
+
+    results: List[Dict[str, Any]]
+
+
+class ExecutionHistoryListResponse(BaseModel):
+    """Paginated list of execution history summaries."""
+
+    items: List[ExecutionHistorySummary]
+    total_count: int
+
+
+class DuplicateCheckResponse(BaseModel):
+    """Response for duplicate execution check via fingerprint."""
+
+    exists: bool
+    existing_id: Optional[str] = None
+    created_at: Optional[str] = None

--- a/api/services/execution_history_service.py
+++ b/api/services/execution_history_service.py
@@ -1,0 +1,253 @@
+"""
+Execution History Service.
+
+Business logic for saving/loading execution history (screening & strategy results).
+Provides CRUD operations with duplicate detection via fingerprint.
+"""
+
+import logging
+import uuid
+from datetime import datetime
+from typing import Dict, List, Optional, Any
+
+from sqlalchemy.orm import defer
+
+from api.database import SessionLocal
+from api.models.execution_history import ExecutionHistory
+from api.schemas.execution_history import (
+    ExecutionHistoryCreate,
+    ExecutionHistoryDetail,
+    ExecutionHistoryListResponse,
+    ExecutionHistorySummary,
+    DuplicateCheckResponse,
+    compute_fingerprint,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _row_to_summary(row: ExecutionHistory) -> ExecutionHistorySummary:
+    return ExecutionHistorySummary(
+        id=row.id,
+        execution_type=row.execution_type,
+        preset=row.preset,
+        universes=row.universes or [],
+        reference_date=row.reference_date,
+        total_count=row.total_count,
+        matched_count=row.matched_count,
+        elapsed_ms=row.elapsed_ms,
+        name=row.name,
+        description=row.description,
+        strategy_id=row.strategy_id,
+        created_at=row.created_at.isoformat() if row.created_at else "",
+    )
+
+
+def _row_to_detail(row: ExecutionHistory) -> ExecutionHistoryDetail:
+    return ExecutionHistoryDetail(
+        id=row.id,
+        execution_type=row.execution_type,
+        preset=row.preset,
+        universes=row.universes or [],
+        reference_date=row.reference_date,
+        total_count=row.total_count,
+        matched_count=row.matched_count,
+        elapsed_ms=row.elapsed_ms,
+        name=row.name,
+        description=row.description,
+        strategy_id=row.strategy_id,
+        created_at=row.created_at.isoformat() if row.created_at else "",
+        results=row.results or [],
+    )
+
+
+class ExecutionHistoryService:
+    """Service for managing execution history records."""
+
+    def list_executions(
+        self,
+        execution_type: Optional[str] = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> ExecutionHistoryListResponse:
+        """
+        List execution history records (lightweight, without results column).
+
+        Args:
+            execution_type: Filter by type ('screening' or 'strategy'), None for all
+            limit: Maximum number of records to return
+            offset: Number of records to skip
+
+        Returns:
+            Paginated list of execution history summaries
+        """
+        db = SessionLocal()
+        try:
+            query = db.query(ExecutionHistory).options(
+                defer(ExecutionHistory.results),
+                defer(ExecutionHistory.graph),
+            )
+            if execution_type:
+                query = query.filter(ExecutionHistory.execution_type == execution_type)
+
+            total = query.count()
+            rows = (
+                query.order_by(ExecutionHistory.created_at.desc())
+                .offset(offset)
+                .limit(limit)
+                .all()
+            )
+            return ExecutionHistoryListResponse(
+                items=[_row_to_summary(r) for r in rows],
+                total_count=total,
+            )
+        finally:
+            db.close()
+
+    def get_execution(self, execution_id: str) -> Optional[ExecutionHistoryDetail]:
+        """
+        Get a single execution history record by ID.
+
+        Args:
+            execution_id: Execution history ID
+
+        Returns:
+            Full execution detail if found, otherwise None
+        """
+        db = SessionLocal()
+        try:
+            row = db.get(ExecutionHistory, execution_id)
+            if row is None:
+                return None
+            return _row_to_detail(row)
+        finally:
+            db.close()
+
+    def check_duplicate(
+        self,
+        execution_type: str,
+        preset: str,
+        universes: List[str],
+        reference_date: Optional[str],
+        params: Optional[Dict[str, Any]],
+    ) -> DuplicateCheckResponse:
+        """
+        Check if an execution with the same fingerprint already exists.
+
+        Args:
+            execution_type: 'screening' or 'strategy'
+            preset: Preset name
+            universes: Universe list
+            reference_date: Reference date string
+            params: Optional parameters
+
+        Returns:
+            DuplicateCheckResponse with exists flag and existing ID if found
+        """
+        fp = compute_fingerprint(execution_type, preset, universes, reference_date, params)
+        db = SessionLocal()
+        try:
+            row = (
+                db.query(ExecutionHistory)
+                .filter(ExecutionHistory.fingerprint == fp)
+                .order_by(ExecutionHistory.created_at.desc())
+                .first()
+            )
+            if row is None:
+                return DuplicateCheckResponse(exists=False)
+            return DuplicateCheckResponse(
+                exists=True,
+                existing_id=row.id,
+                created_at=row.created_at.isoformat() if row.created_at else None,
+            )
+        finally:
+            db.close()
+
+    def save_execution(self, data: ExecutionHistoryCreate) -> ExecutionHistoryDetail:
+        """
+        Save a new execution history record.
+
+        Args:
+            data: Execution history payload
+
+        Returns:
+            Created execution history detail
+        """
+        execution_id = uuid.uuid4().hex
+        now = datetime.utcnow()
+        fp = compute_fingerprint(
+            data.execution_type,
+            data.preset,
+            data.universes,
+            data.reference_date,
+            data.params,
+        )
+
+        row = ExecutionHistory(
+            id=execution_id,
+            execution_type=data.execution_type,
+            preset=data.preset,
+            universes=data.universes,
+            reference_date=data.reference_date,
+            params=data.params,
+            graph=data.graph,
+            total_count=data.total_count,
+            matched_count=data.matched_count,
+            elapsed_ms=data.elapsed_ms,
+            results=data.results,
+            name=data.name,
+            description=data.description,
+            strategy_id=data.strategy_id,
+            fingerprint=fp,
+            created_at=now,
+        )
+
+        db = SessionLocal()
+        try:
+            db.add(row)
+            db.commit()
+            db.refresh(row)
+            logger.info("Saved execution history: %s (type=%s)", execution_id, data.execution_type)
+            return _row_to_detail(row)
+        except Exception:
+            db.rollback()
+            raise
+        finally:
+            db.close()
+
+    def delete_execution(self, execution_id: str) -> bool:
+        """
+        Delete an execution history record by ID.
+
+        Args:
+            execution_id: Execution history ID
+
+        Returns:
+            True if deleted, False if not found
+        """
+        db = SessionLocal()
+        try:
+            row = db.get(ExecutionHistory, execution_id)
+            if row is None:
+                return False
+            db.delete(row)
+            db.commit()
+            logger.info("Deleted execution history: %s", execution_id)
+            return True
+        except Exception:
+            db.rollback()
+            raise
+        finally:
+            db.close()
+
+
+# Singleton instance
+_execution_history_service: Optional[ExecutionHistoryService] = None
+
+
+def get_execution_history_service() -> ExecutionHistoryService:
+    """Get or create execution history service singleton."""
+    global _execution_history_service
+    if _execution_history_service is None:
+        _execution_history_service = ExecutionHistoryService()
+    return _execution_history_service


### PR DESCRIPTION
## Summary
- New `execution_history` table to unify screening and strategy execution results
- CRUD API at `/api/reports/executions` with pagination, type filtering, and path param validation
- Fingerprint-based duplicate detection (`SHA-256` of canonical execution params)
- Auto-migration from existing `saved_screening_results` table on startup
- `Literal["screening", "strategy"]` schema validation for execution_type

Closes #941
Closes #942

## Test plan
- [x] All modules import correctly (schemas, model, service, router)
- [x] `init_db()` creates `execution_history` table
- [x] CRUD flow verified: save → list → get → duplicate check → delete
- [x] Fingerprint determinism: universe/param order independence
- [x] `Literal` type rejects invalid `execution_type`
- [x] `check_duplicate` endpoint supports JSON-encoded `params` query
- [x] Codex code review: 2 medium + 2 low issues found and fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)