### PR TITLE
feat(search): add Korean stock name search

### DIFF
--- a/api/routers/search.py
+++ b/api/routers/search.py
@@ -5,12 +5,14 @@ Provides endpoint for searching tickers by name or symbol.
 """
 
 import logging
+import re
 from typing import List
 
 import yfinance as yf
 from fastapi import APIRouter, Query
 
 from api.schemas.analysis import SearchResult
+from api.services.korean_search_service import get_korean_search_service
 
 logger = logging.getLogger(__name__)
 
@@ -18,6 +20,17 @@ router = APIRouter(
     prefix="/api",
     tags=["Search"],
 )
+
+_KOREAN_RE = re.compile(r"[\uAC00-\uD7AF]")
+_KR_CODE_RE = re.compile(r"^\d{6}$")
+
+
+def _contains_korean(text: str) -> bool:
+    return bool(_KOREAN_RE.search(text))
+
+
+def _is_korean_code(text: str) -> bool:
+    return bool(_KR_CODE_RE.match(text.strip()))
 
 
 @router.get(
@@ -37,6 +50,8 @@ async def search_tickers(
     Search for tickers matching the query.
 
     Searches by ticker symbol prefix and company name substring.
+    Korean queries (hangul or 6-digit code) use local CSV data;
+    other queries use yfinance.
     Returns up to 20 results.
 
     Args:
@@ -45,6 +60,34 @@ async def search_tickers(
     Returns:
         List of matching SearchResult objects
     """
+    if _contains_korean(q):
+        return _search_korean(q)
+
+    if _is_korean_code(q):
+        results = _search_korean(q)
+        if results:
+            return results
+        # Fallback to yfinance if code not found in local data
+        return _search_yfinance(q)
+
+    return _search_yfinance(q)
+
+
+def _search_korean(q: str) -> List[SearchResult]:
+    """Search Korean stocks from local CSV data."""
+    service = get_korean_search_service()
+    entries = service.search(q, limit=20)
+
+    results: List[SearchResult] = []
+    for entry in entries:
+        display = f"{entry.name} ({entry.sector})" if entry.sector else entry.name
+        results.append(SearchResult(ticker=entry.symbol, name=display))
+
+    return results
+
+
+def _search_yfinance(q: str) -> List[SearchResult]:
+    """Search using yfinance API (existing behavior)."""
     results: List[SearchResult] = []
     query_upper = q.upper()
 

--- a/api/services/__init__.py
+++ b/api/services/__init__.py
@@ -21,6 +21,7 @@ from api.services.backtest_service import (
     STRATEGY_META,
 )
 from api.services.kiwoom_service import KiwoomService
+from api.services.korean_search_service import KoreanSearchService, get_korean_search_service
 from api.services.strategy_service import (
     execute_strategy,
     get_available_conditions,
@@ -51,6 +52,9 @@ __all__ = [
     "STRATEGY_META",
     # Kiwoom
     "KiwoomService",
+    # Korean Search
+    "KoreanSearchService",
+    "get_korean_search_service",
     # Strategy
     "execute_strategy",
     "get_available_conditions",

--- a/api/services/korean_search_service.py
+++ b/api/services/korean_search_service.py
@@ -1,0 +1,185 @@
+"""
+Korean stock search service.
+
+Provides in-memory search for Korean stocks using local CSV data.
+Supports name substring matching and code prefix matching.
+"""
+
+import csv
+import logging
+import re
+import threading
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+DATA_DIR = Path(__file__).resolve().parent.parent.parent / "data" / "korean"
+
+CSV_SOURCES = {
+    "kospi": {
+        "cache": "kospi_list.csv",
+        "master": "kospi_master.csv",
+        "suffix": ".KS",
+    },
+    "kosdaq": {
+        "cache": "kosdaq_list.csv",
+        "master": "kosdaq_master.csv",
+        "suffix": ".KQ",
+    },
+}
+
+
+@dataclass
+class KoreanStockEntry:
+    symbol: str  # e.g. "005930.KS"
+    code: str  # e.g. "005930"
+    name: str  # e.g. "삼성전자"
+    sector: str  # e.g. "전기전자"
+
+
+@dataclass
+class _MarketData:
+    entries: List[KoreanStockEntry] = field(default_factory=list)
+    source_path: str = ""
+    mtime: float = 0.0
+
+
+class KoreanSearchService:
+    """In-memory search service for Korean stocks loaded from CSV files."""
+
+    def __init__(self) -> None:
+        self._markets: Dict[str, _MarketData] = {}
+        self._loaded = False
+        self._lock = threading.Lock()
+
+    def _pick_csv(self, market: str) -> Optional[Path]:
+        """Pick best available CSV: cache first, then master fallback."""
+        src = CSV_SOURCES[market]
+        cache_path = DATA_DIR / src["cache"]
+        master_path = DATA_DIR / src["master"]
+
+        # Use cache if it exists and has more than just a header
+        if cache_path.exists() and cache_path.stat().st_size > 50:
+            return cache_path
+
+        if master_path.exists():
+            return master_path
+
+        return None
+
+    def _load_csv(self, market: str) -> List[KoreanStockEntry]:
+        """Load entries from a single market CSV."""
+        path = self._pick_csv(market)
+        if path is None:
+            logger.warning("No CSV found for market %s", market)
+            return []
+
+        suffix = CSV_SOURCES[market]["suffix"]
+        entries: List[KoreanStockEntry] = []
+
+        try:
+            with open(path, encoding="utf-8-sig") as f:
+                reader = csv.DictReader(f)
+                for row in reader:
+                    code = row.get("code", "").strip()
+                    name = row.get("name", "").strip()
+                    sector = row.get("sector", "").strip()
+                    if not code or not name:
+                        continue
+                    entries.append(
+                        KoreanStockEntry(
+                            symbol=f"{code}{suffix}",
+                            code=code,
+                            name=name,
+                            sector=sector,
+                        )
+                    )
+        except Exception:
+            logger.exception("Failed to load %s", path)
+            return []
+
+        mtime = path.stat().st_mtime
+        self._markets[market] = _MarketData(
+            entries=entries, source_path=str(path), mtime=mtime
+        )
+        logger.info("Loaded %d entries from %s", len(entries), path)
+        return entries
+
+    def _ensure_loaded(self) -> None:
+        """Lazy-load all market CSVs on first access, reload if files changed."""
+        with self._lock:
+            if not self._loaded:
+                for market in CSV_SOURCES:
+                    self._load_csv(market)
+                self._loaded = True
+                return
+
+            # Check for file changes
+            for market in CSV_SOURCES:
+                path = self._pick_csv(market)
+                if path is None:
+                    continue
+                current_mtime = path.stat().st_mtime
+                cached = self._markets.get(market)
+                if cached is None or cached.mtime < current_mtime:
+                    self._load_csv(market)
+
+    def _all_entries(self) -> List[KoreanStockEntry]:
+        """Return combined entries from all markets."""
+        self._ensure_loaded()
+        result: List[KoreanStockEntry] = []
+        for data in self._markets.values():
+            result.extend(data.entries)
+        return result
+
+    def search(self, query: str, limit: int = 20) -> List[KoreanStockEntry]:
+        """
+        Search Korean stocks by name or code.
+
+        Name: substring match (case-insensitive for mixed queries).
+        Code: prefix match on numeric code.
+
+        Args:
+            query: Search string (Korean name or numeric code).
+            limit: Maximum results to return.
+
+        Returns:
+            Matching KoreanStockEntry list, in CSV order (KOSPI first, then KOSDAQ).
+        """
+        entries = self._all_entries()
+        if not entries:
+            return []
+
+        query = query.strip()
+        if not query:
+            return []
+
+        is_code_query = bool(re.match(r"^\d+$", query))
+        results: List[KoreanStockEntry] = []
+        query_lower = query.lower()
+
+        for entry in entries:
+            if is_code_query:
+                if entry.code.startswith(query):
+                    results.append(entry)
+            else:
+                if query_lower in entry.name.lower():
+                    results.append(entry)
+
+            if len(results) >= limit:
+                break
+
+        return results
+
+
+_instance: Optional[KoreanSearchService] = None
+
+
+def get_korean_search_service() -> KoreanSearchService:
+    """Get or create the singleton KoreanSearchService instance."""
+    global _instance
+    if _instance is None:
+        _instance = KoreanSearchService()
+    return _instance


### PR DESCRIPTION
## Summary
- Add `KoreanSearchService` that searches ~2,700 Korean stocks from local CSV data (kospi/kosdaq master files)
- Detect hangul characters or 6-digit KRX codes in search query → dispatch to local in-memory search instead of yfinance
- 6-digit code queries fall back to yfinance if not found locally; pure hangul queries use local search only

## Changes
| File | Action |
|------|--------|
| `api/services/korean_search_service.py` | **NEW** — Singleton service with lazy CSV loading, thread-safe, mtime-based reload |
| `api/routers/search.py` | **MODIFIED** — Korean detection + dispatch logic |
| `api/services/__init__.py` | **MODIFIED** — Register new service |

No frontend changes needed (SearchResult schema unchanged, `.KS`/`.KQ` suffixes already render as "KRX" badge).

## Test plan
- [ ] `curl 'http://localhost:8001/api/search?q=삼성전자'` → returns Korean stocks with `.KS` suffix
- [ ] `curl 'http://localhost:8001/api/search?q=005930'` → returns 삼성전자 from local data
- [ ] `curl 'http://localhost:8001/api/search?q=AAPL'` → unchanged yfinance results
- [ ] `curl 'http://localhost:8001/api/search?q=에코프로'` → returns KOSDAQ stocks with `.KQ` suffix
- [ ] Frontend: type "삼성" in analysis page search → dropdown shows Korean stocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*Written by: Claude Code*