### PR TITLE
feat(reports): auto-save execution results + duplicate detection (#945)

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -208,7 +208,11 @@
     "noSavedResultsDesc": "Run a screening and save the results to view them here.",
     "savedTab": "Saved Results",
     "savedOn": "Saved on",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "duplicateFound": "A result with the same conditions already exists",
+    "duplicateCreatedAt": "Created: {date}",
+    "viewExistingResult": "View Existing Result",
+    "runAnyway": "Run Anyway"
   },
   "portfolio": {
     "title": "Portfolio",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -208,7 +208,11 @@
     "noSavedResultsDesc": "스크리닝을 실행하고 결과를 저장하면 여기에 표시됩니다.",
     "savedTab": "저장된 결과",
     "savedOn": "저장일",
-    "cancel": "취소"
+    "cancel": "취소",
+    "duplicateFound": "동일 조건의 실행 결과가 이미 있습니다",
+    "duplicateCreatedAt": "생성일: {date}",
+    "viewExistingResult": "기존 결과 보기",
+    "runAnyway": "새로 실행"
   },
   "portfolio": {
     "title": "포트폴리오",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -208,7 +208,11 @@
     "noSavedResultsDesc": "运行筛选并保存结果后，它们将显示在此处。",
     "savedTab": "已保存结果",
     "savedOn": "保存日期",
-    "cancel": "取消"
+    "cancel": "取消",
+    "duplicateFound": "已存在相同条件的执行结果",
+    "duplicateCreatedAt": "创建时间: {date}",
+    "viewExistingResult": "查看已有结果",
+    "runAnyway": "重新执行"
   },
   "portfolio": {
     "title": "投资组合",

--- a/web/src/app/[locale]/screening/page.tsx
+++ b/web/src/app/[locale]/screening/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useTranslations } from 'next-intl';
 import { AlertCircle, Clock } from 'lucide-react';
 import {
@@ -8,8 +8,9 @@ import {
   FilterPanel,
   ResultTable,
 } from '@/components/screening';
-import { runScreeningStream } from '@/lib/api';
-import type { ScreeningProgressEvent, ScreeningResult } from '@/lib/types';
+import { runScreeningStream, saveExecution, checkDuplicateExecution } from '@/lib/api';
+import type { ScreeningProgressEvent, ScreeningResult, DuplicateCheckResponse } from '@/lib/types';
+import { Link } from '@/i18n/navigation';
 
 export default function ScreeningPage() {
   const t = useTranslations('screening');
@@ -30,13 +31,19 @@ export default function ScreeningPage() {
     elapsedMs: number | null;
   } | null>(null);
   const [selectedGraph, setSelectedGraph] = useState<Record<string, unknown> | null>(null);
+  const [duplicateInfo, setDuplicateInfo] = useState<DuplicateCheckResponse | null>(null);
+  const [pendingRun, setPendingRun] = useState(false);
 
-  const handleRunScreening = async () => {
-    if (!selectedPreset || selectedUniverses.length === 0) {
-      setError(t('selectPresetAndUniverse'));
-      return;
-    }
+  useEffect(() => {
+    if (!duplicateInfo) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setDuplicateInfo(null);
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [duplicateInfo]);
 
+  const startScreening = () => {
     setIsLoading(true);
     setError(null);
     setResults([]);
@@ -76,6 +83,21 @@ export default function ScreeningPage() {
           status: 'done',
         });
         setIsLoading(false);
+
+        // Auto-save execution result (fire-and-forget)
+        saveExecution({
+          execution_type: 'screening',
+          preset: selectedPreset,
+          universes: response.universes ?? selectedUniverses,
+          reference_date: response.reference_date ?? referenceDate,
+          graph: selectedGraph,
+          total_count: response.total_count,
+          matched_count: response.matched_count,
+          elapsed_ms: response.elapsed_ms ?? null,
+          results: response.results as unknown as Array<Record<string, unknown>>,
+        }).catch((err) => {
+          console.warn('Auto-save failed:', err);
+        });
       },
       onError: (message) => {
         console.error('Screening failed:', message);
@@ -96,6 +118,34 @@ export default function ScreeningPage() {
         );
       },
     }, selectedGraph);
+  };
+
+  const handleRunScreening = async () => {
+    if (!selectedPreset || selectedUniverses.length === 0) {
+      setError(t('selectPresetAndUniverse'));
+      return;
+    }
+
+    // Check for duplicate execution before running
+    try {
+      setPendingRun(true);
+      const dup = await checkDuplicateExecution(
+        'screening',
+        selectedPreset,
+        selectedUniverses,
+        referenceDate
+      );
+      if (dup.exists) {
+        setDuplicateInfo(dup);
+        return;
+      }
+    } catch {
+      // If duplicate check fails, proceed with screening anyway
+    } finally {
+      setPendingRun(false);
+    }
+
+    startScreening();
   };
 
   return (
@@ -145,7 +195,7 @@ export default function ScreeningPage() {
                 selectedPreset={selectedPreset}
                 selectedUniverses={selectedUniverses}
                 referenceDate={referenceDate}
-                isLoading={isLoading}
+                isLoading={isLoading || pendingRun}
                 onPresetChange={setSelectedPreset}
                 onUniverseChange={setSelectedUniverses}
                 onReferenceDateChange={setReferenceDate}
@@ -271,6 +321,51 @@ export default function ScreeningPage() {
           </div>
         )}
       </div>
+
+      {/* Duplicate detection dialog */}
+      {duplicateInfo && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+          <button
+            type="button"
+            className="absolute inset-0"
+            onClick={() => setDuplicateInfo(null)}
+            aria-label="Close"
+          />
+          <div className="relative z-10 w-full max-w-sm rounded-xl border border-[var(--border)] bg-[var(--background-secondary)] p-6 shadow-2xl">
+            <p className="text-[var(--foreground)]">
+              {t('duplicateFound')}
+            </p>
+            {duplicateInfo.created_at && (
+              <p className="mt-1 text-sm text-[var(--foreground-muted)]">
+                {t('duplicateCreatedAt', {
+                  date: new Date(duplicateInfo.created_at).toLocaleString(),
+                })}
+              </p>
+            )}
+            <div className="mt-4 flex justify-end gap-3">
+              {duplicateInfo.existing_id && (
+                <Link
+                  href={`/reports/${duplicateInfo.existing_id}`}
+                  className="rounded-lg border border-[var(--border)] px-4 py-2 text-sm font-medium text-[var(--foreground)] hover:bg-[var(--background)] transition-colors"
+                  onClick={() => setDuplicateInfo(null)}
+                >
+                  {t('viewExistingResult')}
+                </Link>
+              )}
+              <button
+                type="button"
+                onClick={() => {
+                  setDuplicateInfo(null);
+                  startScreening();
+                }}
+                className="rounded-lg bg-[var(--color-primary)] px-4 py-2 text-sm font-medium text-white hover:opacity-90 transition-colors"
+              >
+                {t('runAnyway')}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/app/[locale]/strategy/page.tsx
+++ b/web/src/app/[locale]/strategy/page.tsx
@@ -46,7 +46,7 @@ import { SAMPLE_STRATEGY_PRESETS, type SampleStrategyPreset } from '@/lib/strate
 import { ConditionsProvider, useConditions } from '@/contexts/ConditionsContext';
 import { useSavedStrategies, useSaveStrategy, useUpdateStrategy } from '@/hooks/useStrategy';
 import type { StrategyResultItem, SavedStrategy, NodeIntermediateResult } from '@/lib/api';
-import { runStrategyStream } from '@/lib/api';
+import { runStrategyStream, saveExecution } from '@/lib/api';
 
 const nodeTypes: NodeTypes = {
   universeNode: UniverseNode,
@@ -883,6 +883,20 @@ function StrategyPageInner() {
         t('deploySuccess', { count: data.matched_count, total: data.total_count }),
         'success'
       );
+
+      // Auto-save execution result (fire-and-forget)
+      saveExecution({
+        execution_type: 'strategy',
+        preset: strategyName || 'Untitled Strategy',
+        universes: [data.universe],
+        graph: graph as unknown as Record<string, unknown>,
+        total_count: data.total_count,
+        matched_count: data.matched_count,
+        results: data.results as unknown as Array<Record<string, unknown>>,
+        strategy_id: currentStrategyId ?? undefined,
+      }).catch((err) => {
+        console.warn('Auto-save failed:', err);
+      });
     };
 
     const stream = runStrategyStream(graph, undefined, {


### PR DESCRIPTION
## Summary
- Auto-save screening/strategy execution results to execution history on completion (fire-and-forget pattern)
- Show duplicate detection dialog before running screening when same conditions already exist
- User can choose "View Existing Result" or "Run Anyway"
- Escape key + backdrop click to dismiss dialog

## Changes
- `web/src/app/[locale]/screening/page.tsx` — auto-save in onResult callback, duplicate check before run, modal dialog
- `web/src/app/[locale]/strategy/page.tsx` — auto-save after strategy execution success
- `web/messages/{en,ko,zh}.json` — 4 new i18n keys (duplicateFound, duplicateCreatedAt, viewExistingResult, runAnyway)

## Test plan
- [ ] Run screening → verify result auto-saved in Reports page
- [ ] Run same screening again → verify duplicate dialog appears
- [ ] Click "View Existing Result" → navigates to report detail
- [ ] Click "Run Anyway" → proceeds with screening
- [ ] Press Escape → dialog dismisses
- [ ] Run strategy → verify result auto-saved in Reports page
- [ ] Verify no console errors

Closes #945

🤖 Generated with [Claude Code](https://claude.com/claude-code)