### PR TITLE
feat(settings): broker connections section with status sync

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -12,7 +12,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from api.config import get_settings
 from api.database import init_db
-from api.routers import analysis_router, broker_router, exchange_rates_router, health_router, portfolio_router, screening_router
+from api.routers import analysis_router, broker_router, exchange_rates_router, health_router, portfolio_router, screening_router, settings_router
 from api.routers.backtest import router as backtest_router
 from api.routers.market import router as market_router
 from api.routers.search import router as search_router
@@ -89,6 +89,7 @@ def create_app() -> FastAPI:
     app.include_router(portfolio_router)
     app.include_router(exchange_rates_router)
     app.include_router(screening_router)
+    app.include_router(settings_router)
     app.include_router(search_router)
     app.include_router(strategy_router)
     app.include_router(backtest_router)

--- a/api/routers/__init__.py
+++ b/api/routers/__init__.py
@@ -14,6 +14,7 @@ from api.routers.portfolio import router as portfolio_router
 from api.routers.screening import router as screening_router
 from api.routers.search import router as search_router
 from api.routers.backtest import router as backtest_router
+from api.routers.settings import router as settings_router
 from api.routers.strategy import router as strategy_router
 
 __all__ = [
@@ -27,5 +28,6 @@ __all__ = [
     "portfolio_router",
     "screening_router",
     "search_router",
+    "settings_router",
     "strategy_router",
 ]

--- a/api/routers/settings.py
+++ b/api/routers/settings.py
@@ -1,0 +1,58 @@
+"""Settings router."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from brokers.base import ConnectionState
+from brokers.exceptions import BrokerConnectionError
+
+from api.schemas.broker import BrokerConnectionResponse, BrokerSettingsResponse
+from api.services.broker_service import BrokerService
+
+router = APIRouter(prefix="/api/settings", tags=["Settings"])
+
+_service = BrokerService()
+
+
+@router.get(
+    "/brokers",
+    response_model=BrokerSettingsResponse,
+    summary="List broker statuses for settings",
+    description="Return connection status snapshots for all registered brokers.",
+)
+def list_settings_brokers() -> BrokerSettingsResponse:
+    brokers: list[BrokerConnectionResponse] = []
+    for name in _service.list_brokers():
+        try:
+            status = _service.get_connection_status(name)
+            brokers.append(
+                BrokerConnectionResponse(
+                    broker=status.broker,
+                    status=status.status,
+                    is_paper_trading=status.is_paper_trading,
+                    accounts=status.accounts,
+                    updated_at=status.updated_at,
+                )
+            )
+        except BrokerConnectionError:
+            brokers.append(
+                BrokerConnectionResponse(
+                    broker=name,
+                    status=ConnectionState.UNAVAILABLE,
+                    is_paper_trading=None,
+                    accounts=[],
+                    updated_at=None,
+                )
+            )
+        except Exception:
+            brokers.append(
+                BrokerConnectionResponse(
+                    broker=name,
+                    status=ConnectionState.UNAVAILABLE,
+                    is_paper_trading=None,
+                    accounts=[],
+                    updated_at=None,
+                )
+            )
+    return BrokerSettingsResponse(brokers=brokers)

--- a/api/schemas/broker.py
+++ b/api/schemas/broker.py
@@ -99,3 +99,11 @@ class BrokerListResponse(BaseModel):
     brokers: List[str] = Field(
         default_factory=list, description="Registered broker names"
     )
+
+
+class BrokerSettingsResponse(BaseModel):
+    """Aggregated broker status payload for settings page."""
+
+    brokers: List[BrokerConnectionResponse] = Field(
+        default_factory=list, description="Broker statuses for settings page"
+    )

--- a/api/tests/test_settings.py
+++ b/api/tests/test_settings.py
@@ -1,0 +1,42 @@
+"""Tests for settings router."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from brokers.base import ConnectionState
+from brokers.exceptions import BrokerConnectionError
+
+
+def test_list_settings_brokers_returns_statuses(client):
+    status = SimpleNamespace(
+        broker="kiwoom",
+        status=ConnectionState.CONNECTED,
+        is_paper_trading=True,
+        accounts=["12345678"],
+        updated_at="2026-02-26T00:00:00Z",
+    )
+
+    with patch("api.routers.settings._service.list_brokers", return_value=["kiwoom"]):
+        with patch("api.routers.settings._service.get_connection_status", return_value=status):
+            response = client.get("/api/settings/brokers")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "brokers" in data
+    assert len(data["brokers"]) == 1
+    assert data["brokers"][0]["broker"] == "kiwoom"
+    assert data["brokers"][0]["status"] == "connected"
+
+
+def test_list_settings_brokers_marks_unavailable_on_connection_error(client):
+    with patch("api.routers.settings._service.list_brokers", return_value=["tiger"]):
+        with patch(
+            "api.routers.settings._service.get_connection_status",
+            side_effect=BrokerConnectionError("down"),
+        ):
+            response = client.get("/api/settings/brokers")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["brokers"][0]["broker"] == "tiger"
+    assert data["brokers"][0]["status"] == "unavailable"

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -2672,7 +2672,20 @@
     "languageDesc": "UI display language. This does not affect how numbers or currencies are formatted for each market.",
     "saved": "Settings saved",
     "general": "General",
-    "display": "Display"
+    "display": "Display",
+    "brokerConnections": "Broker Connections",
+    "sync": "Sync All",
+    "loading": "Loading...",
+    "accountsCount": "{count} account(s)",
+    "primaryAccount": "Primary Account",
+    "lastChecked": "Last Checked",
+    "testConnection": "Test Connection",
+    "disconnect": "Disconnect",
+    "disconnectPhaseLater": "Disconnect will be available in Phase B/C.",
+    "connected": "Connected",
+    "disconnected": "Disconnected",
+    "connecting": "Connecting",
+    "unavailable": "Unavailable"
   },
   "kiwoom": {
     "title": "Kiwoom",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -2672,7 +2672,20 @@
     "languageDesc": "UI 표시 언어입니다. 각 시장의 숫자나 통화 표시 방식에는 영향을 주지 않습니다.",
     "saved": "설정이 저장되었습니다",
     "general": "일반",
-    "display": "표시"
+    "display": "표시",
+    "brokerConnections": "브로커 연결",
+    "sync": "전체 동기화",
+    "loading": "불러오는 중...",
+    "accountsCount": "{count}개 계좌",
+    "primaryAccount": "기본 계좌",
+    "lastChecked": "마지막 점검",
+    "testConnection": "연결 테스트",
+    "disconnect": "연결 해제",
+    "disconnectPhaseLater": "연결 해제는 다음 단계(Phase B/C)에서 제공됩니다.",
+    "connected": "연결됨",
+    "disconnected": "연결 끊김",
+    "connecting": "연결 중",
+    "unavailable": "사용 불가"
   },
   "kiwoom": {
     "title": "키움",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -2672,7 +2672,20 @@
     "languageDesc": "界面显示语言。这不会影响每个市场的数字或货币格式。",
     "saved": "设置已保存",
     "general": "常规",
-    "display": "显示"
+    "display": "显示",
+    "brokerConnections": "券商连接",
+    "sync": "全部同步",
+    "loading": "加载中...",
+    "accountsCount": "{count} 个账户",
+    "primaryAccount": "主账户",
+    "lastChecked": "上次检查",
+    "testConnection": "连接测试",
+    "disconnect": "断开连接",
+    "disconnectPhaseLater": "断开连接将在 Phase B/C 提供。",
+    "connected": "已连接",
+    "disconnected": "已断开",
+    "connecting": "连接中",
+    "unavailable": "不可用"
   },
   "kiwoom": {
     "title": "Kiwoom",

--- a/web/src/app/[locale]/settings/page.tsx
+++ b/web/src/app/[locale]/settings/page.tsx
@@ -3,12 +3,14 @@
 import { useTranslations } from 'next-intl';
 import { useLocale } from 'next-intl';
 import { useEffect, useState } from 'react';
-import { Globe, DollarSign } from 'lucide-react';
+import { Globe, DollarSign, PlugZap, RefreshCw, Link2Off } from 'lucide-react';
 import { useUserSettings } from '@/contexts/UserSettingsContext';
 import { BASE_CURRENCIES, CURRENCY_LABELS } from '@/lib/format';
 import type { BaseCurrency } from '@/lib/format';
 import { useRouter, usePathname } from '@/i18n/navigation';
 import { routing } from '@/i18n/routing';
+import { getBrokerConnectionStatus, getSettingsBrokerStatuses } from '@/lib/api';
+import type { BrokerConnectionStatus, BrokerConnectionState } from '@/lib/types';
 
 const LOCALE_LABELS: Record<string, string> = {
   en: 'English',
@@ -25,10 +27,44 @@ export default function SettingsPage() {
   const pathname = usePathname();
   const { settings, updateBaseCurrency } = useUserSettings();
   const [selectedLocale, setSelectedLocale] = useState(locale);
+  const [brokers, setBrokers] = useState<BrokerConnectionStatus[]>([]);
+  const [loadingBrokers, setLoadingBrokers] = useState(true);
+  const [brokerError, setBrokerError] = useState<string | null>(null);
+  const [refreshingBroker, setRefreshingBroker] = useState<string | null>(null);
+  const [syncingAll, setSyncingAll] = useState(false);
+
+  const statusTextKey: Record<BrokerConnectionState, string> = {
+    connected: 'connected',
+    disconnected: 'disconnected',
+    connecting: 'connecting',
+    unavailable: 'unavailable',
+  };
+  const statusDotClass: Record<BrokerConnectionState, string> = {
+    connected: 'bg-green-500',
+    disconnected: 'bg-slate-400',
+    connecting: 'bg-amber-500 animate-pulse',
+    unavailable: 'bg-red-500',
+  };
 
   useEffect(() => {
     setSelectedLocale(locale);
   }, [locale]);
+
+  useEffect(() => {
+    const load = async () => {
+      setLoadingBrokers(true);
+      setBrokerError(null);
+      try {
+        const result = await getSettingsBrokerStatuses();
+        setBrokers(result);
+      } catch (e) {
+        setBrokerError(e instanceof Error ? e.message : 'Failed to load broker status');
+      } finally {
+        setLoadingBrokers(false);
+      }
+    };
+    load();
+  }, []);
 
   const handleLocaleSave = () => {
     if (selectedLocale === locale) return;
@@ -40,6 +76,51 @@ export default function SettingsPage() {
       JSON.stringify({ locale: selectedLocale })
     );
     router.replace(pathname, { locale: selectedLocale });
+  };
+
+  const maskAccount = (value: string): string => {
+    if (value.length <= 4) return value;
+    return `${value.slice(0, 3)}****${value.slice(-2)}`;
+  };
+
+  const formatUpdatedAt = (value: string | null): string => {
+    if (!value) return '-';
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return '-';
+    return new Intl.DateTimeFormat(locale, {
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    }).format(date);
+  };
+
+  const handleSyncAll = async () => {
+    setSyncingAll(true);
+    setBrokerError(null);
+    try {
+      const result = await getSettingsBrokerStatuses();
+      setBrokers(result);
+    } catch (e) {
+      setBrokerError(e instanceof Error ? e.message : 'Failed to sync broker status');
+    } finally {
+      setSyncingAll(false);
+    }
+  };
+
+  const handleTestBroker = async (broker: string) => {
+    setRefreshingBroker(broker);
+    setBrokerError(null);
+    try {
+      const status = await getBrokerConnectionStatus(broker);
+      setBrokers((prev) =>
+        prev.map((item) => (item.broker === broker ? status : item))
+      );
+    } catch (e) {
+      setBrokerError(e instanceof Error ? e.message : 'Failed to test broker connection');
+    } finally {
+      setRefreshingBroker(null);
+    }
   };
 
   return (
@@ -124,6 +205,89 @@ export default function SettingsPage() {
               </p>
             </div>
           </div>
+        </div>
+      </section>
+
+      <section className="space-y-6">
+        <div className="flex items-center justify-between gap-3">
+          <h2 className="text-lg font-semibold text-[var(--foreground)]">{t('brokerConnections')}</h2>
+          <button
+            type="button"
+            onClick={handleSyncAll}
+            disabled={syncingAll || loadingBrokers}
+            className="rounded-lg border border-[var(--border)] bg-[var(--background-secondary)] px-3 py-2 text-sm font-medium text-[var(--foreground)] hover:bg-[var(--background)] disabled:opacity-60"
+          >
+            <span className="inline-flex items-center gap-2">
+              <RefreshCw className={`h-4 w-4 ${syncingAll ? 'animate-spin' : ''}`} />
+              {t('sync')}
+            </span>
+          </button>
+        </div>
+
+        {brokerError && (
+          <div className="rounded-xl border border-red-300 bg-red-50 p-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-950/50 dark:text-red-300">
+            {brokerError}
+          </div>
+        )}
+
+        <div className="space-y-3">
+          {loadingBrokers ? (
+            <div className="rounded-xl border border-[var(--border)] bg-[var(--background-secondary)] p-4 text-sm text-[var(--foreground-muted)]">
+              {t('loading')}
+            </div>
+          ) : (
+            brokers.map((broker) => (
+              <div
+                key={broker.broker}
+                className="rounded-xl border border-[var(--border)] bg-[var(--background-secondary)] p-4"
+              >
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                  <div className="space-y-1">
+                    <div className="flex items-center gap-2">
+                      <PlugZap className="h-4 w-4 text-[var(--foreground-muted)]" />
+                      <span className="font-medium text-[var(--foreground)]">{broker.broker.toUpperCase()}</span>
+                      <span className={`h-2.5 w-2.5 rounded-full ${statusDotClass[broker.status]}`} />
+                      <span className="text-sm text-[var(--foreground-muted)]">
+                        {t(statusTextKey[broker.status])}
+                      </span>
+                    </div>
+                    <p className="text-xs text-[var(--foreground-muted)]">
+                      {t('accountsCount', { count: broker.accounts.length })}
+                      {broker.accounts[0] ? ` · ${t('primaryAccount')}: ${maskAccount(broker.accounts[0])}` : ''}
+                    </p>
+                    <p className="text-xs text-[var(--foreground-muted)]">
+                      {t('lastChecked')}: {formatUpdatedAt(broker.updated_at)}
+                    </p>
+                  </div>
+
+                  <div className="flex gap-2">
+                    <button
+                      type="button"
+                      onClick={() => handleTestBroker(broker.broker)}
+                      disabled={refreshingBroker === broker.broker}
+                      className="rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm font-medium text-[var(--foreground)] hover:bg-[var(--background-secondary)] disabled:opacity-60"
+                    >
+                      <span className="inline-flex items-center gap-2">
+                        <RefreshCw className={`h-4 w-4 ${refreshingBroker === broker.broker ? 'animate-spin' : ''}`} />
+                        {t('testConnection')}
+                      </span>
+                    </button>
+                    <button
+                      type="button"
+                      disabled
+                      title={t('disconnectPhaseLater')}
+                      className="rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm font-medium text-[var(--foreground-muted)] opacity-70"
+                    >
+                      <span className="inline-flex items-center gap-2">
+                        <Link2Off className="h-4 w-4" />
+                        {t('disconnect')}
+                      </span>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            ))
+          )}
         </div>
       </section>
     </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -706,6 +706,11 @@ export async function listBrokers(): Promise<string[]> {
   return data.brokers;
 }
 
+export async function getSettingsBrokerStatuses(): Promise<BrokerConnectionStatus[]> {
+  const data = await fetchApi<{ brokers: BrokerConnectionStatus[] }>('/api/settings/brokers');
+  return data.brokers;
+}
+
 export async function getBrokerConnectionStatus(
   broker: string
 ): Promise<BrokerConnectionStatus> {


### PR DESCRIPTION
## Summary
- add api settings endpoint to aggregate broker statuses for settings UI
- add broker connection cards in settings page with status badge, accounts, and last-checked info
- add actions for single broker connection test and sync-all refresh
- keep disconnect action as disabled placeholder for later phases

## Verification
- source venv/bin/activate && pytest -q api/tests/test_settings.py
- cd web && npm run lint -- src/app/[locale]/settings/page.tsx src/lib/api.ts

Closes #951