### PR TITLE
fix(reports,strategy): target date display + market badge

### DIFF
--- a/api/schemas/strategy.py
+++ b/api/schemas/strategy.py
@@ -176,6 +176,7 @@ class StrategyResultItem(BaseModel):
     ticker: str
     name: str
     current_price: Optional[float] = None
+    market: Optional[str] = None
     per: Optional[float] = None
     pbr: Optional[float] = None
     dividend_yield: Optional[float] = None

--- a/api/services/strategy_service.py
+++ b/api/services/strategy_service.py
@@ -1211,10 +1211,16 @@ def execute_strategy(
     resolve_elapsed_ms = (time.perf_counter() - resolve_started_at) * 1000.0
 
     fetch_started_at = time.perf_counter()
-    tickers = screening_service.get_tickers_for_universes(
+    symbols_dict, resolved_universes_from_fetch, failed_errors, ticker_to_market = screening_service._get_symbols_for_universes(
         universe_input=resolved_universes,
         fail_fast=False,
     )
+    if not symbols_dict:
+        if failed_errors:
+            details = ", ".join(f"{k}: {v}" for k, v in failed_errors.items())
+            raise ValueError(f"Failed to fetch all universes ({details})")
+        raise ValueError(f"No tickers available for universes: {resolved_universes_from_fetch}")
+    tickers = list(symbols_dict.keys())
     fetch_elapsed_ms = (time.perf_counter() - fetch_started_at) * 1000.0
     total_count = len(tickers)
 
@@ -1313,6 +1319,7 @@ def execute_strategy(
                     ticker=r.ticker,
                     name=r.name,
                     current_price=r.current_price,
+                    market=ticker_to_market.get(r.ticker),
                     matched=True,
                     conditions=cond_details,
                 )
@@ -1345,6 +1352,7 @@ def execute_strategy(
                         ticker=result.ticker,
                         name=result.name,
                         current_price=result.current_price,
+                        market=ticker_to_market.get(result.ticker),
                         matched=result.matched,
                         conditions=cond_details,
                     )

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -454,6 +454,7 @@
     "ticker": "Ticker",
     "name": "Name",
     "price": "Price",
+    "market": "Market",
     "status": "Status",
     "inputBadge": "Input",
     "screeningBadge": "Screening",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -454,6 +454,7 @@
     "ticker": "종목코드",
     "name": "종목명",
     "price": "가격",
+    "market": "시장",
     "status": "상태",
     "inputBadge": "입력",
     "screeningBadge": "스크리닝",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -454,6 +454,7 @@
     "ticker": "代码",
     "name": "名称",
     "price": "价格",
+    "market": "市场",
     "status": "状态",
     "inputBadge": "输入",
     "screeningBadge": "筛选",

--- a/web/src/app/[locale]/reports/[id]/page.tsx
+++ b/web/src/app/[locale]/reports/[id]/page.tsx
@@ -9,6 +9,7 @@ import { getExecution } from '@/lib/api';
 import type { ExecutionHistoryDetail, ScreeningResult } from '@/lib/types';
 import {
   ArrowLeft,
+  CalendarDays,
   Clock,
   RefreshCw,
   Play,
@@ -157,8 +158,9 @@ export default function ExecutionDetailPage() {
               </span>
             ))}
             {execution.reference_date && (
-              <span className="inline-flex items-center rounded-full bg-[var(--background)] border border-[var(--border)] px-2.5 py-0.5 text-xs text-[var(--foreground-muted)]">
-                {execution.reference_date}
+              <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 border border-amber-200 px-2.5 py-0.5 text-xs font-medium text-amber-700 dark:bg-amber-900/20 dark:border-amber-800 dark:text-amber-300">
+                <CalendarDays className="h-3 w-3" />
+                {t('referenceDate')}: {execution.reference_date}
               </span>
             )}
             <span className="text-sm text-[var(--foreground-muted)]">
@@ -178,7 +180,13 @@ export default function ExecutionDetailPage() {
       </div>
 
       {/* Stats cards */}
-      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-5">
+        <StatCard
+          icon={<CalendarDays className="h-5 w-5" />}
+          label={t('referenceDate')}
+          value={execution.reference_date ?? 'N/A'}
+          accent={execution.reference_date ? 'amber' : undefined}
+        />
         <StatCard
           icon={<Database className="h-5 w-5" />}
           label={t('totalCount')}
@@ -237,8 +245,14 @@ function StatCard({
   icon: React.ReactNode;
   label: string;
   value: string;
-  accent?: 'green';
+  accent?: 'green' | 'amber';
 }) {
+  const valueColor =
+    accent === 'green'
+      ? 'text-green-600 dark:text-green-400'
+      : accent === 'amber'
+        ? 'text-amber-600 dark:text-amber-400'
+        : 'text-[var(--foreground)]';
   return (
     <div className="flex items-center gap-3 rounded-xl border border-[var(--border)] bg-[var(--background-secondary)] px-4 py-3 backdrop-blur-sm">
       <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-[var(--color-primary)]/10 text-[var(--color-primary)]">
@@ -248,13 +262,7 @@ function StatCard({
         <p className="text-xs text-[var(--foreground-muted)] truncate">
           {label}
         </p>
-        <p
-          className={`text-lg font-semibold tabular-nums ${
-            accent === 'green'
-              ? 'text-green-600 dark:text-green-400'
-              : 'text-[var(--foreground)]'
-          }`}
-        >
+        <p className={`text-lg font-semibold tabular-nums ${valueColor}`}>
           {value}
         </p>
       </div>

--- a/web/src/components/strategy/IntermediateResultsPanel.tsx
+++ b/web/src/components/strategy/IntermediateResultsPanel.tsx
@@ -365,6 +365,7 @@ export default function IntermediateResultsPanel({
                   <th className="px-4 py-2 w-10">#</th>
                   <th className="px-4 py-2">{t('ticker')}</th>
                   <th className="px-4 py-2">{t('name')}</th>
+                  <th className="px-3 py-2">{t('market')}</th>
                   <th className="px-4 py-2 text-right">{t('price')}</th>
                   {metricColumns.map((col) => (
                     <th key={col} className="px-3 py-2 text-right">
@@ -390,6 +391,17 @@ export default function IntermediateResultsPanel({
                       </td>
                       <td className="px-4 py-1.5 text-gray-700 dark:text-gray-200 truncate max-w-[120px]">
                         {stock.name}
+                      </td>
+                      <td className="px-3 py-1.5">
+                        {stock.market && (
+                          <span className={`inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-bold ${
+                            stock.market === 'KOSDAQ'
+                              ? 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300'
+                              : 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300'
+                          }`}>
+                            {stock.market}
+                          </span>
+                        )}
                       </td>
                       <td className="px-4 py-1.5 text-right text-gray-700 dark:text-gray-200">
                         {stock.current_price?.toLocaleString() ?? '-'}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -943,6 +943,7 @@ export interface StrategyResultItem {
   ticker: string;
   name: string;
   current_price: number | null;
+  market?: string | null;
   matched: boolean;
   conditions: Array<Record<string, unknown>>;
 }


### PR DESCRIPTION
## Summary
- **#1021**: Reports detail page now clearly shows target date (reference_date) with CalendarDays icon, amber badge in header, and a dedicated StatCard. Shows "N/A" when missing.
- **#1023**: Strategy execution result table now includes a Market column with color-coded KOSPI/KOSDAQ badges. Backend passes `ticker_to_market` mapping from universe resolution.

## Changes

| File | Issue | Change |
|------|-------|--------|
| `web/src/app/[locale]/reports/[id]/page.tsx` | #1021 | CalendarDays icon + label on reference_date badge, new StatCard with amber accent |
| `api/schemas/strategy.py` | #1023 | `market: Optional[str]` field on `StrategyResultItem` |
| `api/services/strategy_service.py` | #1023 | Pass `ticker_to_market` from `_get_symbols_for_universes()` to result items |
| `web/src/components/strategy/IntermediateResultsPanel.tsx` | #1023 | Market column with KOSPI(blue)/KOSDAQ(purple) badges |
| `web/src/lib/api.ts` | #1023 | `market` field on `StrategyResultItem` interface |
| `web/messages/{en,ko,zh}.json` | #1023 | `strategy.market` i18n key |

## Test plan
- [ ] `/reports/{id}` shows target date StatCard (amber) + labeled badge in header
- [ ] `/reports/{id}` with no reference_date shows "N/A" without breaking
- [ ] `/strategy` run → result table shows Market column with KOSPI/KOSDAQ badges
- [ ] Non-KR universe results show empty market cell (no crash)
- [ ] Locale switch (en/ko/zh) displays correct market/referenceDate labels

Closes #1021
Closes #1023

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*Written by: Claude Code*