### PR TITLE
perf: avoid duplicate price fetch on portfolio page load

### DIFF
--- a/api/routers/portfolio.py
+++ b/api/routers/portfolio.py
@@ -71,7 +71,7 @@ async def get_portfolio() -> PortfolioResponse:
 
     try:
         holdings = service.get_all_holdings(with_prices=True)
-        summary = service.get_summary()
+        summary = service.build_summary(holdings)
 
         return PortfolioResponse(
             holdings=holdings,

--- a/api/services/portfolio_service.py
+++ b/api/services/portfolio_service.py
@@ -542,6 +542,19 @@ class PortfolioService:
             PortfolioSummary with aggregated metrics
         """
         holdings = self.get_all_holdings(with_prices=True)
+        return self.build_summary(holdings, base_currency=base_currency)
+
+    def build_summary(
+        self,
+        holdings: List[HoldingResponse],
+        base_currency: Optional[str] = None,
+    ) -> PortfolioSummary:
+        """
+        Build portfolio summary from a pre-fetched holdings list.
+
+        Useful when callers already loaded holdings with prices and want to
+        avoid a second fetch cycle.
+        """
 
         total_investment = 0.0
         total_market_value = 0.0

--- a/api/tests/test_portfolio.py
+++ b/api/tests/test_portfolio.py
@@ -492,7 +492,7 @@ class TestGetFullPortfolio:
                 "note": None
             }
         ]
-        mock_portfolio_service.get_summary.return_value = {
+        mock_portfolio_service.build_summary.return_value = {
             "total_investment": 1500.0,
             "total_market_value": 1750.0,
             "total_pnl": 250.0,
@@ -512,6 +512,9 @@ class TestGetFullPortfolio:
         assert "summary" in data
         assert len(data["holdings"]) == 1
         assert data["summary"]["holdings_count"] == 1
+        mock_portfolio_service.get_all_holdings.assert_called_once_with(with_prices=True)
+        mock_portfolio_service.build_summary.assert_called_once()
+        mock_portfolio_service.get_summary.assert_not_called()
 
 
 class TestTradeEndpoints:


### PR DESCRIPTION
## Summary
- avoid duplicate holdings/price fetch in `GET /api/portfolio`
- add `PortfolioService.build_summary(holdings, ...)` to reuse already-fetched holdings
- update portfolio endpoint test to assert summary is built from existing holdings

## Why
`/api/portfolio` previously called:
1) `get_all_holdings(with_prices=True)`
2) `get_summary()` (which calls `get_all_holdings(with_prices=True)` again)

This caused duplicate price fetch work on each page load.

## Validation
- `python -m py_compile api/services/portfolio_service.py api/routers/portfolio.py`
- `venv/bin/python -m pytest -q api/tests/test_portfolio.py -k "get_portfolio_returns_holdings_and_summary or summary_reuses_cached_prices"`

Closes #985