### PR TITLE
style(portfolio): reduce price font size in holdings table

### DIFF
--- a/web/src/components/portfolio/HoldingsTable.tsx
+++ b/web/src/components/portfolio/HoldingsTable.tsx
@@ -270,14 +270,14 @@ export default function HoldingsTable({
                     {ta(marketI18nKey(classifyMarket(holding.ticker)))}
                   </span>
                 </td>
-                <td className="px-4 py-3 text-right font-mono text-[var(--foreground)]">
+                <td className="px-4 py-3 text-right font-mono text-sm text-[var(--foreground)]">
                   {formatQuantity(holding.quantity)}
                 </td>
-                <td className="px-4 py-3 text-right font-mono text-[var(--foreground)]">
+                <td className="px-4 py-3 text-right font-mono text-sm text-[var(--foreground)]">
                   {formatCurrency(holding.avg_price, holding.currency)}
                 </td>
                 <td
-                  className={`px-4 py-3 text-right font-mono transition-colors ${getPnlColorClass(holding.change_pct)} ${
+                  className={`px-4 py-3 text-right font-mono text-sm transition-colors ${getPnlColorClass(holding.change_pct)} ${
                     priceChangeDirection?.[holding.ticker] === 'up'
                       ? 'bg-red-100/70 dark:bg-red-900/30'
                       : priceChangeDirection?.[holding.ticker] === 'down'
@@ -296,10 +296,10 @@ export default function HoldingsTable({
                     {formatCurrency(holding.current_price, holding.currency)}
                   </span>
                 </td>
-                <td className="px-4 py-3 text-right font-mono text-[var(--foreground)]">
+                <td className="px-4 py-3 text-right font-mono text-sm text-[var(--foreground)]">
                   {formatCurrency(holding.market_value, holding.currency)}
                 </td>
-                <td className={`px-4 py-3 text-right font-mono ${getPnlColorClass(holding.pnl)}`}>
+                <td className={`px-4 py-3 text-right font-mono text-sm ${getPnlColorClass(holding.pnl)}`}>
                   <span className="flex items-center justify-end gap-1">
                     {holding.pnl !== null && holding.pnl !== 0 && (
                       holding.pnl > 0 ? (
@@ -311,7 +311,7 @@ export default function HoldingsTable({
                     {formatCurrency(holding.pnl, holding.currency)}
                   </span>
                 </td>
-                <td className={`px-4 py-3 text-right font-mono ${getPnlColorClass(holding.pnl_pct)}`}>
+                <td className={`px-4 py-3 text-right font-mono text-sm ${getPnlColorClass(holding.pnl_pct)}`}>
                   {formatPercent(holding.pnl_pct)}
                 </td>
                 <td className="px-4 py-3" onClick={(e) => e.stopPropagation()}>


### PR DESCRIPTION
## Summary
- Holdings 테이블의 숫자 셀(수량, 평균단가, 현재가, 평가금, 손익, 손익률)에 `text-sm` 적용하여 폰트 크기 축소 (16px → 14px)

## Test plan
- [ ] `/portfolio` 페이지에서 보유종목 테이블 가격 글씨 크기 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)