### PR TITLE
feat(portfolio): allocation charts + sector/market enrichment

### DIFF
--- a/api/schemas/portfolio.py
+++ b/api/schemas/portfolio.py
@@ -64,6 +64,7 @@ class HoldingResponse(BaseModel):
         pnl: Profit/Loss amount
         pnl_pct: Profit/Loss percentage
         currency: Currency code
+        sector: Stock sector classification (None if unavailable)
         bought_at: Purchase date
         note: Optional note
     """
@@ -73,11 +74,13 @@ class HoldingResponse(BaseModel):
     quantity: int = Field(..., description="Number of shares")
     avg_price: float = Field(..., description="Average purchase price")
     current_price: Optional[float] = Field(default=None, description="Current market price")
+    change_pct: Optional[float] = Field(default=None, description="Daily price change percentage")
     market_value: Optional[float] = Field(default=None, description="Current market value")
     cost_basis: float = Field(..., description="Total cost basis (quantity * avg_price)")
     pnl: Optional[float] = Field(default=None, description="Profit/Loss amount")
     pnl_pct: Optional[float] = Field(default=None, description="Profit/Loss percentage")
     currency: str = Field(default="KRW", description="Currency code")
+    sector: Optional[str] = Field(default=None, description="Stock sector classification")
     bought_at: Optional[date] = Field(default=None, description="Purchase date")
     note: Optional[str] = Field(default=None, description="Optional note")
 

--- a/api/services/portfolio_service.py
+++ b/api/services/portfolio_service.py
@@ -160,10 +160,127 @@ class PortfolioService:
             self._price_cache_time = time.monotonic()
             return prices
 
+    def _get_daily_changes(self, tickers: List[str]) -> Dict[str, float]:
+        """
+        Get daily price change percentages for multiple tickers.
+
+        Computes (last_close - prev_close) / prev_close * 100
+        from OHLCV cache data.
+
+        Returns:
+            Dict mapping ticker to change_pct (e.g. -1.5 for -1.5%)
+        """
+        if not tickers:
+            return {}
+
+        changes: Dict[str, float] = {}
+
+        def _calc_change(ticker: str) -> Optional[float]:
+            try:
+                data = self._cache.get(ticker, days=5, force_refresh=False)
+                if data is not None and len(data) >= 2:
+                    cur = float(data["close"].iloc[-1])
+                    prev = float(data["close"].iloc[-2])
+                    if prev > 0:
+                        return (cur - prev) / prev * 100
+            except Exception:
+                pass
+            return None
+
+        with ThreadPoolExecutor(max_workers=min(len(tickers), 8)) as executor:
+            futures = {executor.submit(_calc_change, t): t for t in tickers}
+            for future in as_completed(futures):
+                ticker = futures[future]
+                try:
+                    result = future.result()
+                    if result is not None:
+                        changes[ticker] = result
+                except Exception:
+                    pass
+
+        return changes
+
+    def _get_sectors(self, tickers: List[str]) -> Dict[str, Optional[str]]:
+        """
+        Get sector classifications for multiple tickers.
+
+        For Korean stocks (.KS, .KQ): uses pykrx via SectorFetcher batch lookup.
+        For US stocks (no dot suffix): uses yfinance Ticker.info["sector"].
+        Best-effort: returns None for any ticker whose sector cannot be resolved.
+
+        Args:
+            tickers: List of ticker symbols
+
+        Returns:
+            Dict mapping ticker to sector name (or None)
+        """
+        if not tickers:
+            return {}
+
+        sectors: Dict[str, Optional[str]] = {}
+
+        # Partition tickers by market
+        kr_kospi: List[str] = []
+        kr_kosdaq: List[str] = []
+        us_tickers: List[str] = []
+
+        for t in tickers:
+            if t.endswith(".KS"):
+                kr_kospi.append(t)
+            elif t.endswith(".KQ"):
+                kr_kosdaq.append(t)
+            else:
+                us_tickers.append(t)
+
+        # Korean stocks: batch lookup via SectorFetcher
+        try:
+            from screener.sector_fetcher import get_sector_fetcher
+            fetcher = get_sector_fetcher()
+
+            if kr_kospi:
+                kospi_map = fetcher.get_all_sector_classifications("KOSPI")
+                for t in kr_kospi:
+                    sectors[t] = kospi_map.get(t)
+
+            if kr_kosdaq:
+                kosdaq_map = fetcher.get_all_sector_classifications("KOSDAQ")
+                for t in kr_kosdaq:
+                    sectors[t] = kosdaq_map.get(t)
+        except Exception as e:
+            logger.warning(f"Failed to fetch Korean sector data: {e}")
+            for t in kr_kospi + kr_kosdaq:
+                sectors[t] = None
+
+        # US stocks: per-ticker yfinance lookup in parallel
+        if us_tickers:
+            def _fetch_us_sector(ticker: str) -> Optional[str]:
+                try:
+                    import yfinance as yf
+                    return yf.Ticker(ticker).info.get("sector")
+                except Exception:
+                    return None
+
+            with ThreadPoolExecutor(max_workers=min(len(us_tickers), 8)) as executor:
+                futures = {
+                    executor.submit(_fetch_us_sector, t): t
+                    for t in us_tickers
+                }
+                for future in as_completed(futures):
+                    ticker = futures[future]
+                    try:
+                        sectors[ticker] = future.result()
+                    except Exception as e:
+                        logger.warning(f"Failed to fetch sector for {ticker}: {e}")
+                        sectors[ticker] = None
+
+        return sectors
+
     def _holding_to_response(
         self,
         holding: Dict[str, Any],
-        current_price: Optional[float] = None
+        current_price: Optional[float] = None,
+        sector: Optional[str] = None,
+        change_pct: Optional[float] = None,
     ) -> HoldingResponse:
         """
         Convert holding dict to HoldingResponse with P&L.
@@ -171,6 +288,7 @@ class PortfolioService:
         Args:
             holding: Holding data dict
             current_price: Current market price (optional)
+            sector: Stock sector classification (optional)
 
         Returns:
             HoldingResponse with calculated fields
@@ -202,11 +320,13 @@ class PortfolioService:
             quantity=quantity,
             avg_price=avg_price,
             current_price=current_price,
+            change_pct=change_pct,
             market_value=market_value,
             cost_basis=cost_basis,
             pnl=pnl,
             pnl_pct=pnl_pct,
             currency=holding.get("currency", "KRW"),
+            sector=sector,
             bought_at=bought_at,
             note=holding.get("note")
         )
@@ -228,13 +348,28 @@ class PortfolioService:
         finally:
             db.close()
 
-        prices = {}
+        prices: Dict[str, float] = {}
+        sectors: Dict[str, Optional[str]] = {}
+        changes: Dict[str, float] = {}
         if with_prices and holdings_dicts:
             tickers = [h["ticker"] for h in holdings_dicts]
             prices = self._get_current_prices(tickers)
+            try:
+                changes = self._get_daily_changes(tickers)
+            except Exception as e:
+                logger.warning(f"Daily change enrichment failed: {e}")
+            try:
+                sectors = self._get_sectors(tickers)
+            except Exception as e:
+                logger.warning(f"Sector enrichment failed: {e}")
 
         return [
-            self._holding_to_response(h, prices.get(h["ticker"]))
+            self._holding_to_response(
+                h,
+                prices.get(h["ticker"]),
+                sector=sectors.get(h["ticker"]),
+                change_pct=changes.get(h["ticker"]),
+            )
             for h in holdings_dicts
         ]
 
@@ -259,10 +394,22 @@ class PortfolioService:
             db.close()
 
         current_price = None
+        sector = None
+        change_pct = None
         if with_price:
             current_price = self._get_current_price(ticker)
+            try:
+                sector_map = self._get_sectors([ticker])
+                sector = sector_map.get(ticker)
+            except Exception as e:
+                logger.warning(f"Sector enrichment failed for {ticker}: {e}")
+            try:
+                changes = self._get_daily_changes([ticker])
+                change_pct = changes.get(ticker)
+            except Exception as e:
+                logger.warning(f"Daily change enrichment failed for {ticker}: {e}")
 
-        return self._holding_to_response(holding, current_price)
+        return self._holding_to_response(holding, current_price, sector=sector, change_pct=change_pct)
 
     def add_holding(self, data: HoldingCreate) -> HoldingResponse:
         """

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -371,7 +371,9 @@
     "noTrades": "No trade history yet",
     "tradeQuantity": "Qty",
     "tradeAvgCost": "Avg Cost",
-    "tradePnl": "P&L"
+    "tradePnl": "P&L",
+    "sector": "Sector",
+    "market": "Market"
   },
   "brokerOrderDesk": {
     "title": "Broker Order Desk",
@@ -2771,5 +2773,31 @@
     "macdStrength": "Momentum",
     "macdGrowing": "Getting stronger",
     "macdFading": "Getting weaker"
+  },
+  "allocation": {
+    "stockAllocation": "Stock Allocation",
+    "marketAllocation": "Market Allocation",
+    "sectorAllocation": "Sector Allocation",
+    "totalInvested": "Total Invested",
+    "totalHoldings": "holdings",
+    "sectors": "sectors",
+    "others": "Others",
+    "kospi": "KOSPI",
+    "kosdaq": "KOSDAQ",
+    "us": "US Market",
+    "etf": "ETF",
+    "unknown": "Other",
+    "noData": "Add holdings to see allocation charts",
+    "clearFilter": "Clear filter",
+    "technology": "Technology",
+    "financials": "Financials",
+    "consumer": "Consumer",
+    "healthcare": "Healthcare",
+    "energy": "Energy",
+    "industrials": "Industrials",
+    "materials": "Materials",
+    "realEstate": "Real Estate",
+    "utilities": "Utilities",
+    "communication": "Communication"
   }
 }

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -371,7 +371,9 @@
     "noTrades": "거래 이력이 없습니다",
     "tradeQuantity": "수량",
     "tradeAvgCost": "평단가",
-    "tradePnl": "손익"
+    "tradePnl": "손익",
+    "sector": "섹터",
+    "market": "마켓"
   },
   "brokerOrderDesk": {
     "title": "통합 주문 데스크",
@@ -2771,5 +2773,31 @@
     "macdStrength": "추세 강도",
     "macdGrowing": "점점 강해지는 중",
     "macdFading": "점점 약해지는 중"
+  },
+  "allocation": {
+    "stockAllocation": "종목별 비중",
+    "marketAllocation": "마켓별 비중",
+    "sectorAllocation": "섹터별 비중",
+    "totalInvested": "총 투자금액",
+    "totalHoldings": "종목",
+    "sectors": "섹터",
+    "others": "기타",
+    "kospi": "코스피",
+    "kosdaq": "코스닥",
+    "us": "미국 시장",
+    "etf": "ETF",
+    "unknown": "기타",
+    "noData": "보유 종목을 추가하면 비중 차트를 볼 수 있습니다",
+    "clearFilter": "필터 해제",
+    "technology": "기술",
+    "financials": "금융",
+    "consumer": "소비재",
+    "healthcare": "헬스케어",
+    "energy": "에너지",
+    "industrials": "산업재",
+    "materials": "소재",
+    "realEstate": "부동산",
+    "utilities": "유틸리티",
+    "communication": "통신"
   }
 }

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -371,7 +371,9 @@
     "noTrades": "暂无交易记录",
     "tradeQuantity": "数量",
     "tradeAvgCost": "均价",
-    "tradePnl": "盈亏"
+    "tradePnl": "盈亏",
+    "sector": "行业",
+    "market": "市场"
   },
   "brokerOrderDesk": {
     "title": "统一下单台",
@@ -2771,5 +2773,31 @@
     "macdStrength": "趋势强度",
     "macdGrowing": "逐渐增强",
     "macdFading": "逐渐减弱"
+  },
+  "allocation": {
+    "stockAllocation": "个股比重",
+    "marketAllocation": "市场比重",
+    "sectorAllocation": "行业比重",
+    "totalInvested": "总投资额",
+    "totalHoldings": "持仓",
+    "sectors": "行业",
+    "others": "其他",
+    "kospi": "KOSPI",
+    "kosdaq": "KOSDAQ",
+    "us": "美国市场",
+    "etf": "ETF",
+    "unknown": "其他",
+    "noData": "添加持仓后即可查看比重图表",
+    "clearFilter": "清除筛选",
+    "technology": "科技",
+    "financials": "金融",
+    "consumer": "消费",
+    "healthcare": "医疗",
+    "energy": "能源",
+    "industrials": "工业",
+    "materials": "材料",
+    "realEstate": "房地产",
+    "utilities": "公用事业",
+    "communication": "通信"
   }
 }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -18,6 +18,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-markdown": "^10.1.0",
+        "recharts": "^3.7.0",
         "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
@@ -1619,6 +1620,42 @@
         "node": ">=18"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1630,6 +1667,18 @@
       "version": "1.21.5",
       "resolved": "https://registry.npmjs.org/@schummar/icu-type-parser/-/icu-type-parser-1.21.5.tgz",
       "integrity": "sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@swc/core-darwin-arm64": {
@@ -2136,6 +2185,12 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-color": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
@@ -2151,6 +2206,12 @@
         "@types/d3-selection": "*"
       }
     },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-interpolate": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
@@ -2160,10 +2221,46 @@
         "@types/d3-color": "*"
       }
     },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
     "node_modules/@types/d3-selection": {
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
       "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
     "node_modules/@types/d3-transition": {
@@ -2280,6 +2377,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -3387,6 +3490,15 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3464,6 +3576,18 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-color": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
@@ -3504,6 +3628,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-interpolate": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
@@ -3516,11 +3649,72 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-selection": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -3651,6 +3845,12 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
@@ -3972,6 +4172,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.44.0.tgz",
+      "integrity": "sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -4429,6 +4639,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -4978,6 +5194,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -5024,6 +5250,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/intl-messageformat": {
@@ -7623,7 +7858,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-markdown": {
@@ -7651,6 +7885,74 @@
       "peerDependencies": {
         "@types/react": ">=18",
         "react": ">=18"
+      }
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.7.0.tgz",
+      "integrity": "sha512-l2VCsy3XXeraxIID9fx23eCb6iCBsxUQDnE8tWm6DFdszVAO7WVY/ChAD9wVit01y6B2PMupYiMmQwhgPHc9Ew==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -7762,6 +8064,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -8393,6 +8701,12 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -8899,6 +9213,28 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/which": {

--- a/web/package.json
+++ b/web/package.json
@@ -25,16 +25,17 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-markdown": "^10.1.0",
+    "recharts": "^3.7.0",
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
-    "@playwright/test": "^1.58.2",
     "tailwindcss": "^4",
     "typescript": "5.9.3"
   }

--- a/web/src/app/[locale]/portfolio/page.tsx
+++ b/web/src/app/[locale]/portfolio/page.tsx
@@ -15,7 +15,9 @@ import {
   BrokerOrderDesk,
   SellModal,
   TradeHistory,
+  AllocationCharts,
 } from '@/components/portfolio';
+import { normalizeSector, classifyMarket } from '@/components/portfolio/AllocationCharts';
 import {
   getHoldings,
   addHolding,
@@ -136,6 +138,8 @@ export default function PortfolioPage() {
   // Filter state
   const [activeFilter, setActiveFilter] = useState<FilterTab>('all');
   const [searchQuery, setSearchQuery] = useState('');
+  const [sectorFilter, setSectorFilter] = useState<string | null>(null);
+  const [marketFilter, setMarketFilter] = useState<string | null>(null);
   const [orderDeskPrefill, setOrderDeskPrefill] = useState<OrderDeskPrefill | null>(null);
   const [orderDeskTab, setOrderDeskTab] = useState<'kiwoom' | 'unified'>('unified');
   const tradeHistoryRef = useRef<HTMLDivElement | null>(null);
@@ -459,6 +463,16 @@ export default function PortfolioPage() {
       );
     }
 
+    // Apply sector filter (from chart click)
+    if (sectorFilter) {
+      filtered = filtered.filter((h) => normalizeSector(h.sector) === sectorFilter);
+    }
+
+    // Apply market filter (from chart click)
+    if (marketFilter) {
+      filtered = filtered.filter((h) => classifyMarket(h.ticker) === marketFilter);
+    }
+
     // Apply search filter
     if (searchQuery.trim()) {
       const query = searchQuery.toLowerCase();
@@ -470,7 +484,7 @@ export default function PortfolioPage() {
     }
 
     return filtered;
-  }, [holdings, activeFilter, searchQuery]);
+  }, [holdings, activeFilter, sectorFilter, marketFilter, searchQuery]);
 
   /**
    * Handle adding a new holding
@@ -534,6 +548,18 @@ export default function PortfolioPage() {
     window.open(
       `/${locale}/analysis/${encodeURIComponent(holding.ticker)}?popup=true`,
       `analysis_${holding.ticker}`,
+      `width=${width},height=${height},left=${left},top=${top},scrollbars=yes,resizable=yes`
+    );
+  }, [locale]);
+
+  const handleTreemapTickerClick = useCallback((ticker: string) => {
+    const width = 900;
+    const height = 700;
+    const left = (screen.width - width) / 2;
+    const top = (screen.height - height) / 2;
+    window.open(
+      `/${locale}/analysis/${encodeURIComponent(ticker)}?popup=true`,
+      `analysis_${ticker}`,
       `width=${width},height=${height},left=${left},top=${top},scrollbars=yes,resizable=yes`
     );
   }, [locale]);
@@ -724,6 +750,19 @@ export default function PortfolioPage() {
             iconBgClass="bg-amber-50 dark:bg-amber-900/20 text-amber-600 dark:text-amber-400"
           />
         </div>
+      )}
+
+      {/* Allocation Charts */}
+      {!isLoading && holdings.length > 0 && (
+        <AllocationCharts
+          holdings={holdings}
+          formatCurrency={formatCurrency}
+          onSectorClick={setSectorFilter}
+          onMarketClick={setMarketFilter}
+          onTickerClick={handleTreemapTickerClick}
+          activeSectorFilter={sectorFilter}
+          activeMarketFilter={marketFilter}
+        />
       )}
 
       {/* Search + Filter */}

--- a/web/src/components/portfolio/AllocationCharts.tsx
+++ b/web/src/components/portfolio/AllocationCharts.tsx
@@ -1,0 +1,491 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useTranslations } from 'next-intl';
+import {
+  Treemap,
+  PieChart,
+  Pie,
+  Cell,
+  ResponsiveContainer,
+  Tooltip,
+} from 'recharts';
+import type { Holding } from '@/lib/types';
+
+interface AllocationChartsProps {
+  holdings: Holding[];
+  formatCurrency: (amount: number, currency?: string) => string;
+  onSectorClick?: (sector: string | null) => void;
+  onMarketClick?: (market: string | null) => void;
+  onTickerClick?: (ticker: string) => void;
+  activeSectorFilter?: string | null;
+  activeMarketFilter?: string | null;
+}
+
+// Color palette for treemap cells (muted, distinct hues)
+const TREEMAP_COLORS = [
+  '#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6',
+  '#ec4899', '#06b6d4', '#84cc16', '#f97316', '#6366f1',
+  '#14b8a6', '#e11d48', '#0ea5e9', '#a855f7', '#22c55e',
+  '#eab308', '#d946ef', '#64748b', '#f43f5e', '#0891b2',
+];
+
+// Market donut colors
+export const MARKET_COLORS: Record<string, string> = {
+  KOSPI: '#3b82f6',
+  KOSDAQ: '#10b981',
+  US: '#f59e0b',
+  ETF: '#8b5cf6',
+  unknown: '#94a3b8',
+};
+
+// Sector donut colors
+export const SECTOR_COLORS: Record<string, string> = {
+  Technology: '#3b82f6',
+  Financials: '#10b981',
+  Consumer: '#f59e0b',
+  Healthcare: '#ef4444',
+  Energy: '#8b5cf6',
+  Industrials: '#06b6d4',
+  Materials: '#84cc16',
+  'Real Estate': '#ec4899',
+  Utilities: '#f97316',
+  Communication: '#6366f1',
+  Others: '#94a3b8',
+};
+
+export function classifyMarket(ticker: string): string {
+  if (ticker.endsWith('.KS')) return 'KOSPI';
+  if (ticker.endsWith('.KQ')) return 'KOSDAQ';
+  // Simple ETF heuristic: common ETF patterns
+  const base = ticker.split('.')[0];
+  if (/^(SPY|QQQ|IWM|DIA|VOO|VTI|ARKK|XL[A-Z]|KODEX|TIGER|KBSTAR|KOSEF)/i.test(base)) return 'ETF';
+  return 'US';
+}
+
+// Explicit mapping for pykrx Korean sector names → normalized category
+const KR_SECTOR_MAP: Record<string, string> = {
+  '전기·전자': 'Technology',
+  'IT 서비스': 'Technology',
+  '화학': 'Materials',
+  '금속': 'Materials',
+  '비금속': 'Materials',
+  '종이·목재': 'Materials',
+  '섬유·의류': 'Consumer',
+  '음식료·담배': 'Consumer',
+  '유통': 'Consumer',
+  '오락·문화': 'Consumer',
+  '일반서비스': 'Consumer',
+  '건설': 'Industrials',
+  '기계·장비': 'Industrials',
+  '운송·창고': 'Industrials',
+  '운송장비·부품': 'Industrials',
+  '기타제조': 'Industrials',
+  '제약': 'Healthcare',
+  '의료·정밀기기': 'Healthcare',
+  '은행': 'Financials',
+  '보험': 'Financials',
+  '증권': 'Financials',
+  '기타금융': 'Financials',
+  '금융': 'Financials',
+  '전기·가스': 'Utilities',
+  '전기·가스·수도': 'Utilities',
+  '통신': 'Communication',
+  '출판·매체복제': 'Communication',
+  '부동산': 'Real Estate',
+  '농업 임업 및 어업': 'Others',
+};
+
+export function normalizeSector(sector: string | null | undefined): string {
+  if (!sector) return 'Others';
+
+  // Check exact Korean sector name first (pykrx)
+  const mapped = KR_SECTOR_MAP[sector];
+  if (mapped) return mapped;
+
+  // Fallback: fuzzy match for yfinance English sectors
+  const s = sector.toLowerCase();
+  if (s.includes('technol') || s.includes('information')) return 'Technology';
+  if (s.includes('financ')) return 'Financials';
+  if (s.includes('consumer')) return 'Consumer';
+  if (s.includes('health')) return 'Healthcare';
+  if (s.includes('energy')) return 'Energy';
+  if (s.includes('industrial')) return 'Industrials';
+  if (s.includes('material') || s.includes('basic')) return 'Materials';
+  if (s.includes('real estate')) return 'Real Estate';
+  if (s.includes('utilit')) return 'Utilities';
+  if (s.includes('communic')) return 'Communication';
+  return 'Others';
+}
+
+// Sector key map for i18n
+const SECTOR_I18N_KEY: Record<string, string> = {
+  Technology: 'technology',
+  Financials: 'financials',
+  Consumer: 'consumer',
+  Healthcare: 'healthcare',
+  Energy: 'energy',
+  Industrials: 'industrials',
+  Materials: 'materials',
+  'Real Estate': 'realEstate',
+  Utilities: 'utilities',
+  Communication: 'communication',
+  Others: 'others',
+};
+
+const MARKET_I18N_KEY: Record<string, string> = {
+  KOSPI: 'kospi',
+  KOSDAQ: 'kosdaq',
+  US: 'us',
+  ETF: 'etf',
+  unknown: 'unknown',
+};
+
+interface TreemapContentProps {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  name: string;
+  pct: number;
+  fill: string;
+}
+
+function TreemapContent({ x, y, width, height, name, pct, fill }: TreemapContentProps) {
+  if (width < 40 || height < 30) return null;
+  const fontSize = Math.min(width / 8, height / 3, 14);
+  const showPct = width > 55 && height > 40;
+
+  return (
+    <g>
+      <rect x={x} y={y} width={width} height={height} rx={4} fill={fill} stroke="var(--background-secondary)" strokeWidth={2} />
+      <text
+        x={x + width / 2}
+        y={y + height / 2 - (showPct ? 6 : 0)}
+        textAnchor="middle"
+        dominantBaseline="central"
+        fill="#fff"
+        fontSize={fontSize}
+        fontWeight={600}
+      >
+        {name}
+      </text>
+      {showPct && (
+        <text
+          x={x + width / 2}
+          y={y + height / 2 + fontSize}
+          textAnchor="middle"
+          dominantBaseline="central"
+          fill="rgba(255,255,255,0.8)"
+          fontSize={fontSize * 0.8}
+        >
+          {pct.toFixed(1)}%
+        </text>
+      )}
+    </g>
+  );
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function renderDonutLabel(props: any) {
+  const { cx, cy, midAngle, innerRadius, outerRadius, percent, name } = props;
+  if (!percent || percent < 0.05) return null;
+  const RADIAN = Math.PI / 180;
+  const radius = (innerRadius ?? 0) + ((outerRadius ?? 0) - (innerRadius ?? 0)) * 0.5;
+  const x = (cx ?? 0) + radius * Math.cos(-(midAngle ?? 0) * RADIAN);
+  const y = (cy ?? 0) + radius * Math.sin(-(midAngle ?? 0) * RADIAN);
+
+  return (
+    <text x={x} y={y} fill="#fff" textAnchor="middle" dominantBaseline="central" fontSize={11} fontWeight={600}>
+      {(name ?? '').length > 5 ? `${(percent * 100).toFixed(0)}%` : `${name}`}
+    </text>
+  );
+}
+
+export default function AllocationCharts({ holdings, formatCurrency, onSectorClick, onMarketClick, onTickerClick, activeSectorFilter, activeMarketFilter }: AllocationChartsProps) {
+  const t = useTranslations('allocation');
+
+  const { treemapData, marketData, sectorData, totalInvested } = useMemo(() => {
+    const holdingsWithValue = holdings.filter(
+      (h) => h.market_value != null && h.market_value > 0
+    );
+
+    if (holdingsWithValue.length === 0) {
+      return { treemapData: [], marketData: [], sectorData: [], totalInvested: 0 };
+    }
+
+    const total = holdingsWithValue.reduce((sum, h) => sum + (h.market_value ?? 0), 0);
+
+    // Treemap: per-stock allocation
+    const treeItems = holdingsWithValue
+      .map((h, i) => ({
+        name: h.name || h.ticker,
+        ticker: h.ticker,
+        value: h.market_value ?? 0,
+        pct: ((h.market_value ?? 0) / total) * 100,
+        fill: TREEMAP_COLORS[i % TREEMAP_COLORS.length],
+      }))
+      .sort((a, b) => b.value - a.value);
+
+    // Market donut: group by market
+    const marketGroups = new Map<string, number>();
+    for (const h of holdingsWithValue) {
+      const market = classifyMarket(h.ticker);
+      marketGroups.set(market, (marketGroups.get(market) ?? 0) + (h.market_value ?? 0));
+    }
+    const mktData = Array.from(marketGroups.entries())
+      .map(([name, value]) => ({
+        name,
+        displayName: t(MARKET_I18N_KEY[name] ?? 'unknown'),
+        value,
+        pct: (value / total) * 100,
+        color: MARKET_COLORS[name] ?? '#94a3b8',
+      }))
+      .sort((a, b) => b.value - a.value);
+
+    // Sector donut: group by sector
+    const sectorGroups = new Map<string, number>();
+    for (const h of holdingsWithValue) {
+      const sector = normalizeSector(h.sector);
+      sectorGroups.set(sector, (sectorGroups.get(sector) ?? 0) + (h.market_value ?? 0));
+    }
+    const secData = Array.from(sectorGroups.entries())
+      .map(([name, value]) => ({
+        name,
+        displayName: t(SECTOR_I18N_KEY[name] ?? 'others'),
+        value,
+        pct: (value / total) * 100,
+        color: SECTOR_COLORS[name] ?? '#94a3b8',
+      }))
+      .sort((a, b) => b.value - a.value);
+
+    return {
+      treemapData: treeItems,
+      marketData: mktData,
+      sectorData: secData,
+      totalInvested: total,
+    };
+  }, [holdings, t]);
+
+  if (treemapData.length === 0) {
+    return null;
+  }
+
+  // Determine primary currency from first holding
+  const primaryCurrency = holdings[0]?.currency ?? 'KRW';
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+      {/* Treemap: Stock Allocation */}
+      <div className="rounded-lg border border-[var(--border)] bg-[var(--background-secondary)] shadow-sm lg:row-span-2">
+        <div className="border-b border-[var(--border)] px-6 py-4">
+          <h3 className="text-lg font-semibold text-[var(--foreground)]">{t('stockAllocation')}</h3>
+          <p className="text-sm text-[var(--foreground-muted)] mt-1">
+            {treemapData.length} {t('totalHoldings')} &middot; {formatCurrency(totalInvested, primaryCurrency)}
+          </p>
+        </div>
+        <div className="p-4">
+          <ResponsiveContainer width="100%" height={360}>
+            <Treemap
+              data={treemapData}
+              dataKey="value"
+              stroke="none"
+              content={<TreemapContent x={0} y={0} width={0} height={0} name="" pct={0} fill="" />}
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              onClick={onTickerClick ? (node: any) => {
+                if (node?.ticker) onTickerClick(node.ticker);
+              } : undefined}
+              style={onTickerClick ? { cursor: 'pointer' } : undefined}
+            >
+              <Tooltip
+                content={({ payload }) => {
+                  if (!payload || payload.length === 0) return null;
+                  const d = payload[0].payload;
+                  return (
+                    <div className="rounded-lg border border-[var(--border)] bg-[var(--background-secondary)] px-3 py-2 shadow-lg text-sm">
+                      <div className="font-semibold text-[var(--foreground)]">{d.name}</div>
+                      <div className="text-[var(--foreground-muted)]">{d.ticker}</div>
+                      <div className="mt-1 text-[var(--foreground)]">{d.pct.toFixed(1)}%</div>
+                    </div>
+                  );
+                }}
+              />
+            </Treemap>
+          </ResponsiveContainer>
+          {/* Legend: top 5 stocks */}
+          <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-xs text-[var(--foreground-muted)]">
+            {treemapData.slice(0, 5).map((item) => (
+              <span key={item.ticker} className="flex items-center gap-1">
+                <span className="inline-block h-2.5 w-2.5 rounded-sm" style={{ backgroundColor: item.fill }} />
+                {item.name} {item.pct.toFixed(1)}%
+              </span>
+            ))}
+            {treemapData.length > 5 && (
+              <span className="text-[var(--foreground-muted)]">+{treemapData.length - 5} {t('others').toLowerCase()}</span>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Market Donut */}
+      <div className="rounded-lg border border-[var(--border)] bg-[var(--background-secondary)] shadow-sm">
+        <div className="border-b border-[var(--border)] px-6 py-4 flex items-center justify-between">
+          <h3 className="text-lg font-semibold text-[var(--foreground)]">{t('marketAllocation')}</h3>
+          {activeMarketFilter && (
+            <button
+              type="button"
+              onClick={() => onMarketClick?.(null)}
+              className="text-xs text-[var(--color-primary)] hover:underline"
+            >
+              {t('clearFilter')}
+            </button>
+          )}
+        </div>
+        <div className="p-4 flex items-center gap-4">
+          <div className="w-1/2 flex-shrink-0">
+            <ResponsiveContainer width="100%" height={160}>
+              <PieChart>
+                <Pie
+                  data={marketData}
+                  dataKey="value"
+                  nameKey="displayName"
+                  cx="50%"
+                  cy="50%"
+                  innerRadius="50%"
+                  outerRadius="90%"
+                  strokeWidth={2}
+                  stroke="var(--background-secondary)"
+                  label={renderDonutLabel}
+                  labelLine={false}
+                  onClick={onMarketClick ? (_: unknown, index: number) => {
+                    const clicked = marketData[index]?.name;
+                    if (clicked) onMarketClick(activeMarketFilter === clicked ? null : clicked);
+                  } : undefined}
+                  style={onMarketClick ? { cursor: 'pointer' } : undefined}
+                >
+                  {marketData.map((entry) => (
+                    <Cell
+                      key={entry.name}
+                      fill={entry.color}
+                      opacity={activeMarketFilter && activeMarketFilter !== entry.name ? 0.3 : 1}
+                    />
+                  ))}
+                </Pie>
+                <Tooltip
+                  content={({ payload }) => {
+                    if (!payload || payload.length === 0) return null;
+                    const d = payload[0].payload;
+                    return (
+                      <div className="rounded-lg border border-[var(--border)] bg-[var(--background-secondary)] px-3 py-2 shadow-lg text-sm">
+                        <div className="font-semibold text-[var(--foreground)]">{d.displayName}</div>
+                        <div className="text-[var(--foreground)]">{d.pct.toFixed(1)}%</div>
+                      </div>
+                    );
+                  }}
+                />
+              </PieChart>
+            </ResponsiveContainer>
+          </div>
+          <div className="flex flex-col gap-2 text-sm">
+            {marketData.map((item) => (
+              <button
+                key={item.name}
+                type="button"
+                onClick={() => onMarketClick?.(activeMarketFilter === item.name ? null : item.name)}
+                className={`flex items-center gap-2 rounded-md px-2 py-1 transition-colors text-left ${
+                  activeMarketFilter === item.name
+                    ? 'bg-[var(--color-primary)]/10 ring-1 ring-[var(--color-primary)]'
+                    : 'hover:bg-[var(--background)]/50'
+                } ${activeMarketFilter && activeMarketFilter !== item.name ? 'opacity-40' : ''}`}
+              >
+                <span className="inline-block h-3 w-3 rounded-full flex-shrink-0" style={{ backgroundColor: item.color }} />
+                <span className="text-[var(--foreground)]">{item.displayName}</span>
+                <span className="text-[var(--foreground-muted)] ml-auto">{item.pct.toFixed(1)}%</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Sector Donut */}
+      <div className="rounded-lg border border-[var(--border)] bg-[var(--background-secondary)] shadow-sm">
+        <div className="border-b border-[var(--border)] px-6 py-4 flex items-center justify-between">
+          <h3 className="text-lg font-semibold text-[var(--foreground)]">{t('sectorAllocation')}</h3>
+          {activeSectorFilter && (
+            <button
+              type="button"
+              onClick={() => onSectorClick?.(null)}
+              className="text-xs text-[var(--color-primary)] hover:underline"
+            >
+              {t('clearFilter')}
+            </button>
+          )}
+        </div>
+        <div className="p-4 flex items-center gap-4">
+          <div className="w-1/2 flex-shrink-0">
+            <ResponsiveContainer width="100%" height={160}>
+              <PieChart>
+                <Pie
+                  data={sectorData}
+                  dataKey="value"
+                  nameKey="displayName"
+                  cx="50%"
+                  cy="50%"
+                  innerRadius="50%"
+                  outerRadius="90%"
+                  strokeWidth={2}
+                  stroke="var(--background-secondary)"
+                  label={renderDonutLabel}
+                  labelLine={false}
+                  onClick={onSectorClick ? (_: unknown, index: number) => {
+                    const clicked = sectorData[index]?.name;
+                    if (clicked) onSectorClick(activeSectorFilter === clicked ? null : clicked);
+                  } : undefined}
+                  style={onSectorClick ? { cursor: 'pointer' } : undefined}
+                >
+                  {sectorData.map((entry) => (
+                    <Cell
+                      key={entry.name}
+                      fill={entry.color}
+                      opacity={activeSectorFilter && activeSectorFilter !== entry.name ? 0.3 : 1}
+                    />
+                  ))}
+                </Pie>
+                <Tooltip
+                  content={({ payload }) => {
+                    if (!payload || payload.length === 0) return null;
+                    const d = payload[0].payload;
+                    return (
+                      <div className="rounded-lg border border-[var(--border)] bg-[var(--background-secondary)] px-3 py-2 shadow-lg text-sm">
+                        <div className="font-semibold text-[var(--foreground)]">{d.displayName}</div>
+                        <div className="text-[var(--foreground)]">{d.pct.toFixed(1)}%</div>
+                      </div>
+                    );
+                  }}
+                />
+              </PieChart>
+            </ResponsiveContainer>
+          </div>
+          <div className="flex flex-col gap-2 text-sm">
+            {sectorData.map((item) => (
+              <button
+                key={item.name}
+                type="button"
+                onClick={() => onSectorClick?.(activeSectorFilter === item.name ? null : item.name)}
+                className={`flex items-center gap-2 rounded-md px-2 py-1 transition-colors text-left ${
+                  activeSectorFilter === item.name
+                    ? 'bg-[var(--color-primary)]/10 ring-1 ring-[var(--color-primary)]'
+                    : 'hover:bg-[var(--background)]/50'
+                } ${activeSectorFilter && activeSectorFilter !== item.name ? 'opacity-40' : ''}`}
+              >
+                <span className="inline-block h-3 w-3 rounded-full flex-shrink-0" style={{ backgroundColor: item.color }} />
+                <span className="text-[var(--foreground)]">{item.displayName}</span>
+                <span className="text-[var(--foreground-muted)] ml-auto">{item.pct.toFixed(1)}%</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/portfolio/HoldingsTable.tsx
+++ b/web/src/components/portfolio/HoldingsTable.tsx
@@ -5,8 +5,9 @@ import { useTranslations, useLocale } from 'next-intl';
 import { ArrowUpDown, Edit2, Trash2, TrendingUp, TrendingDown, BarChart3, Banknote } from 'lucide-react';
 import type { Holding } from '@/lib/types';
 import { formatCurrency as formatCurrencyUtil, formatQuantity as formatQuantityUtil, formatPercent as formatPercentUtil } from '@/lib/format';
+import { classifyMarket, normalizeSector, MARKET_COLORS, SECTOR_COLORS } from './AllocationCharts';
 
-type SortField = 'ticker' | 'name' | 'quantity' | 'avg_price' | 'current_price' | 'market_value' | 'pnl' | 'pnl_pct';
+type SortField = 'ticker' | 'name' | 'sector' | 'market' | 'quantity' | 'avg_price' | 'current_price' | 'market_value' | 'pnl' | 'pnl_pct';
 type SortDirection = 'asc' | 'desc';
 
 interface HoldingsTableProps {
@@ -63,6 +64,25 @@ function SortButton({ field, currentField, direction, children, onSort, align = 
 // Local wrappers that capture the locale from the component tree.
 // The actual implementations live in @/lib/format.
 
+const SECTOR_I18N: Record<string, string> = {
+  Technology: 'technology', Financials: 'financials', Consumer: 'consumer',
+  Healthcare: 'healthcare', Energy: 'energy', Industrials: 'industrials',
+  Materials: 'materials', 'Real Estate': 'realEstate', Utilities: 'utilities',
+  Communication: 'communication', Others: 'others',
+};
+
+const MARKET_I18N: Record<string, string> = {
+  KOSPI: 'kospi', KOSDAQ: 'kosdaq', US: 'us', ETF: 'etf', unknown: 'unknown',
+};
+
+function sectorI18nKey(sector: string): string {
+  return SECTOR_I18N[sector] ?? 'others';
+}
+
+function marketI18nKey(market: string): string {
+  return MARKET_I18N[market] ?? 'unknown';
+}
+
 /**
  * Get color class based on P&L value
  */
@@ -87,6 +107,7 @@ export default function HoldingsTable({
   priceChangeDirection,
 }: HoldingsTableProps) {
   const t = useTranslations('portfolio');
+  const ta = useTranslations('allocation');
   const locale = useLocale();
   const formatCurrency = (value: number | null, currency?: string) => formatCurrencyUtil(value, currency, locale);
   const formatPercent = (value: number | null) => formatPercentUtil(value);
@@ -104,6 +125,12 @@ export default function HoldingsTable({
           break;
         case 'name':
           comparison = (a.name || '').localeCompare(b.name || '');
+          break;
+        case 'sector':
+          comparison = normalizeSector(a.sector).localeCompare(normalizeSector(b.sector));
+          break;
+        case 'market':
+          comparison = classifyMarket(a.ticker).localeCompare(classifyMarket(b.ticker));
           break;
         case 'quantity':
           comparison = a.quantity - b.quantity;
@@ -172,13 +199,18 @@ export default function HoldingsTable({
           <thead>
             <tr className="border-b border-[var(--border)] bg-[var(--background)]/50">
               <th className="px-4 py-3 text-left">
-                <SortButton field="ticker" currentField={sortField} direction={sortDirection} onSort={handleSort}>
-                  {t('ticker')}
+                <SortButton field="name" currentField={sortField} direction={sortDirection} onSort={handleSort}>
+                  {t('name')}
                 </SortButton>
               </th>
               <th className="px-4 py-3 text-left">
-                <SortButton field="name" currentField={sortField} direction={sortDirection} onSort={handleSort}>
-                  {t('name')}
+                <SortButton field="sector" currentField={sortField} direction={sortDirection} onSort={handleSort}>
+                  {t('sector')}
+                </SortButton>
+              </th>
+              <th className="px-4 py-3 text-left">
+                <SortButton field="market" currentField={sortField} direction={sortDirection} onSort={handleSort}>
+                  {t('market')}
                 </SortButton>
               </th>
               <th className="px-4 py-3 text-right">
@@ -223,13 +255,20 @@ export default function HoldingsTable({
                 onClick={() => onRowClick?.(holding)}
                 className={`border-b border-[var(--border)] hover:bg-blue-50/50 dark:hover:bg-blue-900/10 transition-colors ${onRowClick ? 'cursor-pointer' : ''}`}
               >
+                <td className="px-4 py-3 text-[var(--foreground)]">
+                  {holding.name || holding.ticker}
+                </td>
                 <td className="px-4 py-3">
-                  <span className="font-mono font-medium text-[var(--color-primary)]">
-                    {holding.ticker}
+                  <span className="inline-flex items-center gap-1.5 rounded-full bg-[var(--background)] px-2.5 py-0.5 text-xs text-[var(--foreground-muted)]">
+                    <span className="inline-block h-2 w-2 rounded-full flex-shrink-0" style={{ backgroundColor: SECTOR_COLORS[normalizeSector(holding.sector)] ?? '#94a3b8' }} />
+                    {ta(sectorI18nKey(normalizeSector(holding.sector)))}
                   </span>
                 </td>
-                <td className="px-4 py-3 text-[var(--foreground)]">
-                  {holding.name || '-'}
+                <td className="px-4 py-3">
+                  <span className="inline-flex items-center gap-1.5 rounded-full bg-[var(--background)] px-2.5 py-0.5 text-xs text-[var(--foreground-muted)]">
+                    <span className="inline-block h-2 w-2 rounded-full flex-shrink-0" style={{ backgroundColor: MARKET_COLORS[classifyMarket(holding.ticker)] ?? '#94a3b8' }} />
+                    {ta(marketI18nKey(classifyMarket(holding.ticker)))}
+                  </span>
                 </td>
                 <td className="px-4 py-3 text-right font-mono text-[var(--foreground)]">
                   {formatQuantity(holding.quantity)}
@@ -238,7 +277,7 @@ export default function HoldingsTable({
                   {formatCurrency(holding.avg_price, holding.currency)}
                 </td>
                 <td
-                  className={`px-4 py-3 text-right font-mono text-[var(--foreground)] transition-colors ${
+                  className={`px-4 py-3 text-right font-mono transition-colors ${getPnlColorClass(holding.change_pct)} ${
                     priceChangeDirection?.[holding.ticker] === 'up'
                       ? 'bg-red-100/70 dark:bg-red-900/30'
                       : priceChangeDirection?.[holding.ticker] === 'down'
@@ -246,7 +285,16 @@ export default function HoldingsTable({
                       : ''
                   }`}
                 >
-                  {formatCurrency(holding.current_price, holding.currency)}
+                  <span className="flex items-center justify-end gap-1">
+                    {holding.change_pct !== null && holding.change_pct !== undefined && holding.change_pct !== 0 && (
+                      holding.change_pct > 0 ? (
+                        <TrendingUp className="h-3.5 w-3.5" />
+                      ) : (
+                        <TrendingDown className="h-3.5 w-3.5" />
+                      )
+                    )}
+                    {formatCurrency(holding.current_price, holding.currency)}
+                  </span>
                 </td>
                 <td className="px-4 py-3 text-right font-mono text-[var(--foreground)]">
                   {formatCurrency(holding.market_value, holding.currency)}
@@ -367,8 +415,8 @@ function MobileCard({ holding, onRowClick, onEdit, onDelete, onAnalyze, onSell, 
             <span className="font-mono font-medium text-[var(--color-primary)]">
               {holding.ticker}
             </span>
-            {holding.pnl !== null && holding.pnl !== 0 && (
-              holding.pnl > 0 ? (
+            {holding.change_pct !== null && holding.change_pct !== undefined && holding.change_pct !== 0 && (
+              holding.change_pct > 0 ? (
                 <TrendingUp className="h-4 w-4 text-green-600 dark:text-green-400" />
               ) : (
                 <TrendingDown className="h-4 w-4 text-red-600 dark:text-red-400" />
@@ -439,7 +487,7 @@ function MobileCard({ holding, onRowClick, onEdit, onDelete, onAnalyze, onSell, 
         <div>
           <p className="text-[var(--foreground-muted)]">{t('currentPrice')}</p>
           <p
-            className={`font-mono font-medium text-[var(--foreground)] inline-block rounded px-1 transition-colors ${
+            className={`font-mono font-medium inline-flex items-center gap-1 rounded px-1 transition-colors ${getPnlColorClass(holding.change_pct)} ${
               priceChangeDirection?.[holding.ticker] === 'up'
                 ? 'bg-red-100/70 dark:bg-red-900/30'
                 : priceChangeDirection?.[holding.ticker] === 'down'
@@ -447,6 +495,13 @@ function MobileCard({ holding, onRowClick, onEdit, onDelete, onAnalyze, onSell, 
                 : ''
             }`}
           >
+            {holding.change_pct !== null && holding.change_pct !== undefined && holding.change_pct !== 0 && (
+              holding.change_pct > 0 ? (
+                <TrendingUp className="h-3.5 w-3.5" />
+              ) : (
+                <TrendingDown className="h-3.5 w-3.5" />
+              )
+            )}
             {formatCurrency(holding.current_price, holding.currency)}
           </p>
         </div>

--- a/web/src/components/portfolio/index.ts
+++ b/web/src/components/portfolio/index.ts
@@ -8,3 +8,4 @@ export { default as OrderDesk } from './OrderDesk';
 export { default as BrokerOrderDesk } from './BrokerOrderDesk';
 export { default as SellModal } from './SellModal';
 export { default as TradeHistory } from './TradeHistory';
+export { default as AllocationCharts } from './AllocationCharts';

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -132,10 +132,12 @@ export interface Holding {
   quantity: number;
   avg_price: number;
   current_price: number | null;
+  change_pct: number | null;
   market_value: number | null;
   pnl: number | null;
   pnl_pct: number | null;
   currency: string;
+  sector: string | null;
 }
 
 export interface HoldingCreate {


### PR DESCRIPTION
## Summary
- Add **Treemap** (stock allocation by weight) + **Market/Sector donut** charts using recharts
- Backend enriches holdings with **sector** (pykrx for KR, yfinance for US) and **daily change_pct** from OHLCV cache
- Holdings table gains **sector + market columns** with color-coded badges matching chart palette
- **Interactive filtering**: click sector/market donut segment → filter holdings list; click treemap cell → open analysis popup
- Current price **TrendingUp/TrendingDown** icons now reflect **actual daily change**, not P&L vs avg price
- i18n: 23 allocation namespace keys added for en/ko/zh

Closes #956

## Test plan
- [ ] Navigate to `/portfolio` — verify Treemap + 2 donuts render with holdings data
- [ ] Click sector donut segment → holdings list filters to that sector
- [ ] Click market donut segment → holdings list filters to that market
- [ ] Click treemap cell → analysis popup opens for that ticker
- [ ] Verify current price icons match actual daily price direction (compare with market data)
- [ ] Check mobile responsive layout (375×812)
- [ ] `npm run build` passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)