### PR TITLE
feat(watchlist): add BuyRuleTemplate model + template_id FK

### DIFF
--- a/api/database.py
+++ b/api/database.py
@@ -60,10 +60,33 @@ def init_db() -> None:
     logger.info("Database tables ensured")
     _migrate_trade_columns()
     _migrate_holding_metadata_columns()
+    _migrate_buy_rule_template_id()
 
     _migrate_json_data()
     _migrate_portfolio_json()
     _migrate_saved_screening_to_execution_history()
+
+
+def _get_column_names(conn, table_name: str):
+    """Return a set of column names for *table_name*, or None if the table
+    does not exist.  Works with both SQLite and PostgreSQL."""
+    dialect = engine.dialect.name
+    if dialect == "sqlite":
+        rows = conn.execute(text(f"PRAGMA table_info({table_name})")).fetchall()
+        if not rows:
+            return None
+        return {row[1] for row in rows}
+    # PostgreSQL / other dialects
+    rows = conn.execute(
+        text(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_schema = current_schema() AND table_name = :tbl"
+        ),
+        {"tbl": table_name},
+    ).fetchall()
+    if not rows:
+        return None
+    return {row[0] for row in rows}
 
 
 def _migrate_trade_columns() -> None:
@@ -99,6 +122,27 @@ def _migrate_holding_metadata_columns() -> None:
                 logger.info("Added missing holdings.exchange column for legacy DB compatibility")
     except Exception as e:
         logger.warning("Holding schema compatibility migration skipped: %s", e)
+
+
+def _migrate_buy_rule_template_id() -> None:
+    """Add template_id column to buy_rules for existing databases.
+
+    Uses dialect-aware column introspection: PRAGMA for SQLite,
+    information_schema for PostgreSQL.
+    """
+    try:
+        with engine.begin() as conn:
+            existing_columns = _get_column_names(conn, "buy_rules")
+            if existing_columns is None:
+                return  # table does not exist yet; create_all will handle it
+            if "template_id" not in existing_columns:
+                conn.execute(
+                    text("ALTER TABLE buy_rules ADD COLUMN template_id INTEGER REFERENCES buy_rule_templates(id) ON DELETE SET NULL")
+                )
+                conn.execute(text("CREATE INDEX IF NOT EXISTS ix_buy_rules_template_id ON buy_rules (template_id)"))
+                logger.info("Added buy_rules.template_id column")
+    except Exception as e:
+        logger.warning("buy_rules template_id migration skipped: %s", e)
 
 
 def _migrate_json_data() -> None:

--- a/api/models/watchlist.py
+++ b/api/models/watchlist.py
@@ -1,11 +1,13 @@
 """
-SQLAlchemy models for the watchlist tables (watchlist_items + buy_rules).
+SQLAlchemy models for the watchlist tables
+(watchlist_items, buy_rules, buy_rule_templates).
 """
 
 from datetime import datetime
 
 from sqlalchemy import (
     Boolean,
+    CheckConstraint,
     Column,
     DateTime,
     Float,
@@ -53,6 +55,12 @@ class BuyRule(Base):
         nullable=False,
         index=True,
     )
+    template_id = Column(
+        Integer,
+        ForeignKey("buy_rule_templates.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
     rule_type = Column(String(32), nullable=False)  # target_price, rsi_oversold
     params = Column(_JSON, nullable=False)  # e.g. {"price": 50000} or {"rsi": 30}
     state_json = Column(_JSON, nullable=True)  # evaluation state
@@ -62,3 +70,28 @@ class BuyRule(Base):
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 
     watchlist_item = relationship("WatchlistItem", back_populates="buy_rules")
+    template = relationship("BuyRuleTemplate", back_populates="linked_rules")
+
+
+class BuyRuleTemplate(Base):
+    __tablename__ = "buy_rule_templates"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(String(255), unique=True, nullable=False)
+    rule_type = Column(String(32), nullable=False)
+    params = Column(_JSON, nullable=False)
+    description = Column(Text, nullable=True)
+    is_active = Column(Boolean, default=True, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    linked_rules = relationship(
+        "BuyRule", back_populates="template", passive_deletes=True,
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "rule_type IN ('target_price', 'rsi_oversold')",
+            name="ck_buy_rule_template_type",
+        ),
+    )


### PR DESCRIPTION
## Summary
- Add `BuyRuleTemplate` SQLAlchemy model (`buy_rule_templates` table) for reusable buy rule templates
- Add `template_id` FK column to `BuyRule` model with `ON DELETE SET NULL`
- Add dialect-aware migration (`_get_column_names` helper supports both SQLite and PostgreSQL)
- Migration creates index `ix_buy_rules_template_id` for existing databases

## Changes
| File | Description |
|------|-------------|
| `api/models/watchlist.py` | New `BuyRuleTemplate` model + `BuyRule.template_id` FK + relationship |
| `api/database.py` | `_get_column_names()` helper + `_migrate_buy_rule_template_id()` migration |

## Parent issue
Part of #1027 (Buy Rule Templates epic)

Closes #1029

## Test plan
- [x] Model loads correctly (verified via Python import)
- [x] Codex code review: LGTM (2 rounds)
- [ ] Verify `init_db()` creates table on fresh DB
- [ ] Verify migration adds `template_id` column on existing DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)