### PR TITLE
feat(search): add Korean stock name search using local CSV data

### DIFF
--- a/web/src/app/[locale]/watchlist/page.tsx
+++ b/web/src/app/[locale]/watchlist/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { useTranslations, useLocale } from 'next-intl';
 import { Plus, RefreshCw, Star, Trash2, Edit3, Shield, TrendingDown, TrendingUp } from 'lucide-react';
 import { Button, Card } from '@/components/ui';
+import TickerSearchInput from '@/components/ui/TickerSearchInput';
 import {
   getWatchlistItems,
   createWatchlistItem,
@@ -299,12 +300,10 @@ export default function WatchlistPage() {
             <div className="space-y-3">
               <div>
                 <label className="block text-sm font-medium text-[var(--foreground-muted)] mb-1">{t('ticker')}</label>
-                <input
-                  type="text"
+                <TickerSearchInput
                   value={addForm.ticker}
-                  onChange={(e) => setAddForm({ ...addForm, ticker: e.target.value })}
-                  placeholder={t('tickerPlaceholder')}
-                  className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)]"
+                  onChange={(ticker, name) => setAddForm({ ...addForm, ticker, name: name || addForm.name })}
+                  placeholder={t('tickerPlaceholder') + ' / 삼성전자'}
                   autoFocus
                 />
               </div>

--- a/web/src/components/portfolio/AddHoldingModal.tsx
+++ b/web/src/components/portfolio/AddHoldingModal.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { X } from 'lucide-react';
 import { Button } from '@/components/ui';
+import TickerSearchInput from '@/components/ui/TickerSearchInput';
 import type { HoldingCreate } from '@/lib/types';
 
 interface AddHoldingModalProps {
@@ -64,8 +65,8 @@ export default function AddHoldingModal({ isOpen, onClose, onAdd }: AddHoldingMo
 
     if (!ticker.trim()) {
       newErrors.ticker = 'Ticker is required';
-    } else if (!/^[A-Za-z0-9.-]+$/.test(ticker.trim())) {
-      newErrors.ticker = 'Invalid ticker format';
+    } else if (!/^[A-Za-z0-9.^-]+$/.test(ticker.trim())) {
+      newErrors.ticker = 'Select a stock from the search results';
     }
 
     const qty = parseFloat(quantity);
@@ -156,16 +157,16 @@ export default function AddHoldingModal({ isOpen, onClose, onAdd }: AddHoldingMo
               <label htmlFor="ticker" className="block text-sm font-medium text-[var(--foreground)] mb-1">
                 Ticker <span className="text-red-500">*</span>
               </label>
-              <input
-                ref={tickerInputRef}
-                type="text"
+              <TickerSearchInput
+                inputRef={tickerInputRef}
                 id="ticker"
                 value={ticker}
-                onChange={(e) => setTicker(e.target.value.toUpperCase())}
-                placeholder="e.g., AAPL"
-                className={`w-full rounded-lg border px-3 py-2 text-[var(--foreground)] placeholder-[var(--foreground-muted)] bg-[var(--background)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)] ${
-                  errors.ticker ? 'border-red-500' : 'border-[var(--border)]'
-                }`}
+                onChange={(t) => {
+                  setTicker(t.toUpperCase());
+                  if (t.endsWith('.KS') || t.endsWith('.KQ')) setCurrency('KRW');
+                }}
+                placeholder="e.g., AAPL or 삼성전자"
+                hasError={!!errors.ticker}
                 disabled={isSubmitting}
               />
               {errors.ticker && (

--- a/web/src/components/ui/TickerSearchInput.tsx
+++ b/web/src/components/ui/TickerSearchInput.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { searchTickers } from '@/lib/api';
+
+interface SearchResult {
+  ticker: string;
+  name: string;
+}
+
+interface TickerSearchInputProps {
+  value: string;
+  onChange: (ticker: string, name?: string) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  hasError?: boolean;
+  autoFocus?: boolean;
+  id?: string;
+  /** Ref forwarded to the underlying input element */
+  inputRef?: React.RefObject<HTMLInputElement | null>;
+}
+
+/**
+ * Ticker input with autocomplete search dropdown.
+ * Searches by stock name (Korean/English) or ticker symbol.
+ * On select, fills the ticker field and optionally returns the stock name.
+ */
+export default function TickerSearchInput({
+  value,
+  onChange,
+  placeholder = 'e.g., AAPL',
+  disabled = false,
+  hasError = false,
+  autoFocus = false,
+  id,
+  inputRef: externalRef,
+}: TickerSearchInputProps) {
+  const [query, setQuery] = useState(value);
+  const [results, setResults] = useState<SearchResult[]>([]);
+  const [isOpen, setIsOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const internalRef = useRef<HTMLInputElement>(null);
+  const inputElement = externalRef || internalRef;
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>();
+
+  // Sync external value changes
+  useEffect(() => {
+    setQuery(value);
+  }, [value]);
+
+  const doSearch = useCallback(async (q: string) => {
+    if (q.trim().length < 1) {
+      setResults([]);
+      setIsOpen(false);
+      return;
+    }
+    setIsLoading(true);
+    try {
+      const data = await searchTickers(q.trim());
+      setResults(data.slice(0, 10));
+      setIsOpen(data.length > 0);
+      setActiveIndex(-1);
+    } catch {
+      setResults([]);
+      setIsOpen(false);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value;
+    setQuery(val);
+    onChange(val);
+
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => doSearch(val), 300);
+  };
+
+  const handleSelect = (result: SearchResult) => {
+    setQuery(result.ticker);
+    onChange(result.ticker, result.name);
+    setIsOpen(false);
+    setResults([]);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (!isOpen || results.length === 0) return;
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActiveIndex((prev) => (prev < results.length - 1 ? prev + 1 : 0));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActiveIndex((prev) => (prev > 0 ? prev - 1 : results.length - 1));
+    } else if (e.key === 'Enter' && activeIndex >= 0) {
+      e.preventDefault();
+      handleSelect(results[activeIndex]);
+    } else if (e.key === 'Escape') {
+      setIsOpen(false);
+    }
+  };
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  // Cleanup debounce on unmount
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
+
+  return (
+    <div ref={containerRef} className="relative">
+      <input
+        ref={inputElement}
+        type="text"
+        id={id}
+        value={query}
+        onChange={handleInputChange}
+        onKeyDown={handleKeyDown}
+        onFocus={() => { if (results.length > 0) setIsOpen(true); }}
+        placeholder={placeholder}
+        disabled={disabled}
+        autoFocus={autoFocus}
+        autoComplete="off"
+        className={`w-full rounded-lg border px-3 py-2 text-[var(--foreground)] placeholder-[var(--foreground-muted)] bg-[var(--background)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)] ${
+          hasError ? 'border-red-500' : 'border-[var(--border)]'
+        }`}
+      />
+
+      {isLoading && (
+        <div className="absolute right-3 top-1/2 -translate-y-1/2">
+          <div className="h-4 w-4 animate-spin rounded-full border-2 border-[var(--foreground-muted)] border-t-transparent" />
+        </div>
+      )}
+
+      {isOpen && results.length > 0 && (
+        <ul
+          className="absolute z-50 mt-1 max-h-60 w-full overflow-auto rounded-lg border border-[var(--border)] bg-[var(--background-secondary)] shadow-lg"
+          role="listbox"
+        >
+          {results.map((result, index) => (
+            <li
+              key={result.ticker}
+              role="option"
+              aria-selected={index === activeIndex}
+              onClick={() => handleSelect(result)}
+              onMouseEnter={() => setActiveIndex(index)}
+              className={`cursor-pointer px-3 py-2 text-sm ${
+                index === activeIndex
+                  ? 'bg-[var(--color-primary)]/10 text-[var(--foreground)]'
+                  : 'text-[var(--foreground)] hover:bg-[var(--border)]/50'
+              }`}
+            >
+              <span className="font-mono font-semibold">{result.ticker}</span>
+              <span className="ml-2 text-[var(--foreground-muted)]">{result.name}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/ui/index.ts
+++ b/web/src/components/ui/index.ts
@@ -1,2 +1,3 @@
 export { default as Button } from './Button';
 export { default as Card } from './Card';
+export { default as TickerSearchInput } from './TickerSearchInput';


### PR DESCRIPTION
## Summary
- Add `TickerSearchInput` autocomplete component — type stock name (Korean/English) or ticker to search
- Portfolio "Add Holding" modal: search by name, auto-fill ticker, auto-switch to KRW for Korean stocks
- Watchlist "관심종목에 추가" modal: search by name, auto-fill ticker + name fields
- Uses existing `/api/search` endpoint (local CSV for Korean, yfinance for US)

## Test plan
- [ ] Portfolio → Add Holding → type "삼성" → dropdown shows Samsung stocks → select → ticker auto-filled
- [ ] Portfolio → Add Holding → type "AAPL" → shows Apple → select → ticker filled, currency stays USD
- [ ] Portfolio → Add Holding → select Korean stock → currency auto-switches to KRW
- [ ] Watchlist → 관심종목에 추가 → type "카카오" → select → ticker + name auto-filled
- [ ] Keyboard navigation (Arrow Up/Down, Enter, Escape) works in dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)