### PR TITLE
perf: bound backtest trades/equity payload size

### DIFF
--- a/api/schemas/backtest.py
+++ b/api/schemas/backtest.py
@@ -53,6 +53,26 @@ class BacktestRequest(BaseModel):
         default_factory=dict,
         description="Strategy-specific parameters (e.g., {'n1': 10, 'n2': 20})",
     )
+    include_trades: bool = Field(
+        default=True,
+        description="Include trade records in response",
+    )
+    include_equity_curve: bool = Field(
+        default=True,
+        description="Include equity curve in response",
+    )
+    max_trades: int = Field(
+        default=500,
+        ge=1,
+        le=5000,
+        description="Maximum number of trades to return",
+    )
+    max_equity_points: int = Field(
+        default=1000,
+        ge=10,
+        le=5000,
+        description="Maximum number of equity curve points to return",
+    )
 
 
 class BacktestMetrics(BaseModel):
@@ -118,6 +138,26 @@ class OptimizeRequest(BaseModel):
     maximize: str = Field(
         default="Sharpe Ratio",
         description="Metric to maximize (e.g., 'Sharpe Ratio', 'Return [%]', 'Win Rate [%]')",
+    )
+    include_trades: bool = Field(
+        default=True,
+        description="Include trade records in optimization response",
+    )
+    include_equity_curve: bool = Field(
+        default=True,
+        description="Include equity curve in optimization response",
+    )
+    max_trades: int = Field(
+        default=500,
+        ge=1,
+        le=5000,
+        description="Maximum number of trades to return",
+    )
+    max_equity_points: int = Field(
+        default=1000,
+        ge=10,
+        le=5000,
+        description="Maximum number of equity curve points to return",
     )
 
 

--- a/api/services/backtest_service.py
+++ b/api/services/backtest_service.py
@@ -147,14 +147,19 @@ def _metrics_to_schema(perf: PerformanceMetrics) -> BacktestMetrics:
     return BacktestMetrics(**sanitized)
 
 
-def _extract_trades(result: BacktestResult) -> List[TradeRecord]:
+def _extract_trades(result: BacktestResult, max_trades: Optional[int] = None) -> List[TradeRecord]:
     """Extract trade records from BacktestResult, converting to JSON-safe types."""
     trades_df = result.trades
     if trades_df is None or trades_df.empty:
         return []
 
+    records_raw = trades_df.to_dict(orient="records")
+    if max_trades is not None and len(records_raw) > max_trades:
+        # Keep recent trades when response size is bounded.
+        records_raw = records_raw[-max_trades:]
+
     records = []
-    for _, row in trades_df.iterrows():
+    for row in records_raw:
         # Backtesting.py trade columns: EntryBar, ExitBar, EntryPrice, ExitPrice,
         # PnL, ReturnPct, EntryTime, ExitTime, Size, ...
         entry_date = _sanitize_value(row.get("EntryTime"))
@@ -179,7 +184,10 @@ def _extract_trades(result: BacktestResult) -> List[TradeRecord]:
     return records
 
 
-def _extract_equity_curve(result: BacktestResult) -> List[EquityPoint]:
+def _extract_equity_curve(
+    result: BacktestResult,
+    max_points: Optional[int] = None,
+) -> List[EquityPoint]:
     """Extract equity curve points from BacktestResult."""
     eq_df = result.equity_curve
     if eq_df is None or eq_df.empty:
@@ -188,13 +196,19 @@ def _extract_equity_curve(result: BacktestResult) -> List[EquityPoint]:
     if "Equity" not in eq_df.columns:
         return []
 
+    indices = list(range(len(eq_df)))
+    if max_points is not None and len(indices) > max_points:
+        sampled = np.linspace(0, len(indices) - 1, num=max_points, dtype=int).tolist()
+        indices = sorted(set(sampled))
+
     points = []
-    for idx, row in eq_df.iterrows():
+    for i in indices:
+        idx = eq_df.index[i]
         date_str = _sanitize_value(idx)
         if date_str is None:
             # Fallback for non-Timestamp index
             date_str = str(idx)
-        equity = _sanitize_value(row["Equity"])
+        equity = _sanitize_value(eq_df["Equity"].iat[i])
         if equity is not None:
             points.append(EquityPoint(date=date_str, equity=equity))
     return points
@@ -259,8 +273,16 @@ def run_backtest(request: BacktestRequest) -> BacktestResponse:
     metrics = _metrics_to_schema(perf)
 
     # Extract trades and equity curve
-    trades = _extract_trades(result)
-    equity_curve = _extract_equity_curve(result)
+    trades = (
+        _extract_trades(result, max_trades=request.max_trades)
+        if request.include_trades
+        else []
+    )
+    equity_curve = (
+        _extract_equity_curve(result, max_points=request.max_equity_points)
+        if request.include_equity_curve
+        else []
+    )
 
     return BacktestResponse(
         ticker=request.ticker,
@@ -332,8 +354,16 @@ def optimize_backtest(request: OptimizeRequest) -> OptimizeResponse:
     metrics = _metrics_to_schema(perf)
 
     # Extract trades and equity curve
-    trades = _extract_trades(result)
-    equity_curve = _extract_equity_curve(result)
+    trades = (
+        _extract_trades(result, max_trades=request.max_trades)
+        if request.include_trades
+        else []
+    )
+    equity_curve = (
+        _extract_equity_curve(result, max_points=request.max_equity_points)
+        if request.include_equity_curve
+        else []
+    )
 
     return OptimizeResponse(
         ticker=request.ticker,

--- a/api/tests/test_backtest.py
+++ b/api/tests/test_backtest.py
@@ -308,6 +308,54 @@ class TestBacktestRunEndpoint:
         data = response.json()
         assert data["strategy"] == "ma_touch"
 
+    @patch("api.services.backtest_service.BacktestEngine")
+    def test_run_backtest_respects_response_bounds(self, mock_engine_cls):
+        """Should limit trades/equity payload size when max_* options are set."""
+        mock_result = _make_mock_backtest_result()
+        mock_engine = MagicMock()
+        mock_engine.run.return_value = mock_result
+        mock_engine_cls.return_value = mock_engine
+
+        response = client.post(
+            "/api/backtest/run",
+            json={
+                "ticker": "AAPL",
+                "strategy": "sma",
+                "period": "1mo",
+                "max_trades": 2,
+                "max_equity_points": 20,
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["trades"]) == 2
+        assert len(data["equity_curve"]) <= 20
+
+    @patch("api.services.backtest_service.BacktestEngine")
+    def test_run_backtest_allows_disabling_large_sections(self, mock_engine_cls):
+        """Should return only metrics when trades/equity are disabled."""
+        mock_result = _make_mock_backtest_result()
+        mock_engine = MagicMock()
+        mock_engine.run.return_value = mock_result
+        mock_engine_cls.return_value = mock_engine
+
+        response = client.post(
+            "/api/backtest/run",
+            json={
+                "ticker": "AAPL",
+                "strategy": "sma",
+                "period": "1mo",
+                "include_trades": False,
+                "include_equity_curve": False,
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["trades"] == []
+        assert data["equity_curve"] == []
+
 
 class TestOptimizeEndpoint:
     """Test POST /api/backtest/optimize."""


### PR DESCRIPTION
## Summary
- add response-bound controls to backtest requests:
  - `include_trades`, `include_equity_curve`
  - `max_trades`, `max_equity_points`
- apply same controls to optimize requests
- optimize serialization paths:
  - trade extraction via record conversion + recent-N slicing
  - equity curve sampling capped to requested max points
- add endpoint tests for bounds and payload toggles

## Why
Large backtest responses were unbounded and serialized row-by-row, increasing API latency and frontend payload/render cost.

## Validation
- `python -m py_compile api/schemas/backtest.py api/services/backtest_service.py`
- `venv/bin/python -m pytest -q api/tests/test_backtest.py -k "response_bounds or disabling_large_sections or run_backtest_success"`

Closes #982