### PR TITLE
perf: make websocket broadcast concurrent

### DIFF
--- a/api/services/ws_manager.py
+++ b/api/services/ws_manager.py
@@ -50,7 +50,10 @@ class ConnectionManager:
         )
 
     async def broadcast(
-        self, data: Dict[str, Any], timeout_seconds: float = 5.0
+        self,
+        data: Dict[str, Any],
+        timeout_seconds: float = 5.0,
+        max_concurrent_sends: int = 32,
     ) -> None:
         """Send *data* as JSON to every connected client.
 
@@ -58,16 +61,25 @@ class ConnectionManager:
         silently removed.
         """
         message = json.dumps(data, default=str)
+        if not self._connections:
+            return
+
         disconnected: List[WebSocket] = []
-        for ws in self._connections:
-            try:
-                await asyncio.wait_for(
-                    ws.send_text(message), timeout=timeout_seconds
-                )
-            except asyncio.TimeoutError:
-                disconnected.append(ws)
-            except Exception:
-                disconnected.append(ws)
+        semaphore = asyncio.Semaphore(max(1, max_concurrent_sends))
+        connections = list(self._connections)
+
+        async def _send(ws: WebSocket) -> None:
+            async with semaphore:
+                try:
+                    await asyncio.wait_for(
+                        ws.send_text(message), timeout=timeout_seconds
+                    )
+                except asyncio.TimeoutError:
+                    disconnected.append(ws)
+                except Exception:
+                    disconnected.append(ws)
+
+        await asyncio.gather(*(_send(ws) for ws in connections))
         for ws in disconnected:
             self._connections.discard(ws)
 

--- a/api/tests/test_ws_manager.py
+++ b/api/tests/test_ws_manager.py
@@ -1,0 +1,48 @@
+"""Tests for websocket connection manager broadcast behavior."""
+
+import asyncio
+import time
+
+from api.services.ws_manager import ConnectionManager
+
+
+class _FakeWebSocket:
+    def __init__(self, delay: float = 0.0, fail: bool = False):
+        self.delay = delay
+        self.fail = fail
+        self.messages: list[str] = []
+
+    async def send_text(self, message: str) -> None:
+        if self.delay > 0:
+            await asyncio.sleep(self.delay)
+        if self.fail:
+            raise RuntimeError("send failed")
+        self.messages.append(message)
+
+
+def test_broadcast_removes_failed_connections() -> None:
+    manager = ConnectionManager()
+    ok = _FakeWebSocket()
+    bad = _FakeWebSocket(fail=True)
+    manager._connections = {ok, bad}
+
+    asyncio.run(manager.broadcast({"type": "ping"}, timeout_seconds=0.2))
+
+    assert manager.connection_count == 1
+    assert ok in manager._connections
+    assert bad not in manager._connections
+
+
+def test_broadcast_sends_concurrently() -> None:
+    manager = ConnectionManager()
+    ws1 = _FakeWebSocket(delay=0.05)
+    ws2 = _FakeWebSocket(delay=0.05)
+    manager._connections = {ws1, ws2}
+
+    start = time.perf_counter()
+    asyncio.run(manager.broadcast({"type": "ping"}, timeout_seconds=0.2, max_concurrent_sends=2))
+    elapsed = time.perf_counter() - start
+
+    assert elapsed < 0.09
+    assert len(ws1.messages) == 1
+    assert len(ws2.messages) == 1


### PR DESCRIPTION
## Summary
- change `ConnectionManager.broadcast()` from sequential sends to concurrent sends
- add bounded fan-out control via `max_concurrent_sends`
- preserve timeout/error cleanup behavior for dead/slow clients
- add websocket manager unit tests for:
  - failed client cleanup
  - concurrent-send latency behavior

## Why
Sequential broadcast caused head-of-line blocking where one slow client delayed all others.

## Validation
- `python -m py_compile api/services/ws_manager.py`
- `venv/bin/python -m pytest -q api/tests/test_ws_manager.py`

Closes #981