### PR TITLE
fix(portfolio): auto-populate stock name on add, skip NaN prices

### DIFF
--- a/api/services/portfolio_service.py
+++ b/api/services/portfolio_service.py
@@ -177,7 +177,11 @@ class PortfolioService:
         try:
             data = self._cache.get(ticker, days=5, force_refresh=False)
             if data is not None and not data.empty:
-                price = float(data["close"].iloc[-1])
+                # Drop NaN close rows (e.g. pre-market placeholder for today)
+                valid = data["close"].dropna()
+                if valid.empty:
+                    return None
+                price = float(valid.iloc[-1])
                 return self._sanitize_float(price, default=None)
         except Exception as e:
             logger.warning(f"Failed to get current price for {ticker}: {e}")
@@ -396,28 +400,56 @@ class PortfolioService:
 
     @staticmethod
     def _fetch_static_metadata(ticker: str) -> Dict[str, Optional[str]]:
-        """Fetch static metadata (sector/industry/country/exchange) for a ticker. Called once at creation."""
-        result = {"sector": None, "industry": None, "country": None, "exchange": None}
+        """Fetch static metadata (name/sector/industry/country/exchange) for a ticker. Called once at creation."""
+        result: Dict[str, Optional[str]] = {
+            "name": None, "sector": None, "industry": None, "country": None, "exchange": None,
+        }
         try:
             if ticker.endswith(".KS") or ticker.endswith(".KQ"):
                 # Korean stock
                 suffix = ticker[-3:]  # .KS or .KQ
                 result["country"] = "South Korea"
                 result["exchange"] = "KOSPI" if suffix == ".KS" else "KOSDAQ"
-                # Sector from SectorFetcher
+                # Name + Sector from master CSV via KospiListFetcher
                 try:
-                    from screener.sector_fetcher import get_sector_fetcher
-                    fetcher = get_sector_fetcher()
-                    market = "KOSPI" if suffix == ".KS" else "KOSDAQ"
-                    sector_map = fetcher.get_all_sector_classifications(market)
-                    result["sector"] = sector_map.get(ticker)
+                    from screener.kospi_fetcher import KospiListFetcher
+                    kf = KospiListFetcher(use_cache=True)
+                    symbols = (
+                        kf.get_kospi_symbols()
+                        if suffix == ".KS"
+                        else kf.get_kosdaq_symbols()
+                    )
+                    for s in symbols:
+                        if s["symbol"] == ticker:
+                            result["name"] = s["name"]
+                            result["sector"] = s.get("sector") or None
+                            break
                 except Exception as e:
-                    logger.warning(f"Failed to fetch KR sector for {ticker}: {e}")
+                    logger.warning(f"Failed to fetch KR metadata for {ticker}: {e}")
+                # Fallback name from pykrx if master CSV didn't have it
+                if not result["name"]:
+                    try:
+                        from pykrx import stock as pykrx_stock
+                        code = ticker.split(".")[0]
+                        result["name"] = pykrx_stock.get_market_ticker_name(code) or None
+                    except Exception:
+                        pass
+                # Fallback sector from SectorFetcher if not found above
+                if not result["sector"]:
+                    try:
+                        from screener.sector_fetcher import get_sector_fetcher
+                        sf = get_sector_fetcher()
+                        market = "KOSPI" if suffix == ".KS" else "KOSDAQ"
+                        sector_map = sf.get_all_sector_classifications(market)
+                        result["sector"] = sector_map.get(ticker)
+                    except Exception as e:
+                        logger.warning(f"Failed to fetch KR sector for {ticker}: {e}")
             else:
                 # US/Other: yfinance
                 try:
                     import yfinance as yf
                     info = yf.Ticker(ticker).info
+                    result["name"] = info.get("shortName") or info.get("longName")
                     result["sector"] = info.get("sector")
                     result["industry"] = info.get("industry")
                     result["country"] = info.get("country")
@@ -601,7 +633,7 @@ class PortfolioService:
                 meta = self._fetch_static_metadata(ticker)
                 existing = Holding(
                     ticker=ticker,
-                    name=data.name or ticker,
+                    name=data.name or meta.get("name") or ticker,
                     quantity=data.quantity,
                     avg_price=data.avg_price,
                     currency=data.currency,

--- a/utils/data_cache.py
+++ b/utils/data_cache.py
@@ -122,10 +122,12 @@ class OHLCVCache:
             else:
                 latest_date = pd.to_datetime(latest).date()
 
-            # Capture close price
+            # Capture close price (skip NaN rows, e.g. pre-market placeholder)
             close_val = None
             if "close" in data.columns:
-                close_val = float(data["close"].iloc[-1])
+                valid_close = data["close"].dropna()
+                if not valid_close.empty:
+                    close_val = float(valid_close.iloc[-1])
 
             with self._meta_lock:
                 self._latest_date_cache[cache_key] = (mtime, latest_date, close_val)
@@ -195,6 +197,12 @@ class OHLCVCache:
             data = data.reset_index()
             data['date'] = pd.to_datetime(data['date'])
             data = data.set_index('date')
+
+            # Drop rows where close is NaN (e.g. pre-market placeholder for today)
+            data = data.dropna(subset=['close'])
+
+            if data.empty:
+                return None
 
             # 티커 컬럼 추가
             data['ticker'] = ticker


### PR DESCRIPTION
## Summary
- Auto-populate Korean stock name from master CSV with pykrx fallback when frontend doesn't provide name
- Auto-populate US stock name from yfinance `shortName`/`longName`
- Fix current_price returning `None` when pykrx cache has NaN trailing row (pre-market placeholder)
- Drop NaN close rows at fetch time and in cache metadata lookup

## Test plan
- [ ] Add a Korean holding (e.g. 189300.KS) without providing name — should show "인텔리안테크"
- [ ] Add a US holding without name — should show company name from yfinance
- [ ] Verify 컴투스(078340.KS), 한국콜마(161890.KQ) show current_price after server restart
- [ ] Verify existing holdings with names still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)