### PR TITLE
feat: show universe stock counts in strategy universe node

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -454,6 +454,7 @@
     "loadingSectors": "Loading sectors...",
     "marketSelection": "Market Selection",
     "composite": "{universe} Composite",
+    "selectedUniverseTotal": "Total {count} stocks",
     "condition": "Condition",
     "finalSelection": "Final Selection",
     "estimatedItems": "{count} estimated items",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -454,6 +454,7 @@
     "loadingSectors": "업종 목록 로딩 중...",
     "marketSelection": "시장 선택",
     "composite": "{universe} 종합",
+    "selectedUniverseTotal": "총 {count}개 종목",
     "condition": "조건",
     "finalSelection": "최종 선택",
     "estimatedItems": "예상 {count}개",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -454,6 +454,7 @@
     "loadingSectors": "正在加载行业列表...",
     "marketSelection": "市场选择",
     "composite": "{universe} 综合",
+    "selectedUniverseTotal": "共 {count} 只股票",
     "condition": "条件",
     "finalSelection": "最终选择",
     "estimatedItems": "预计 {count} 项",

--- a/web/src/components/strategy/nodes/UniverseNode.tsx
+++ b/web/src/components/strategy/nodes/UniverseNode.tsx
@@ -4,7 +4,7 @@ import { memo, useCallback } from 'react';
 import { Handle, Position, useNodeId, useReactFlow } from '@xyflow/react';
 import type { NodeProps } from '@xyflow/react';
 import { Globe, Eye } from 'lucide-react';
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 import {
   SUPPORTED_UNIVERSES,
   parseUniverseSelection,
@@ -12,14 +12,32 @@ import {
   type SupportedUniverse,
   type StrategyNodeData,
 } from '@/lib/strategy/graphSerializer';
+import { useUniverses } from '@/hooks/useScreening';
 import NodeEditPopup, { FieldLabel } from './NodeEditPopup';
 
 function UniverseNode({ data, selected }: NodeProps) {
   const t = useTranslations('strategy');
+  const locale = useLocale();
   const nodeData = data as unknown as StrategyNodeData;
   const nodeId = useNodeId()!;
   const { updateNodeData, deleteElements } = useReactFlow();
   const selectedUniverses = parseUniverseSelection(nodeData.universe);
+  const universesQuery = useUniverses();
+
+  const stockCountMap: Record<string, number> = {};
+  for (const universe of universesQuery.data ?? []) {
+    stockCountMap[universe.name] = universe.stock_count;
+  }
+  const selectedCountText = selectedUniverses.map((u) => {
+    const count = stockCountMap[u];
+    return count !== undefined
+      ? `${u} (${count.toLocaleString(locale)})`
+      : u;
+  });
+  const totalSelectedCount = selectedUniverses.reduce(
+    (sum, u) => sum + (stockCountMap[u] ?? 0),
+    0
+  );
 
   const handleUniverseToggle = useCallback(
     (value: SupportedUniverse) => {
@@ -64,7 +82,12 @@ function UniverseNode({ data, selected }: NodeProps) {
           {t('marketSelection')}
         </div>
         <div className="text-xs text-slate-500 dark:text-slate-400 mt-1">
-          {t('composite', { universe: selectedUniverses.join(' + ') })}
+          {t('composite', { universe: selectedCountText.join(' + ') })}
+        </div>
+        <div className="text-[11px] text-slate-500 dark:text-slate-400 mt-1">
+          {t('selectedUniverseTotal', {
+            count: totalSelectedCount.toLocaleString(locale),
+          })}
         </div>
       </div>
 
@@ -101,6 +124,11 @@ function UniverseNode({ data, selected }: NodeProps) {
                   className="rounded border-[#d0d4d9] text-[#1313ec] focus:ring-[#1313ec]/20"
                 />
                 <span>{universe}</span>
+                {stockCountMap[universe] !== undefined && (
+                  <span className="ml-auto text-xs text-gray-500 dark:text-gray-400">
+                    {stockCountMap[universe].toLocaleString(locale)} {t('stockCount')}
+                  </span>
+                )}
               </label>
             ))}
           </div>


### PR DESCRIPTION
## Summary
- show selected market counts directly in the strategy universe node summary
- show combined total stock count for current universe selection
- show per-market stock counts in the universe node edit popup checkboxes
- add i18n key for total count text (ko/en/zh)

## Validation
- `cd web && npm run lint -- src/components/strategy/nodes/UniverseNode.tsx`

Closes #1010