### PR TITLE
perf: reuse shared snapshot in portfolio realtime websocket

### DIFF
--- a/api/routers/portfolio.py
+++ b/api/routers/portfolio.py
@@ -7,6 +7,7 @@ Provides endpoints for portfolio management operations.
 import io
 import logging
 import asyncio
+import time
 from pathlib import Path
 from typing import List, Optional
 
@@ -36,6 +37,10 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/portfolio", tags=["Portfolio"])
 WS_PUSH_INTERVAL_SECONDS = 10
+WS_SNAPSHOT_TTL_SECONDS = 3
+_ws_snapshot_lock = asyncio.Lock()
+_ws_snapshot_cache: dict | None = None
+_ws_snapshot_ts: float = 0.0
 
 
 def _parse_ticker_query(raw: str | None) -> List[str]:
@@ -50,6 +55,47 @@ def _parse_ticker_query(raw: str | None) -> List[str]:
             seen.add(ticker)
             tickers.append(ticker)
     return tickers
+
+
+async def _get_ws_snapshot(service) -> dict:
+    """
+    Return a shared realtime snapshot for websocket clients.
+
+    Snapshot work (holdings + price fetch) is computed once per TTL window and
+    then reused across concurrent websocket clients.
+    """
+    global _ws_snapshot_cache, _ws_snapshot_ts
+
+    now = time.monotonic()
+    if _ws_snapshot_cache is not None and now - _ws_snapshot_ts < WS_SNAPSHOT_TTL_SECONDS:
+        return _ws_snapshot_cache
+
+    async with _ws_snapshot_lock:
+        # Double-check after lock acquisition.
+        now = time.monotonic()
+        if _ws_snapshot_cache is not None and now - _ws_snapshot_ts < WS_SNAPSHOT_TTL_SECONDS:
+            return _ws_snapshot_cache
+
+        holdings = await asyncio.to_thread(service.get_all_holdings, False)
+        currency_by_ticker = {h.ticker.upper(): h.currency for h in holdings if h.ticker}
+        tickers = list(currency_by_ticker.keys())
+        prices = await asyncio.to_thread(service._get_current_prices, tickers) if tickers else {}
+
+        updates_by_ticker = {
+            ticker: {
+                "ticker": ticker,
+                "current_price": float(price),
+                "currency": currency_by_ticker.get(ticker.upper()),
+            }
+            for ticker, price in prices.items()
+            if price is not None
+        }
+
+        _ws_snapshot_cache = {
+            "updates_by_ticker": updates_by_ticker,
+        }
+        _ws_snapshot_ts = now
+        return _ws_snapshot_cache
 
 
 @router.get(
@@ -537,24 +583,18 @@ async def portfolio_realtime_websocket(websocket: WebSocket) -> None:
 
     try:
         while True:
-            holdings = await asyncio.to_thread(service.get_all_holdings, False)
-            currency_by_ticker = {h.ticker.upper(): h.currency for h in holdings if h.ticker}
-
-            tickers = subscribed or list(currency_by_ticker.keys())
+            snapshot = await _get_ws_snapshot(service)
+            updates_by_ticker = snapshot.get("updates_by_ticker", {})
+            tickers = subscribed or list(updates_by_ticker.keys())
             if not tickers:
                 await websocket.send_json({"updates": []})
                 await asyncio.sleep(WS_PUSH_INTERVAL_SECONDS)
                 continue
 
-            prices = await asyncio.to_thread(service._get_current_prices, tickers)
             updates = [
-                {
-                    "ticker": ticker,
-                    "current_price": float(price),
-                    "currency": currency_by_ticker.get(ticker.upper()),
-                }
-                for ticker, price in prices.items()
-                if price is not None
+                updates_by_ticker[ticker]
+                for ticker in tickers
+                if ticker in updates_by_ticker
             ]
 
             await websocket.send_json({"updates": updates})

--- a/api/tests/test_portfolio_realtime_ws.py
+++ b/api/tests/test_portfolio_realtime_ws.py
@@ -3,15 +3,23 @@
 from types import SimpleNamespace
 from unittest.mock import patch
 
+from api.routers import portfolio as portfolio_router
+
 
 class _FakePortfolioService:
+    def __init__(self):
+        self.holdings_calls = 0
+        self.price_calls = 0
+
     def get_all_holdings(self, with_prices=True):
+        self.holdings_calls += 1
         return [
             SimpleNamespace(ticker="AAPL", currency="USD"),
             SimpleNamespace(ticker="005930.KS", currency="KRW"),
         ]
 
     def _get_current_prices(self, tickers):
+        self.price_calls += 1
         return {ticker: 100.0 + idx for idx, ticker in enumerate(tickers)}
 
 
@@ -27,3 +35,19 @@ def test_portfolio_realtime_websocket_emits_updates(client):
     assert isinstance(payload["updates"], list)
     assert {u["ticker"] for u in payload["updates"]} == {"AAPL", "005930.KS"}
     assert all("current_price" in u for u in payload["updates"])
+
+
+def test_portfolio_realtime_websocket_reuses_shared_snapshot(client):
+    """Two close websocket connections should reuse one snapshot build."""
+    fake_service = _FakePortfolioService()
+    portfolio_router._ws_snapshot_cache = None
+    portfolio_router._ws_snapshot_ts = 0.0
+
+    with patch("api.routers.portfolio.get_portfolio_service", return_value=fake_service):
+        with client.websocket_connect("/api/portfolio/realtime/ws?tickers=AAPL,005930.KS") as ws1:
+            ws1.receive_json()
+        with client.websocket_connect("/api/portfolio/realtime/ws?tickers=AAPL,005930.KS") as ws2:
+            ws2.receive_json()
+
+    assert fake_service.holdings_calls == 1
+    assert fake_service.price_calls == 1


### PR DESCRIPTION
## Summary
- add shared websocket snapshot cache in `api/routers/portfolio.py`
- compute holdings+prices once per short TTL and reuse for concurrent websocket clients
- filter per-client subscribed tickers from shared snapshot instead of recomputing per connection
- add websocket test to verify two close connections reuse one snapshot build

## Why
`/api/portfolio/realtime/ws` previously performed full holdings + prices recompute per client loop, which scales poorly with concurrent dashboards.

## Validation
- `python -m py_compile api/routers/portfolio.py`
- `venv/bin/python -m pytest -q api/tests/test_portfolio_realtime_ws.py`

Closes #980