### PR TITLE
feat(settings): add IBKR broker settings UI

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -45,6 +45,10 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             get_broker_settings_service().apply_tiger_settings_to_runtime()
         except Exception as e:
             print(f"WARNING: Tiger settings runtime apply failed: {e}")
+        try:
+            get_broker_settings_service().apply_ibkr_settings_to_runtime()
+        except Exception as e:
+            print(f"WARNING: IBKR settings runtime apply failed: {e}")
     except Exception as e:
         print(f"WARNING: Database initialization failed: {e}")
         print("Strategy persistence will be unavailable until DB is reachable.")

--- a/api/routers/settings.py
+++ b/api/routers/settings.py
@@ -10,6 +10,8 @@ from brokers.exceptions import BrokerConnectionError
 from api.schemas.broker import (
     BrokerConnectionResponse,
     BrokerSettingsResponse,
+    IBKRSettingsRequest,
+    IBKRSettingsResponse,
     TigerSettingsRequest,
     TigerSettingsResponse,
 )
@@ -113,6 +115,64 @@ def test_tiger_connection() -> BrokerConnectionResponse:
     try:
         _settings_service.apply_tiger_settings_to_runtime()
         status = _service.get_connection_status("tiger")
+        return BrokerConnectionResponse(
+            broker=status.broker,
+            status=status.status,
+            is_paper_trading=status.is_paper_trading,
+            accounts=status.accounts,
+            updated_at=status.updated_at,
+        )
+    except BrokerConnectionError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+# -- IBKR settings ----------------------------------------------------------
+
+
+@router.get(
+    "/brokers/ibkr",
+    response_model=IBKRSettingsResponse,
+    summary="Get IBKR broker settings",
+)
+def get_ibkr_settings() -> IBKRSettingsResponse:
+    view = _settings_service.get_ibkr_settings()
+    return IBKRSettingsResponse(
+        gateway_url=view.gateway_url,
+        account_id=view.account_id,
+        updated_at=view.updated_at,
+    )
+
+
+@router.put(
+    "/brokers/ibkr",
+    response_model=IBKRSettingsResponse,
+    summary="Save IBKR broker settings",
+)
+def save_ibkr_settings(request: IBKRSettingsRequest) -> IBKRSettingsResponse:
+    try:
+        view = _settings_service.save_ibkr_settings(request.model_dump())
+        return IBKRSettingsResponse(
+            gateway_url=view.gateway_url,
+            account_id=view.account_id,
+            updated_at=view.updated_at,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.post(
+    "/brokers/ibkr/test",
+    response_model=BrokerConnectionResponse,
+    summary="Test IBKR broker connection",
+)
+def test_ibkr_connection() -> BrokerConnectionResponse:
+    try:
+        _settings_service.apply_ibkr_settings_to_runtime()
+        status = _service.get_connection_status("ibkr")
         return BrokerConnectionResponse(
             broker=status.broker,
             status=status.status,

--- a/api/schemas/broker.py
+++ b/api/schemas/broker.py
@@ -130,3 +130,23 @@ class TigerSettingsResponse(BaseModel):
     sandbox: bool = False
     has_private_key: bool = False
     updated_at: Optional[str] = None
+
+
+class IBKRSettingsRequest(BaseModel):
+    """IBKR Client Portal Gateway settings payload."""
+
+    gateway_url: str = Field(
+        default="https://localhost:5000",
+        description="Client Portal Gateway base URL",
+    )
+    account_id: Optional[str] = Field(
+        None, description="IBKR account ID (auto-discovered if empty)"
+    )
+
+
+class IBKRSettingsResponse(BaseModel):
+    """IBKR broker settings payload safe for UI."""
+
+    gateway_url: Optional[str] = None
+    account_id: Optional[str] = None
+    updated_at: Optional[str] = None

--- a/api/services/broker_settings_service.py
+++ b/api/services/broker_settings_service.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import base64
 import json
 import os
+import re
 from dataclasses import dataclass
 from typing import Any
+from urllib.parse import urlparse
 
 from brokers import refresh_broker
 
@@ -30,6 +32,13 @@ class TigerSettingsView:
     license: str | None
     sandbox: bool
     has_private_key: bool
+    updated_at: str | None
+
+
+@dataclass
+class IBKRSettingsView:
+    gateway_url: str | None
+    account_id: str | None
     updated_at: str | None
 
 
@@ -167,6 +176,96 @@ class BrokerSettingsService:
             db.close()
 
         refresh_broker("tiger")
+
+    # -- IBKR settings -------------------------------------------------------
+
+    def get_ibkr_settings(self) -> IBKRSettingsView:
+        db = SessionLocal()
+        try:
+            row = db.get(BrokerCredential, "ibkr")
+            if not row:
+                return IBKRSettingsView(
+                    gateway_url=None,
+                    account_id=None,
+                    updated_at=None,
+                )
+
+            data = json.loads(row.config_json)
+            return IBKRSettingsView(
+                gateway_url=data.get("gateway_url"),
+                account_id=data.get("account_id"),
+                updated_at=row.updated_at.isoformat() if row.updated_at else None,
+            )
+        finally:
+            db.close()
+
+    @staticmethod
+    def _validate_ibkr_gateway_url(url: str) -> None:
+        """Restrict gateway_url to localhost to prevent SSRF."""
+        parsed = urlparse(url)
+        host = (parsed.hostname or "").lower()
+        allowed = {"localhost", "127.0.0.1", "::1"}
+        if host not in allowed and not re.match(r"^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$", host):
+            raise ValueError(
+                "gateway_url must point to localhost (e.g. https://localhost:5000)"
+            )
+
+    def save_ibkr_settings(self, payload: dict[str, Any]) -> IBKRSettingsView:
+        gateway_url = (payload.get("gateway_url") or "").strip()
+        account_id = (payload.get("account_id") or "").strip() or None
+
+        if not gateway_url:
+            raise ValueError("gateway_url is required")
+        self._validate_ibkr_gateway_url(gateway_url)
+
+        db = SessionLocal()
+        try:
+            row = db.get(BrokerCredential, "ibkr")
+            if not row:
+                row = BrokerCredential(
+                    broker="ibkr",
+                    account_id=account_id or "",
+                    is_enabled=True,
+                    config_json="{}",
+                )
+
+            merged = {
+                "gateway_url": gateway_url,
+                "account_id": account_id,
+            }
+
+            row.account_id = account_id or ""
+            row.is_enabled = True
+            row.config_json = json.dumps(merged)
+            db.merge(row)
+            db.commit()
+        finally:
+            db.close()
+
+        self.apply_ibkr_settings_to_runtime()
+        return self.get_ibkr_settings()
+
+    def apply_ibkr_settings_to_runtime(self) -> None:
+        """Load IBKR settings from DB and apply into process env."""
+        db = SessionLocal()
+        try:
+            row = db.get(BrokerCredential, "ibkr")
+            if not row:
+                return
+            data = json.loads(row.config_json)
+            gateway_url = data.get("gateway_url")
+            if not gateway_url:
+                return
+            os.environ["IBKR_GATEWAY_URL"] = str(gateway_url).strip()
+            account_id = data.get("account_id")
+            if account_id:
+                os.environ["IBKR_ACCOUNT_ID"] = str(account_id).strip()
+            else:
+                os.environ.pop("IBKR_ACCOUNT_ID", None)
+        finally:
+            db.close()
+
+        refresh_broker("ibkr")
 
 
 _broker_settings_service = BrokerSettingsService()

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -2738,7 +2738,16 @@
     "tigerSaved": "Tiger settings saved.",
     "testSuccess": "Connection test completed.",
     "saveFailed": "Failed to save settings.",
-    "testFailed": "Connection test failed."
+    "testFailed": "Connection test failed.",
+    "ibkrConfigTitle": "IBKR Connection Settings",
+    "ibkrConfigDesc": "Configure Interactive Brokers Client Portal Gateway connection.",
+    "ibkrGatewayUrl": "Gateway URL",
+    "ibkrGatewayUrlPlaceholder": "https://localhost:5000",
+    "ibkrAccountId": "Account ID",
+    "ibkrAccountIdPlaceholder": "Auto-discovered if empty",
+    "saveIbkr": "Save IBKR Settings",
+    "testIbkr": "Test IBKR Connection",
+    "ibkrSaved": "IBKR settings saved."
   },
   "kiwoom": {
     "title": "Kiwoom",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -2738,7 +2738,16 @@
     "tigerSaved": "Tiger 설정이 저장되었습니다.",
     "testSuccess": "연결 테스트가 완료되었습니다.",
     "saveFailed": "저장에 실패했습니다.",
-    "testFailed": "연결 테스트에 실패했습니다."
+    "testFailed": "연결 테스트에 실패했습니다.",
+    "ibkrConfigTitle": "IBKR 연결 설정",
+    "ibkrConfigDesc": "Interactive Brokers Client Portal Gateway 연결을 설정합니다.",
+    "ibkrGatewayUrl": "게이트웨이 URL",
+    "ibkrGatewayUrlPlaceholder": "https://localhost:5000",
+    "ibkrAccountId": "계좌 ID",
+    "ibkrAccountIdPlaceholder": "비워두면 자동 검색",
+    "saveIbkr": "IBKR 설정 저장",
+    "testIbkr": "IBKR 연결 테스트",
+    "ibkrSaved": "IBKR 설정이 저장되었습니다."
   },
   "kiwoom": {
     "title": "키움",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -2738,7 +2738,16 @@
     "tigerSaved": "Tiger 设置已保存。",
     "testSuccess": "连接测试完成。",
     "saveFailed": "保存失败。",
-    "testFailed": "连接测试失败。"
+    "testFailed": "连接测试失败。",
+    "ibkrConfigTitle": "IBKR 连接设置",
+    "ibkrConfigDesc": "配置 Interactive Brokers Client Portal Gateway 连接。",
+    "ibkrGatewayUrl": "网关 URL",
+    "ibkrGatewayUrlPlaceholder": "https://localhost:5000",
+    "ibkrAccountId": "账户 ID",
+    "ibkrAccountIdPlaceholder": "留空自动发现",
+    "saveIbkr": "保存 IBKR 设置",
+    "testIbkr": "测试 IBKR 连接",
+    "ibkrSaved": "IBKR 设置已保存。"
   },
   "kiwoom": {
     "title": "Kiwoom",

--- a/web/src/app/[locale]/settings/page.tsx
+++ b/web/src/app/[locale]/settings/page.tsx
@@ -15,8 +15,11 @@ import {
   getTigerSettings,
   saveTigerSettings,
   testTigerConnection,
+  getIbkrSettings,
+  saveIbkrSettings,
+  testIbkrConnection,
 } from '@/lib/api';
-import type { BrokerConnectionStatus, BrokerConnectionState, TigerSettingsUpsert } from '@/lib/types';
+import type { BrokerConnectionStatus, BrokerConnectionState, TigerSettingsUpsert, IBKRSettingsUpsert } from '@/lib/types';
 
 const LOCALE_LABELS: Record<string, string> = {
   en: 'English',
@@ -49,6 +52,13 @@ export default function SettingsPage() {
   const [savingTiger, setSavingTiger] = useState(false);
   const [testingTiger, setTestingTiger] = useState(false);
   const [tigerMessage, setTigerMessage] = useState<string | null>(null);
+  const [ibkrForm, setIbkrForm] = useState<IBKRSettingsUpsert>({
+    gateway_url: 'https://localhost:5000',
+    account_id: '',
+  });
+  const [savingIbkr, setSavingIbkr] = useState(false);
+  const [testingIbkr, setTestingIbkr] = useState(false);
+  const [ibkrMessage, setIbkrMessage] = useState<string | null>(null);
 
   const statusTextKey: Record<BrokerConnectionState, string> = {
     connected: 'connected',
@@ -72,20 +82,40 @@ export default function SettingsPage() {
       setLoadingBrokers(true);
       setBrokerError(null);
       try {
-        const [brokerStatuses, tigerSettings] = await Promise.all([
+        const [brokerResult, tigerResult, ibkrResult] = await Promise.allSettled([
           getSettingsBrokerStatuses(),
           getTigerSettings(),
+          getIbkrSettings(),
         ]);
-        setBrokers(brokerStatuses);
-        setTigerForm((prev) => ({
-          ...prev,
-          tiger_id: tigerSettings.tiger_id ?? '',
-          account: tigerSettings.account ?? '',
-          license: tigerSettings.license ?? 'TBNZ',
-          sandbox: tigerSettings.sandbox,
-          private_key: '',
-        }));
-        setTigerHasPrivateKey(tigerSettings.has_private_key);
+        if (brokerResult.status === 'fulfilled') {
+          setBrokers(brokerResult.value);
+        }
+        if (tigerResult.status === 'fulfilled') {
+          const tigerSettings = tigerResult.value;
+          setTigerForm((prev) => ({
+            ...prev,
+            tiger_id: tigerSettings.tiger_id ?? '',
+            account: tigerSettings.account ?? '',
+            license: tigerSettings.license ?? 'TBNZ',
+            sandbox: tigerSettings.sandbox,
+            private_key: '',
+          }));
+          setTigerHasPrivateKey(tigerSettings.has_private_key);
+        }
+        if (ibkrResult.status === 'fulfilled') {
+          const ibkrSettings = ibkrResult.value;
+          setIbkrForm({
+            gateway_url: ibkrSettings.gateway_url ?? 'https://localhost:5000',
+            account_id: ibkrSettings.account_id ?? '',
+          });
+        }
+        // Show error only if all requests failed
+        const allFailed = [brokerResult, tigerResult, ibkrResult].every(
+          (r) => r.status === 'rejected'
+        );
+        if (allFailed) {
+          setBrokerError('Failed to load broker status');
+        }
       } catch (e) {
         setBrokerError(e instanceof Error ? e.message : 'Failed to load broker status');
       } finally {
@@ -167,6 +197,41 @@ export default function SettingsPage() {
       setTigerMessage(e instanceof Error ? e.message : t('testFailed'));
     } finally {
       setTestingTiger(false);
+    }
+  };
+
+  const handleSaveIbkr = async () => {
+    setSavingIbkr(true);
+    setIbkrMessage(null);
+    try {
+      const response = await saveIbkrSettings(ibkrForm);
+      setIbkrForm({
+        gateway_url: response.gateway_url ?? 'https://localhost:5000',
+        account_id: response.account_id ?? '',
+      });
+      setIbkrMessage(t('ibkrSaved'));
+      const statuses = await getSettingsBrokerStatuses();
+      setBrokers(statuses);
+    } catch (e) {
+      setIbkrMessage(e instanceof Error ? e.message : t('saveFailed'));
+    } finally {
+      setSavingIbkr(false);
+    }
+  };
+
+  const handleIbkrTest = async () => {
+    setTestingIbkr(true);
+    setIbkrMessage(null);
+    try {
+      const status = await testIbkrConnection();
+      setBrokers((prev) =>
+        prev.map((item) => (item.broker === 'ibkr' ? status : item))
+      );
+      setIbkrMessage(t('testSuccess'));
+    } catch (e) {
+      setIbkrMessage(e instanceof Error ? e.message : t('testFailed'));
+    } finally {
+      setTestingIbkr(false);
     }
   };
 
@@ -428,6 +493,55 @@ export default function SettingsPage() {
               className="rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm font-medium text-[var(--foreground)] hover:bg-[var(--background-secondary)] disabled:opacity-60"
             >
               {testingTiger ? t('testing') : t('testTiger')}
+            </button>
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-[var(--border)] bg-[var(--background-secondary)] p-4">
+          <h3 className="font-medium text-[var(--foreground)]">{t('ibkrConfigTitle')}</h3>
+          <p className="mt-1 text-sm text-[var(--foreground-muted)]">{t('ibkrConfigDesc')}</p>
+
+          <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <label className="text-sm text-[var(--foreground-muted)]">
+              {t('ibkrGatewayUrl')}
+              <input
+                value={ibkrForm.gateway_url}
+                onChange={(e) => setIbkrForm((prev) => ({ ...prev, gateway_url: e.target.value }))}
+                placeholder={t('ibkrGatewayUrlPlaceholder')}
+                className="mt-1 w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)]"
+              />
+            </label>
+            <label className="text-sm text-[var(--foreground-muted)]">
+              {t('ibkrAccountId')}
+              <input
+                value={ibkrForm.account_id ?? ''}
+                onChange={(e) => setIbkrForm((prev) => ({ ...prev, account_id: e.target.value }))}
+                placeholder={t('ibkrAccountIdPlaceholder')}
+                className="mt-1 w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)]"
+              />
+            </label>
+          </div>
+
+          {ibkrMessage && (
+            <p className="mt-3 text-sm text-[var(--foreground-muted)]">{ibkrMessage}</p>
+          )}
+
+          <div className="mt-4 flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={handleSaveIbkr}
+              disabled={savingIbkr}
+              className="rounded-lg bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-60"
+            >
+              {savingIbkr ? t('saving') : t('saveIbkr')}
+            </button>
+            <button
+              type="button"
+              onClick={handleIbkrTest}
+              disabled={testingIbkr}
+              className="rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm font-medium text-[var(--foreground)] hover:bg-[var(--background-secondary)] disabled:opacity-60"
+            >
+              {testingIbkr ? t('testing') : t('testIbkr')}
             </button>
           </div>
         </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -29,6 +29,8 @@ import type {
   BrokerOrderRequest,
   TigerSettings,
   TigerSettingsUpsert,
+  IBKRSettings,
+  IBKRSettingsUpsert,
   Trade,
   TradeHistoryResponse,
   SellRecordCreate,
@@ -750,6 +752,23 @@ export async function saveTigerSettings(payload: TigerSettingsUpsert): Promise<T
 
 export async function testTigerConnection(): Promise<BrokerConnectionStatus> {
   return fetchApi<BrokerConnectionStatus>('/api/settings/brokers/tiger/test', {
+    method: 'POST',
+  });
+}
+
+export async function getIbkrSettings(): Promise<IBKRSettings> {
+  return fetchApi<IBKRSettings>('/api/settings/brokers/ibkr');
+}
+
+export async function saveIbkrSettings(payload: IBKRSettingsUpsert): Promise<IBKRSettings> {
+  return fetchApi<IBKRSettings>('/api/settings/brokers/ibkr', {
+    method: 'PUT',
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function testIbkrConnection(): Promise<BrokerConnectionStatus> {
+  return fetchApi<BrokerConnectionStatus>('/api/settings/brokers/ibkr/test', {
     method: 'POST',
   });
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -344,6 +344,17 @@ export interface TigerSettingsUpsert {
   sandbox: boolean;
 }
 
+export interface IBKRSettings {
+  gateway_url: string | null;
+  account_id: string | null;
+  updated_at: string | null;
+}
+
+export interface IBKRSettingsUpsert {
+  gateway_url: string;
+  account_id?: string | null;
+}
+
 // Execution history types
 export interface ExecutionHistorySummary {
   id: string;


### PR DESCRIPTION
## Summary
- Add IBKR Client Portal Gateway settings management to Settings page, matching Tiger Brokers parity
- Backend: schemas, service (get/save/apply with SSRF-safe localhost validation), 3 API endpoints (GET/PUT/POST test), startup auto-load
- Frontend: IBKR config form (gateway URL + account ID), save/test buttons, `Promise.allSettled` for resilient load
- i18n: en/ko/zh keys added

## Files Changed (10)
| Layer | File | Change |
|-------|------|--------|
| Backend | `api/schemas/broker.py` | `IBKRSettingsRequest`, `IBKRSettingsResponse` |
| Backend | `api/services/broker_settings_service.py` | `get/save/apply_ibkr_settings` + SSRF validation |
| Backend | `api/routers/settings.py` | GET/PUT/POST `/api/settings/brokers/ibkr` |
| Backend | `api/main.py` | Startup auto-load |
| Frontend | `web/src/lib/types.ts` | `IBKRSettings`, `IBKRSettingsUpsert` |
| Frontend | `web/src/lib/api.ts` | `getIbkrSettings`, `saveIbkrSettings`, `testIbkrConnection` |
| Frontend | `web/src/app/[locale]/settings/page.tsx` | IBKR form + `Promise.allSettled` |
| i18n | `web/messages/{en,ko,zh}.json` | 9 keys each |

## Test plan
- [x] Backend: 52/52 tests pass
- [x] TypeScript: no new errors (pre-existing strategy/page.tsx only)
- [x] Codex code review: LGTM (after SSRF fix + Promise.allSettled fix)
- [ ] Manual: Settings page → IBKR form → save gateway URL → test connection

Closes #978

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*Reviewed by: Claude Code (Codex)*