### PR TITLE
feat(portfolio): persist static stock metadata in holdings DB

### DIFF
--- a/api/database.py
+++ b/api/database.py
@@ -58,6 +58,7 @@ def init_db() -> None:
     Base.metadata.create_all(bind=engine)
     logger.info("Database tables ensured")
     _migrate_trade_columns()
+    _migrate_holding_metadata_columns()
 
     _migrate_json_data()
     _migrate_portfolio_json()
@@ -75,6 +76,28 @@ def _migrate_trade_columns() -> None:
                 logger.info("Added missing trades.tax column for legacy DB compatibility")
     except Exception as e:
         logger.warning("Trade schema compatibility migration skipped: %s", e)
+
+
+def _migrate_holding_metadata_columns() -> None:
+    """Schema compatibility migration for legacy holdings metadata columns."""
+    try:
+        with engine.begin() as conn:
+            column_rows = conn.execute(text("PRAGMA table_info(holdings)")).fetchall()
+            existing_columns = {row[1] for row in column_rows}
+            if "sector" not in existing_columns:
+                conn.execute(text("ALTER TABLE holdings ADD COLUMN sector VARCHAR(128)"))
+                logger.info("Added missing holdings.sector column for legacy DB compatibility")
+            if "industry" not in existing_columns:
+                conn.execute(text("ALTER TABLE holdings ADD COLUMN industry VARCHAR(128)"))
+                logger.info("Added missing holdings.industry column for legacy DB compatibility")
+            if "country" not in existing_columns:
+                conn.execute(text("ALTER TABLE holdings ADD COLUMN country VARCHAR(64)"))
+                logger.info("Added missing holdings.country column for legacy DB compatibility")
+            if "exchange" not in existing_columns:
+                conn.execute(text("ALTER TABLE holdings ADD COLUMN exchange VARCHAR(32)"))
+                logger.info("Added missing holdings.exchange column for legacy DB compatibility")
+    except Exception as e:
+        logger.warning("Holding schema compatibility migration skipped: %s", e)
 
 
 def _migrate_json_data() -> None:

--- a/api/main.py
+++ b/api/main.py
@@ -5,6 +5,7 @@ Main application instance with middleware configuration and router registration.
 """
 
 from contextlib import asynccontextmanager
+import threading
 from typing import AsyncGenerator
 
 from fastapi import FastAPI
@@ -20,6 +21,102 @@ from api.routers.search import router as search_router
 from api.routers.agent_task import router as agent_task_router
 from api.routers.kiwoom import router as kiwoom_router
 from api.routers.strategy import router as strategy_router
+
+
+def _backfill_metadata():
+    """One-time backfill: populate sector/industry/country/exchange for existing holdings."""
+    import logging
+    _logger = logging.getLogger(__name__)
+    try:
+        from api.database import SessionLocal
+        from api.models.portfolio import Holding
+        db = SessionLocal()
+        try:
+            # Find holdings missing any metadata field
+            from sqlalchemy import or_
+            rows = db.query(Holding).filter(
+                or_(
+                    Holding.sector.is_(None),
+                    Holding.industry.is_(None),
+                    Holding.country.is_(None),
+                    Holding.exchange.is_(None),
+                )
+            ).all()
+            if not rows:
+                _logger.info("No holdings need metadata backfill")
+                return
+
+            _logger.info(f"Backfilling metadata for {len(rows)} holdings...")
+
+            # Partition by market
+            kr_kospi = [r for r in rows if r.ticker.endswith(".KS")]
+            kr_kosdaq = [r for r in rows if r.ticker.endswith(".KQ")]
+            us_tickers = [r for r in rows if not r.ticker.endswith((".KS", ".KQ"))]
+
+            # Korean: batch via SectorFetcher
+            try:
+                from screener.sector_fetcher import get_sector_fetcher
+                fetcher = get_sector_fetcher()
+
+                if kr_kospi:
+                    kospi_map = fetcher.get_all_sector_classifications("KOSPI")
+                    for r in kr_kospi:
+                        r.sector = kospi_map.get(r.ticker)
+                        r.country = "South Korea"
+                        r.exchange = "KOSPI"
+
+                if kr_kosdaq:
+                    kosdaq_map = fetcher.get_all_sector_classifications("KOSDAQ")
+                    for r in kr_kosdaq:
+                        r.sector = kosdaq_map.get(r.ticker)
+                        r.country = "South Korea"
+                        r.exchange = "KOSDAQ"
+            except Exception as e:
+                _logger.warning(f"KR sector backfill failed: {e}")
+
+            # US: parallel yfinance (return pure dicts to avoid thread-unsafe ORM mutation)
+            if us_tickers:
+                from concurrent.futures import ThreadPoolExecutor, as_completed
+
+                def _fetch_us_meta(ticker: str):
+                    try:
+                        import yfinance as yf
+                        info = yf.Ticker(ticker).info
+                        return {
+                            "sector": info.get("sector"),
+                            "industry": info.get("industry"),
+                            "country": info.get("country"),
+                            "exchange": info.get("exchange"),
+                        }
+                    except Exception as e:
+                        _logger.warning(f"US metadata fetch failed for {ticker}: {e}")
+                        return {}
+
+                ticker_to_holding = {r.ticker: r for r in us_tickers}
+                with ThreadPoolExecutor(max_workers=min(len(us_tickers), 8)) as executor:
+                    futures = {executor.submit(_fetch_us_meta, r.ticker): r.ticker for r in us_tickers}
+                    for f in as_completed(futures):
+                        t = futures[f]
+                        try:
+                            meta = f.result()
+                            h = ticker_to_holding[t]
+                            h.sector = meta.get("sector")
+                            h.industry = meta.get("industry")
+                            h.country = meta.get("country")
+                            h.exchange = meta.get("exchange")
+                        except Exception:
+                            pass
+
+            db.commit()
+            total = len(kr_kospi) + len(kr_kosdaq) + len(us_tickers)
+            _logger.info(f"Backfilled metadata for {total} holdings")
+        except Exception as e:
+            db.rollback()
+            _logger.error(f"Metadata backfill failed: {e}")
+        finally:
+            db.close()
+    except Exception as e:
+        _logger.error(f"Metadata backfill initialization failed: {e}")
 
 
 @asynccontextmanager
@@ -41,6 +138,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     print(f"Debug mode: {settings.debug}")
     try:
         init_db()
+        # Start background metadata backfill for existing holdings
+        threading.Thread(target=_backfill_metadata, daemon=True, name="metadata-backfill").start()
         try:
             get_broker_settings_service().apply_tiger_settings_to_runtime()
         except Exception as e:

--- a/api/models/portfolio.py
+++ b/api/models/portfolio.py
@@ -19,6 +19,10 @@ class Holding(Base):
     currency = Column(String(8), nullable=False, default="KRW")
     note = Column(Text, nullable=True)
     bought_at = Column(Date, nullable=True)
+    sector = Column(String(128), nullable=True)
+    industry = Column(String(128), nullable=True)
+    country = Column(String(64), nullable=True)
+    exchange = Column(String(32), nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 

--- a/api/schemas/portfolio.py
+++ b/api/schemas/portfolio.py
@@ -82,6 +82,9 @@ class HoldingResponse(BaseModel):
     pnl_pct: Optional[float] = Field(default=None, description="Profit/Loss percentage")
     currency: str = Field(default="KRW", description="Currency code")
     sector: Optional[str] = Field(default=None, description="Stock sector classification")
+    industry: Optional[str] = Field(default=None, description="Industry classification")
+    country: Optional[str] = Field(default=None, description="Country of origin")
+    exchange: Optional[str] = Field(default=None, description="Stock exchange")
     bought_at: Optional[date] = Field(default=None, description="Purchase date")
     note: Optional[str] = Field(default=None, description="Optional note")
 

--- a/api/services/portfolio_service.py
+++ b/api/services/portfolio_service.py
@@ -92,6 +92,10 @@ class PortfolioService:
             "currency": row.currency,
             "note": row.note,
             "bought_at": row.bought_at,
+            "sector": row.sector,
+            "industry": row.industry,
+            "country": row.country,
+            "exchange": row.exchange,
         }
 
     @staticmethod
@@ -336,6 +340,40 @@ class PortfolioService:
 
         return sectors
 
+    @staticmethod
+    def _fetch_static_metadata(ticker: str) -> Dict[str, Optional[str]]:
+        """Fetch static metadata (sector/industry/country/exchange) for a ticker. Called once at creation."""
+        result = {"sector": None, "industry": None, "country": None, "exchange": None}
+        try:
+            if ticker.endswith(".KS") or ticker.endswith(".KQ"):
+                # Korean stock
+                suffix = ticker[-3:]  # .KS or .KQ
+                result["country"] = "South Korea"
+                result["exchange"] = "KOSPI" if suffix == ".KS" else "KOSDAQ"
+                # Sector from SectorFetcher
+                try:
+                    from screener.sector_fetcher import get_sector_fetcher
+                    fetcher = get_sector_fetcher()
+                    market = "KOSPI" if suffix == ".KS" else "KOSDAQ"
+                    sector_map = fetcher.get_all_sector_classifications(market)
+                    result["sector"] = sector_map.get(ticker)
+                except Exception as e:
+                    logger.warning(f"Failed to fetch KR sector for {ticker}: {e}")
+            else:
+                # US/Other: yfinance
+                try:
+                    import yfinance as yf
+                    info = yf.Ticker(ticker).info
+                    result["sector"] = info.get("sector")
+                    result["industry"] = info.get("industry")
+                    result["country"] = info.get("country")
+                    result["exchange"] = info.get("exchange")
+                except Exception as e:
+                    logger.warning(f"Failed to fetch metadata for {ticker}: {e}")
+        except Exception as e:
+            logger.warning(f"Unexpected error fetching metadata for {ticker}: {e}")
+        return result
+
     def _holding_to_response(
         self,
         holding: Dict[str, Any],
@@ -390,6 +428,9 @@ class PortfolioService:
             pnl_pct=pnl_pct,
             currency=holding.get("currency", "KRW"),
             sector=sector,
+            industry=holding.get("industry"),
+            country=holding.get("country"),
+            exchange=holding.get("exchange"),
             bought_at=bought_at,
             note=holding.get("note")
         )
@@ -412,32 +453,26 @@ class PortfolioService:
             db.close()
 
         prices: Dict[str, float] = {}
-        sectors: Dict[str, Optional[str]] = {}
         changes: Dict[str, float] = {}
         if with_prices and holdings_dicts:
             tickers = [h["ticker"] for h in holdings_dicts]
 
-            # Run all three enrichment calls in parallel.
-            with ThreadPoolExecutor(max_workers=3) as outer:
+            # Run price and change enrichment in parallel (sector is now in DB).
+            with ThreadPoolExecutor(max_workers=2) as outer:
                 f_prices = outer.submit(self._get_current_prices, tickers)
                 f_changes = outer.submit(self._get_daily_changes, tickers)
-                f_sectors = outer.submit(self._get_sectors, tickers)
 
                 prices = f_prices.result(timeout=ENRICHMENT_TIMEOUT_SECONDS)
                 try:
                     changes = f_changes.result(timeout=ENRICHMENT_TIMEOUT_SECONDS)
                 except Exception as e:
                     logger.warning(f"Daily change enrichment failed: {e}")
-                try:
-                    sectors = f_sectors.result(timeout=ENRICHMENT_TIMEOUT_SECONDS)
-                except Exception as e:
-                    logger.warning(f"Sector enrichment failed: {e}")
 
         return [
             self._holding_to_response(
                 h,
                 prices.get(h["ticker"]),
-                sector=sectors.get(h["ticker"]),
+                sector=h.get("sector"),
                 change_pct=changes.get(h["ticker"]),
             )
             for h in holdings_dicts
@@ -464,22 +499,16 @@ class PortfolioService:
             db.close()
 
         current_price = None
-        sector = None
         change_pct = None
         if with_price:
             current_price = self._get_current_price(ticker)
-            try:
-                sector_map = self._get_sectors([ticker])
-                sector = sector_map.get(ticker)
-            except Exception as e:
-                logger.warning(f"Sector enrichment failed for {ticker}: {e}")
             try:
                 changes = self._get_daily_changes([ticker])
                 change_pct = changes.get(ticker)
             except Exception as e:
                 logger.warning(f"Daily change enrichment failed for {ticker}: {e}")
 
-        return self._holding_to_response(holding, current_price, sector=sector, change_pct=change_pct)
+        return self._holding_to_response(holding, current_price, sector=holding.get("sector"), change_pct=change_pct)
 
     def add_holding(self, data: HoldingCreate) -> HoldingResponse:
         """
@@ -516,6 +545,7 @@ class PortfolioService:
                 logger.info(f"Updated holding: {ticker} (qty: {total_quantity}, avg: {new_avg_price:.2f})")
             else:
                 # Create new holding
+                meta = self._fetch_static_metadata(ticker)
                 existing = Holding(
                     ticker=ticker,
                     name=data.name or ticker,
@@ -524,6 +554,10 @@ class PortfolioService:
                     currency=data.currency,
                     note=data.note,
                     bought_at=date.today(),
+                    sector=meta.get("sector"),
+                    industry=meta.get("industry"),
+                    country=meta.get("country"),
+                    exchange=meta.get("exchange"),
                 )
                 db.add(existing)
                 logger.info(f"Added holding: {ticker} (qty: {data.quantity}, avg: {data.avg_price:.2f})")
@@ -538,7 +572,7 @@ class PortfolioService:
             db.close()
 
         current_price = self._get_current_price(ticker)
-        return self._holding_to_response(holding, current_price)
+        return self._holding_to_response(holding, current_price, sector=holding.get("sector"), change_pct=None)
 
     def update_holding(self, ticker: str, data: HoldingUpdate) -> Optional[HoldingResponse]:
         """
@@ -871,6 +905,31 @@ class PortfolioService:
             db.close()
 
         logger.info(f"CSV import: imported={imported}, updated={updated}, skipped={len(errors)}")
+
+        # Backfill metadata for newly imported holdings in background
+        if imported > 0:
+            import threading
+
+            def _backfill_csv_imports():
+                db2 = SessionLocal()
+                try:
+                    null_rows = db2.query(Holding).filter(Holding.sector.is_(None)).all()
+                    for row in null_rows:
+                        meta = self._fetch_static_metadata(row.ticker)
+                        row.sector = meta.get("sector")
+                        row.industry = meta.get("industry")
+                        row.country = meta.get("country")
+                        row.exchange = meta.get("exchange")
+                    if null_rows:
+                        db2.commit()
+                        logger.info(f"Backfilled metadata for {len(null_rows)} CSV-imported holdings")
+                except Exception as e:
+                    db2.rollback()
+                    logger.warning(f"CSV import metadata backfill failed: {e}")
+                finally:
+                    db2.close()
+
+            threading.Thread(target=_backfill_csv_imports, daemon=True).start()
 
         return {
             "imported": imported,


### PR DESCRIPTION
## Summary
- Store sector/industry/country/exchange as permanent DB columns instead of fetching from pykrx/yfinance on every request
- Eliminate external API calls during portfolio page load (sector enrichment removed from `get_all_holdings` and `get_holding`)
- Auto-backfill existing holdings at server startup via daemon thread
- Background metadata fill after CSV import for newly imported rows

## Changes
| File | Change |
|------|--------|
| `api/models/portfolio.py` | Add 4 nullable columns (sector, industry, country, exchange) |
| `api/database.py` | Add `_migrate_holding_metadata_columns()` for existing DBs |
| `api/schemas/portfolio.py` | Add industry/country/exchange to HoldingResponse |
| `api/services/portfolio_service.py` | New `_fetch_static_metadata()`, remove sector API calls from read paths, CSV import backfill |
| `api/main.py` | Daemon thread backfill at startup for NULL metadata rows |

## Test plan
- [ ] Server starts without errors, backfill log message appears
- [ ] DB columns created via migration (`PRAGMA table_info(holdings)`)
- [ ] `GET /api/portfolio/holdings` returns sector/country/exchange without external API calls
- [ ] New holding creation populates metadata fields
- [ ] CSV import triggers background metadata backfill
- [ ] Existing holdings get backfilled (sector=NULL → populated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Reviewed-By: Codex