### PR TITLE
feat(watchlist): auto-populate target price with current price on stock select

### DIFF
--- a/api/routers/search.py
+++ b/api/routers/search.py
@@ -6,10 +6,11 @@ Provides endpoint for searching tickers by name or symbol.
 
 import logging
 import re
-from typing import List
+from typing import List, Optional
 
 import yfinance as yf
 from fastapi import APIRouter, Query
+from pydantic import BaseModel
 
 from api.schemas.analysis import SearchResult
 from api.services.korean_search_service import get_korean_search_service
@@ -117,3 +118,39 @@ def _search_yfinance(q: str) -> List[SearchResult]:
         logger.warning(f"yfinance search failed: {e}")
 
     return results[:20]
+
+
+class TickerPrice(BaseModel):
+    ticker: str
+    price: Optional[float] = None
+
+
+@router.get(
+    "/price/{ticker}",
+    response_model=TickerPrice,
+    summary="Get Current Price",
+    description="Get current price for a single ticker.",
+)
+async def get_ticker_price(ticker: str) -> TickerPrice:
+    """Get current price from OHLCV cache or yfinance."""
+    try:
+        from utils.data_cache import get_cache
+        cache = get_cache()
+        data = cache.get(ticker, days=5, force_refresh=False)
+        if data is not None and not data.empty:
+            valid = data["close"].dropna()
+            if not valid.empty:
+                return TickerPrice(ticker=ticker, price=float(valid.iloc[-1]))
+    except Exception as e:
+        logger.warning(f"Cache price lookup failed for {ticker}: {e}")
+
+    # Fallback: yfinance
+    try:
+        info = yf.Ticker(ticker).fast_info
+        price = getattr(info, "last_price", None)
+        if price is not None:
+            return TickerPrice(ticker=ticker, price=float(price))
+    except Exception:
+        pass
+
+    return TickerPrice(ticker=ticker, price=None)

--- a/web/src/app/[locale]/watchlist/page.tsx
+++ b/web/src/app/[locale]/watchlist/page.tsx
@@ -10,6 +10,7 @@ import {
   createWatchlistItem,
   updateWatchlistItem,
   deleteWatchlistItem,
+  getTickerPrice,
 } from '@/lib/api';
 import type { WatchlistItem, WatchlistItemCreate, WatchlistItemUpdate } from '@/lib/types';
 import { formatCurrency } from '@/lib/format';
@@ -302,7 +303,22 @@ export default function WatchlistPage() {
                 <label className="block text-sm font-medium text-[var(--foreground-muted)] mb-1">{t('ticker')}</label>
                 <TickerSearchInput
                   value={addForm.ticker}
-                  onChange={(ticker, name) => setAddForm({ ...addForm, ticker, name: name || addForm.name })}
+                  onChange={(ticker, name) => {
+                    setAddForm((prev) => ({ ...prev, ticker, name: name || prev.name }));
+                    // Auto-fill target price with current price on ticker selection
+                    if (ticker && /^[A-Za-z0-9.^-]+$/.test(ticker)) {
+                      getTickerPrice(ticker)
+                        .then(({ price }) => {
+                          if (price != null) {
+                            setAddForm((prev) => prev.ticker === ticker
+                              ? { ...prev, target_price: String(price) }
+                              : prev
+                            );
+                          }
+                        })
+                        .catch(() => {});
+                    }
+                  }}
                   placeholder={t('tickerPlaceholder') + ' / 삼성전자'}
                   autoFocus
                 />

--- a/web/src/components/ui/TickerSearchInput.tsx
+++ b/web/src/components/ui/TickerSearchInput.tsx
@@ -43,7 +43,7 @@ export default function TickerSearchInput({
   const containerRef = useRef<HTMLDivElement>(null);
   const internalRef = useRef<HTMLInputElement>(null);
   const inputElement = externalRef || internalRef;
-  const debounceRef = useRef<ReturnType<typeof setTimeout>>();
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>(null);
 
   // Sync external value changes
   useEffect(() => {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -366,6 +366,13 @@ export async function searchTickers(query: string): Promise<Array<{ ticker: stri
 }
 
 /**
+ * Get current price for a single ticker
+ */
+export async function getTickerPrice(ticker: string): Promise<{ ticker: string; price: number | null }> {
+  return fetchApi<{ ticker: string; price: number | null }>(`/api/price/${encodeURIComponent(ticker)}`);
+}
+
+/**
  * Run AI analysis on a stock (Claude API, may take 30+ seconds)
  */
 export async function analyzeStock(ticker: string, includeNews = true): Promise<AIAnalysisResult> {


### PR DESCRIPTION
## Summary
- Add `/api/price/{ticker}` endpoint for single-ticker current price lookup
- Watchlist add modal: auto-fill target price with current price when user selects a stock
- Fix `TickerSearchInput` useRef init for React 19 strict mode

## Test plan
- [ ] Restart backend server
- [ ] Watchlist → 관심종목에 추가 → search "삼성전자" → select → target price auto-filled with current price
- [ ] Target price is editable after auto-fill
- [ ] If price unavailable, target price stays empty
- [ ] `GET /api/price/005930.KS` returns `{"ticker":"005930.KS","price":...}`

Closes #1026

🤖 Generated with [Claude Code](https://claude.com/claude-code)