### PR TITLE
feat(strategy): add AI chatbot MVP (#966)

### DIFF
--- a/api/routers/strategy.py
+++ b/api/routers/strategy.py
@@ -13,6 +13,7 @@ import time
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import StreamingResponse
 
+from api.schemas.strategy_chat import StrategyChatRequest
 from api.schemas.strategy import (
     ConditionsListResponse,
     SavedStrategiesListResponse,
@@ -372,6 +373,44 @@ async def run_strategy_stream(request: StrategyExecuteRequest):
                     break
         finally:
             cancel_event.set()
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+@router.post(
+    "/chat",
+    summary="Chat with strategy assistant",
+    description="Send a message to the AI strategy assistant. Returns SSE stream.",
+)
+async def strategy_chat(request: StrategyChatRequest):
+    """Stream AI chat responses for strategy building assistance."""
+    from api.services.strategy_chat_service import get_strategy_chat_service
+
+    service = get_strategy_chat_service()
+    if not service.is_available():
+        raise HTTPException(
+            status_code=503,
+            detail="Strategy chat not available. Set ANTHROPIC_API_KEY.",
+        )
+
+    def event_stream():
+        try:
+            for chunk in service.stream_chat(
+                [{"role": m.role, "content": m.content} for m in request.messages],
+                request.graph,
+            ):
+                yield f"data: {json.dumps({'type': 'chunk', 'content': chunk})}\n\n"
+            yield f"data: {json.dumps({'type': 'done'})}\n\n"
+        except Exception as e:
+            logger.exception("Strategy chat failed")
+            yield f"data: {json.dumps({'type': 'error', 'message': 'An error occurred while processing your request.'})}\n\n"
 
     return StreamingResponse(
         event_stream(),

--- a/api/schemas/strategy_chat.py
+++ b/api/schemas/strategy_chat.py
@@ -1,0 +1,32 @@
+"""
+Strategy Chat Schemas.
+
+Pydantic models for the strategy chatbot SSE endpoint.
+"""
+
+from typing import Any, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class ChatMessage(BaseModel):
+    """A single message in the conversation."""
+
+    role: Literal["user", "assistant"] = Field(
+        ..., description="Message role: 'user' or 'assistant'"
+    )
+    content: str = Field(
+        ..., max_length=4000, description="Message text"
+    )
+
+
+class StrategyChatRequest(BaseModel):
+    """Request body for the strategy chat endpoint."""
+
+    messages: list[ChatMessage] = Field(
+        ..., max_length=50, description="Conversation history (max 50 turns)"
+    )
+    graph: Optional[dict[str, Any]] = Field(
+        None,
+        description="Current strategy graph (serialized nodes and edges)",
+    )

--- a/api/services/strategy_chat_service.py
+++ b/api/services/strategy_chat_service.py
@@ -1,0 +1,123 @@
+"""
+Strategy Chat Service.
+
+Provides streaming chat with Claude for strategy building assistance.
+"""
+
+import json
+import logging
+import os
+from typing import Any, Generator, Optional
+
+logger = logging.getLogger(__name__)
+
+# Max characters for graph JSON injected into system prompt
+_MAX_GRAPH_CHARS = 4000
+
+SYSTEM_PROMPT = """\
+You are a quant strategy assistant for QuantCanvas, a visual strategy builder.
+
+## Your Role
+Help users build stock screening strategies by recommending which nodes to use \
+and how to connect them. Explain conditions, parameters, and strategy logic \
+in a clear, practical way.
+
+## Node Types
+- **Universe**: Market selection (KOSPI, KOSDAQ, SP500, NASDAQ100)
+- **Sector**: Filter by industry sector
+- **Condition**: Screening filter (48 types across categories: \
+valuation, profitability, growth, momentum, stability, technical, volume)
+- **Logic**: Combine conditions with AND / OR / NOT operators
+- **Output**: Final result node (connects to the end of the pipeline)
+
+## Strategy Flow
+Universe → [Sector] → Condition(s) → [Logic groups] → Output
+
+## Guidelines
+- Recommend specific condition nodes with parameter values
+- Explain why certain conditions work well together
+- Keep responses concise and actionable
+- Match the language of the user's message (Korean → Korean, English → English)
+"""
+
+
+class StrategyChatService:
+    """Streaming chat service using Anthropic API."""
+
+    def __init__(self, api_key: str):
+        self._api_key = api_key
+        self._client = None
+
+    @property
+    def client(self):
+        if self._client is None:
+            import anthropic
+
+            self._client = anthropic.Anthropic(api_key=self._api_key)
+        return self._client
+
+    def is_available(self) -> bool:
+        return bool(self._api_key)
+
+    def stream_chat(
+        self,
+        messages: list[dict[str, str]],
+        graph: Optional[dict[str, Any]] = None,
+    ) -> Generator[str, None, None]:
+        """Stream chat response chunks from Claude.
+
+        Args:
+            messages: Conversation history [{"role": ..., "content": ...}]
+            graph: Optional current strategy graph for context.
+
+        Yields:
+            Text chunks as they arrive from the API.
+
+        Raises:
+            Exception: Re-raised after logging if the Anthropic API call fails.
+        """
+        import anthropic
+
+        system = SYSTEM_PROMPT
+        if graph:
+            graph_json = json.dumps(graph, ensure_ascii=False, indent=2)
+            if len(graph_json) > _MAX_GRAPH_CHARS:
+                graph_json = graph_json[:_MAX_GRAPH_CHARS] + "\n... (truncated)"
+            system += f"\n\n## Current Strategy Graph\n```json\n{graph_json}\n```"
+
+        api_messages = [{"role": m["role"], "content": m["content"]} for m in messages]
+
+        logger.info(
+            "Strategy chat: %d messages, graph=%s", len(api_messages), bool(graph)
+        )
+
+        try:
+            with self.client.messages.stream(
+                model="claude-sonnet-4-20250514",
+                max_tokens=1024,
+                system=system,
+                messages=api_messages,
+            ) as stream:
+                for text in stream.text_stream:
+                    yield text
+        except anthropic.RateLimitError:
+            logger.warning("Strategy chat: rate limit hit")
+            raise
+        except anthropic.APIConnectionError:
+            logger.warning("Strategy chat: connection error")
+            raise
+        except anthropic.APIStatusError as e:
+            logger.error("Strategy chat: API status error %s", e.status_code)
+            raise
+
+
+_instance: Optional[StrategyChatService] = None
+
+
+def get_strategy_chat_service() -> StrategyChatService:
+    """Return singleton StrategyChatService instance."""
+    global _instance
+    if _instance is None:
+        api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+        _instance = StrategyChatService(api_key=api_key)
+    return _instance

--- a/docs/works/20260227_전략빌더_AI챗봇_MVP.md
+++ b/docs/works/20260227_전략빌더_AI챗봇_MVP.md
@@ -1,0 +1,128 @@
+# Strategy Builder AI Chatbot MVP
+
+- **날짜**: 2026-02-27
+- **이슈**: (생성 예정)
+- **브랜치**: `feature/issue{N}-strategy-chatbot`
+- **상태**: 계획중
+
+## 목표
+
+전략 빌더(QuantCanvas) 페이지에 AI 챗봇을 추가하여 사용자가 자연어로 노드 작성을 도움받을 수 있게 한다.
+MVP 단계로 최소한의 구현, 디자인은 추후 Stitch를 통해 별도 적용.
+
+## 배경
+
+- 전략 빌더에 48개 조건 노드가 있어 초보 사용자가 어떤 조건을 조합해야 할지 어려움
+- 기존 `llm/claude_client.py`에 Anthropic API 연동이 완료되어 있어 재활용 가능
+- 전략 실행에서 SSE 스트리밍 패턴이 이미 구현되어 있어 채팅 스트리밍에 재활용 가능
+
+## 아키텍처 (MVP)
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  Strategy Page (page.tsx)                                │
+│  ┌───────┬──────────────────┬──────────────────────────┐ │
+│  │NodePal│  React Flow      │                          │ │
+│  │       │  Canvas          │                          │ │
+│  │       │                  │                          │ │
+│  │       │           ┌──────┴──────┐                   │ │
+│  │       │           │ ChatPanel   │  ← 플로팅 패널     │ │
+│  │       │           │ (토글)      │    우하단 버블 클릭 │ │
+│  │       │           └─────────────┘                   │ │
+│  └───────┴──────────────────────────────────────────────┘ │
+└──────────────────────────────────────────────────────────┘
+```
+
+### 데이터 흐름
+
+```
+User Message + Current Graph (serialized)
+        │
+        ▼
+POST /api/strategy/chat (SSE)
+        │
+        ▼
+StrategyChatService
+  → 시스템 프롬프트 (조건 목록 + 그래프 구조)
+  → Anthropic Streaming API
+        │
+        ▼
+SSE events → 프론트 실시간 렌더링
+```
+
+## 계획
+
+### Phase 1: 백엔드 — 채팅 API 엔드포인트
+
+- [ ] 1-1. `api/schemas/strategy_chat.py` — 요청/응답 스키마 정의
+  - `ChatRequest`: messages (대화 이력), graph (현재 전략 그래프, optional)
+  - `ChatResponse`: SSE 이벤트 (text chunk, done, error)
+- [ ] 1-2. `api/services/strategy_chat_service.py` — 챗봇 서비스 로직
+  - 시스템 프롬프트: 조건 48개 요약 + 노드 타입 설명 + 현재 그래프 컨텍스트
+  - Anthropic 스트리밍 API 호출 (`client.messages.stream()`)
+  - 대화 이력 관리 (stateless — 프론트에서 매번 전체 이력 전송)
+- [ ] 1-3. `api/routers/strategy.py`에 엔드포인트 추가
+  - `POST /api/strategy/chat` → SSE StreamingResponse
+
+### Phase 2: 프론트엔드 — ChatPanel 컴포넌트
+
+- [ ] 2-1. `web/src/components/strategy/ChatPanel.tsx` — 채팅 UI
+  - 플로팅 버블 버튼 (우하단, 캔버스 위에 z-index)
+  - 클릭 시 채팅 패널 확장 (고정 크기, 우하단 앵커)
+  - 메시지 목록 (유저/AI 구분, 스크롤)
+  - 입력 필드 + 전송 버튼
+  - 스트리밍 응답 실시간 렌더 (타이핑 효과)
+  - 로딩/에러 상태
+- [ ] 2-2. `web/src/lib/api.ts`에 채팅 API 함수 추가
+  - `sendStrategyChat()` — SSE 스트리밍 fetch (기존 `runStrategyStream` 패턴 재활용)
+- [ ] 2-3. `strategy/page.tsx`에 ChatPanel 통합
+  - 캔버스 영역 내부에 ChatPanel 배치
+  - 현재 그래프(nodes/edges) 직렬화하여 API에 전달
+
+### Phase 3: i18n + 마무리
+
+- [ ] 3-1. `messages/{en,ko,zh}.json`에 chatbot 키 추가
+  - `strategy.chatbot.title`, `placeholder`, `send`, `thinking`, `error` 등
+- [ ] 3-2. 기본 동작 테스트 (수동)
+  - 채팅 열기/닫기, 메시지 전송, 스트리밍 수신, 에러 처리
+- [ ] 코드 리뷰 (Codex 검수)
+
+## 변경 파일
+
+| 파일 | 변경 내용 | 팀 |
+|------|----------|-----|
+| `api/schemas/strategy_chat.py` | **신규** — 채팅 요청/응답 스키마 | backend |
+| `api/services/strategy_chat_service.py` | **신규** — 채팅 서비스 (Claude 연동) | backend |
+| `api/routers/strategy.py` | 채팅 엔드포인트 추가 | backend |
+| `web/src/components/strategy/ChatPanel.tsx` | **신규** — 채팅 UI 컴포넌트 | frontend |
+| `web/src/lib/api.ts` | 채팅 API 함수 추가 | frontend |
+| `web/src/app/[locale]/strategy/page.tsx` | ChatPanel import + 배치 | frontend |
+| `web/messages/en.json` | chatbot i18n 키 | frontend |
+| `web/messages/ko.json` | chatbot i18n 키 | frontend |
+| `web/messages/zh.json` | chatbot i18n 키 | frontend |
+
+## 기술적 고려사항
+
+### 심플하게 유지 (MVP 원칙)
+
+1. **Stateless 대화**: 서버에 대화 이력 저장 안 함. 프론트에서 매 요청마다 전체 이력 전송
+2. **노드 자동 추가 없음 (MVP)**: AI가 텍스트로 추천만 함, 실제 노드 추가는 사용자가 직접
+3. **디자인 최소화**: Tailwind 기본 스타일만, Stitch 디자인은 추후 적용
+4. **모델**: claude-sonnet-4 사용 (기존 분석과 동일, 비용 효율)
+5. **컨텍스트 전달**: 현재 캔버스 그래프를 JSON으로 직렬화하여 시스템 프롬프트에 포함
+
+### 의존성
+
+- `anthropic` 패키지 (이미 설치됨)
+- ANTHROPIC_API_KEY 환경변수 (이미 사용 중)
+
+### 향후 확장 가능성 (이번에는 안 함)
+
+- AI 추천 → "적용" 버튼으로 노드 자동 추가
+- 대화 이력 영속 저장 (DB)
+- 전략 템플릿 추천
+- 멀티턴 컨텍스트 최적화
+
+## 결과
+
+(완료 후 작성)

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -532,7 +532,13 @@
     "passRate": "{rate}%",
     "openFullDataset": "Open Full Dataset View",
     "inspectNode": "Click a node to inspect its results",
-    "topResultsPreview": "Top Results Preview"
+    "topResultsPreview": "Top Results Preview",
+    "chatbot": {
+      "title": "AI Strategy Assistant",
+      "placeholder": "Ask about your strategy...",
+      "empty": "Ask me anything about building your strategy.",
+      "error": "Failed to get response. Please try again."
+    }
   },
   "analysis": {
     "title": "Charts & Analysis",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -532,7 +532,13 @@
     "passRate": "{rate}%",
     "openFullDataset": "전체 데이터 보기",
     "inspectNode": "노드를 클릭하면 결과를 확인할 수 있습니다",
-    "topResultsPreview": "상위 결과 미리보기"
+    "topResultsPreview": "상위 결과 미리보기",
+    "chatbot": {
+      "title": "AI 전략 어시스턴트",
+      "placeholder": "전략에 대해 질문하세요...",
+      "empty": "전략 구성에 대해 무엇이든 물어보세요.",
+      "error": "응답을 받지 못했습니다. 다시 시도해주세요."
+    }
   },
   "analysis": {
     "title": "차트 & 분석",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -532,7 +532,13 @@
     "passRate": "{rate}%",
     "openFullDataset": "查看完整数据",
     "inspectNode": "点击节点查看结果",
-    "topResultsPreview": "头部结果预览"
+    "topResultsPreview": "头部结果预览",
+    "chatbot": {
+      "title": "AI策略助手",
+      "placeholder": "询问关于策略的问题...",
+      "empty": "关于构建策略，可以随时问我任何问题。",
+      "error": "未能获取回复，请重试。"
+    }
   },
   "analysis": {
     "title": "图表与分析",

--- a/web/src/app/[locale]/strategy/page.tsx
+++ b/web/src/app/[locale]/strategy/page.tsx
@@ -36,6 +36,7 @@ import LabeledEdge from '@/components/strategy/edges/LabeledEdge';
 import NodePalette from '@/components/strategy/NodePalette';
 import IntermediateResultsPanel from '@/components/strategy/IntermediateResultsPanel';
 import SideInspectionPanel from '@/components/strategy/SideInspectionPanel';
+import ChatPanel from '@/components/strategy/ChatPanel';
 
 import BacktestPanel from '@/components/backtest/BacktestPanel';
 import { Toast, useToast, type ToastType } from '@/components/ui/Toast';
@@ -1289,7 +1290,7 @@ function StrategyPageInner() {
         <NodePalette nodeCount={nodeCount} />
 
         {/* Canvas */}
-        <div className="flex-1" ref={reactFlowWrapper}>
+        <div className="relative flex-1" ref={reactFlowWrapper}>
           <ReactFlow
             nodes={nodes}
             edges={edges}
@@ -1333,6 +1334,7 @@ function StrategyPageInner() {
               className="dark:!opacity-20"
             />
           </ReactFlow>
+          <ChatPanel graph={serializeGraph(nodes as Node<StrategyNodeData>[], edges)} />
         </div>
       </div>
 

--- a/web/src/components/strategy/ChatPanel.tsx
+++ b/web/src/components/strategy/ChatPanel.tsx
@@ -1,0 +1,248 @@
+'use client';
+
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { MessageCircle, X, Send, Loader2 } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+
+interface ChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+interface ChatPanelProps {
+  graph: { nodes: unknown[]; edges: unknown[] } | null;
+}
+
+export default function ChatPanel({ graph }: ChatPanelProps) {
+  const t = useTranslations('strategy');
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState('');
+  const [isStreaming, setIsStreaming] = useState(false);
+
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const chatTitle = t.has('chatbot.title') ? t('chatbot.title') : 'AI Strategy Assistant';
+  const chatPlaceholder = t.has('chatbot.placeholder')
+    ? t('chatbot.placeholder')
+    : 'Ask about your strategy...';
+  const chatError = t.has('chatbot.error')
+    ? t('chatbot.error')
+    : 'Failed to get response. Please try again.';
+  const chatEmpty = t.has('chatbot.empty')
+    ? t('chatbot.empty')
+    : 'Ask me anything about building your strategy.';
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  useEffect(() => {
+    if (isOpen) textareaRef.current?.focus();
+  }, [isOpen]);
+
+  useEffect(() => {
+    return () => { abortRef.current?.abort(); };
+  }, []);
+
+  const sendMessage = useCallback(async () => {
+    const trimmed = input.trim();
+    if (!trimmed || isStreaming) return;
+
+    const userMsg: ChatMessage = { role: 'user', content: trimmed };
+    const newMessages = [...messages, userMsg];
+    setMessages([...newMessages, { role: 'assistant', content: '' }]);
+    setInput('');
+    setIsStreaming(true);
+
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    try {
+      const response = await fetch(`${API_BASE_URL}/api/strategy/chat`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ messages: newMessages, graph }),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) throw new Error(`API Error: ${response.status}`);
+
+      const reader = response.body?.getReader();
+      if (!reader) throw new Error('No response body');
+
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      const processLines = (lines: string[]) => {
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue;
+          try {
+            const data = JSON.parse(line.slice(6));
+            if (data.type === 'chunk' && data.content) {
+              setMessages(prev => {
+                const updated = [...prev];
+                const last = updated[updated.length - 1];
+                if (last?.role === 'assistant') {
+                  updated[updated.length - 1] = {
+                    ...last,
+                    content: last.content + data.content,
+                  };
+                }
+                return updated;
+              });
+            }
+          } catch {
+            // ignore parse errors (heartbeats, etc.)
+          }
+        }
+      };
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() ?? '';
+        processLines(lines);
+      }
+
+      buffer += decoder.decode(new Uint8Array(), { stream: false });
+      if (buffer.trim()) processLines(buffer.split('\n'));
+    } catch (err) {
+      if ((err as Error).name === 'AbortError') return;
+      setMessages(prev => {
+        const updated = [...prev];
+        const last = updated[updated.length - 1];
+        if (last?.role === 'assistant' && !last.content) {
+          updated[updated.length - 1] = { ...last, content: chatError };
+        }
+        return updated;
+      });
+    } finally {
+      setIsStreaming(false);
+    }
+  }, [input, isStreaming, messages, graph, chatError]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        sendMessage();
+      }
+    },
+    [sendMessage],
+  );
+
+  return (
+    <>
+      {/* Floating bubble */}
+      <button
+        type="button"
+        onClick={() => setIsOpen(prev => !prev)}
+        className="fixed bottom-20 right-6 z-50 flex h-12 w-12 items-center justify-center rounded-full bg-blue-600 text-white shadow-lg transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+        aria-label={isOpen ? 'Close chat' : 'Open chat'}
+      >
+        {isOpen ? <X className="h-5 w-5" /> : <MessageCircle className="h-5 w-5" />}
+      </button>
+
+      {/* Chat panel */}
+      {isOpen && (
+        <div
+          className="fixed bottom-36 right-6 z-50 flex h-[500px] w-[380px] flex-col rounded-xl border border-gray-200 bg-white shadow-2xl dark:border-gray-700 dark:bg-gray-900"
+          role="dialog"
+          aria-label={chatTitle}
+        >
+          {/* Header */}
+          <div className="flex h-12 shrink-0 items-center justify-between border-b border-gray-200 px-4 dark:border-gray-700">
+            <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+              {chatTitle}
+            </h3>
+            <button
+              type="button"
+              onClick={() => setIsOpen(false)}
+              className="rounded p-1 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800"
+              aria-label="Close"
+            >
+              <X className="h-4 w-4 text-gray-400" />
+            </button>
+          </div>
+
+          {/* Messages */}
+          <div className="flex-1 overflow-y-auto px-4 py-3">
+            {messages.length === 0 && (
+              <div className="flex h-full items-center justify-center">
+                <p className="text-center text-sm text-gray-400 dark:text-gray-500">
+                  {chatEmpty}
+                </p>
+              </div>
+            )}
+            <div className="flex flex-col gap-3">
+              {messages.map((msg, i) => (
+                <div
+                  key={i}
+                  className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}
+                >
+                  <div
+                    className={`max-w-[80%] whitespace-pre-wrap rounded-lg p-3 text-sm leading-relaxed ${
+                      msg.role === 'user'
+                        ? 'bg-blue-600 text-white'
+                        : 'bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-gray-100'
+                    }`}
+                  >
+                    {msg.content}
+                    {msg.role === 'assistant' &&
+                      i === messages.length - 1 &&
+                      isStreaming && (
+                        <span className="ml-0.5 inline-block h-4 w-1 animate-pulse bg-current align-text-bottom" />
+                      )}
+                    {msg.role === 'assistant' &&
+                      i === messages.length - 1 &&
+                      isStreaming &&
+                      !msg.content && (
+                        <Loader2 className="inline h-3 w-3 animate-spin text-gray-400" />
+                      )}
+                  </div>
+                </div>
+              ))}
+              <div ref={messagesEndRef} />
+            </div>
+          </div>
+
+          {/* Input */}
+          <div className="flex h-14 shrink-0 items-center gap-2 border-t border-gray-200 px-3 dark:border-gray-700">
+            <textarea
+              ref={textareaRef}
+              value={input}
+              onChange={e => setInput(e.target.value)}
+              onKeyDown={handleKeyDown}
+              disabled={isStreaming}
+              placeholder={chatPlaceholder}
+              rows={1}
+              className="flex-1 resize-none rounded-lg border border-gray-200 bg-transparent px-3 py-2 text-sm text-gray-900 placeholder-gray-400 outline-none transition-colors focus:border-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 dark:text-gray-100 dark:placeholder-gray-500 dark:focus:border-blue-400"
+            />
+            <button
+              type="button"
+              onClick={sendMessage}
+              disabled={isStreaming || !input.trim()}
+              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-blue-600 text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-40"
+              aria-label="Send"
+            >
+              {isStreaming ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Send className="h-4 w-4" />
+              )}
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Add floating AI chat bubble + panel to the strategy builder page
- Backend: `POST /api/strategy/chat` SSE endpoint using Anthropic Claude API
- Frontend: `ChatPanel` component with streaming, i18n (en/ko/zh), dark mode
- Input validation: role constrained to user/assistant, content max 4000 chars, max 50 messages
- Graph context injection (truncated at 4000 chars) for context-aware responses

## Changes
| File | Description |
|------|-------------|
| `api/schemas/strategy_chat.py` | Request/response schemas with security constraints |
| `api/services/strategy_chat_service.py` | Claude streaming chat service (singleton) |
| `api/routers/strategy.py` | Added `/chat` SSE endpoint |
| `web/src/components/strategy/ChatPanel.tsx` | Floating chat bubble + panel UI |
| `web/src/app/[locale]/strategy/page.tsx` | Integrated ChatPanel into strategy page |
| `web/messages/{en,ko,zh}.json` | i18n keys for chatbot UI |
| `docs/works/20260227_*.md` | Work plan document |

## Test plan
- [ ] Verify chat bubble appears on strategy page (bottom-right corner)
- [ ] Click bubble → chat panel opens with correct i18n title
- [ ] Send a message → streaming response appears (requires ANTHROPIC_API_KEY)
- [ ] Without API key → 503 error displayed gracefully
- [ ] Check en/ko/zh locale switching works
- [ ] Verify dark mode styling
- [ ] Confirm no console errors on page load

Closes #966

*Created by: Claude Code*