### PR TITLE
feat(portfolio): add SellRule SQLAlchemy model

### DIFF
--- a/api/models/portfolio.py
+++ b/api/models/portfolio.py
@@ -1,12 +1,28 @@
 """
-SQLAlchemy models for the portfolio tables (holdings + trades).
+SQLAlchemy models for the portfolio tables (holdings, trades, sell_rules).
 """
 
 from datetime import date, datetime
 
-from sqlalchemy import Column, Date, DateTime, Float, Integer, String, Text
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    Column,
+    Date,
+    DateTime,
+    Float,
+    ForeignKey,
+    Integer,
+    JSON,
+    String,
+    Text,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import relationship
 
 from api.database import Base
+
+_JSON = JSON().with_variant(JSONB, "postgresql")
 
 
 class Holding(Base):
@@ -26,6 +42,11 @@ class Holding(Base):
     created_at = Column(DateTime, default=datetime.utcnow)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 
+    sell_rules = relationship(
+        "SellRule", back_populates="holding", cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
+
 
 class Trade(Base):
     __tablename__ = "trades"
@@ -44,3 +65,33 @@ class Trade(Base):
     note = Column(Text, nullable=True)
     traded_at = Column(Date, nullable=False)
     created_at = Column(DateTime, default=datetime.utcnow)
+
+
+class SellRule(Base):
+    __tablename__ = "sell_rules"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    ticker = Column(
+        String(32),
+        ForeignKey("holdings.ticker", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    rule_type = Column(
+        String(32), nullable=False,
+    )  # stop_loss | take_profit | trailing_stop | holding_period
+    params = Column(_JSON, nullable=False)  # {"pct": -10} etc.
+    state_json = Column(_JSON, nullable=True)  # runtime state (e.g. trailing_stop high_watermark)
+
+    __table_args__ = (
+        CheckConstraint(
+            "rule_type IN ('stop_loss', 'take_profit', 'trailing_stop', 'holding_period')",
+            name="ck_sell_rule_type",
+        ),
+    )
+    is_active = Column(Boolean, nullable=False, default=True)
+    triggered_at = Column(DateTime, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    holding = relationship("Holding", back_populates="sell_rules")


### PR DESCRIPTION
## Summary
- Add `SellRule` SQLAlchemy model to `api/models/portfolio.py` with FK → `holdings.ticker` (CASCADE)
- `CheckConstraint` on `rule_type`: `stop_loss`, `take_profit`, `trailing_stop`, `holding_period`
- `params` / `state_json` use `JSON().with_variant(JSONB, "postgresql")` matching project pattern
- `Holding.sell_rules` relationship with `cascade="all, delete-orphan"` + `passive_deletes=True`

## Test plan
- [x] Model loads: `from api.models.portfolio import SellRule` OK
- [x] Columns: id, ticker, rule_type, params, state_json, is_active, triggered_at, created_at, updated_at
- [x] FK: `holdings.ticker` with `ondelete=CASCADE`
- [x] CheckConstraint: `rule_type IN ('stop_loss', 'take_profit', 'trailing_stop', 'holding_period')`
- [x] JSON type on params/state_json
- [x] passive_deletes=True on relationship

Closes #988

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*Written by: Claude Code*