### PR TITLE
feat(watchlist): add buy rule template CRUD API + linkage

### DIFF
--- a/api/database.py
+++ b/api/database.py
@@ -141,6 +141,10 @@ def _migrate_buy_rule_template_id() -> None:
                 )
                 conn.execute(text("CREATE INDEX IF NOT EXISTS ix_buy_rules_template_id ON buy_rules (template_id)"))
                 logger.info("Added buy_rules.template_id column")
+            # Ensure unique constraint exists (safe for re-runs)
+            conn.execute(
+                text("CREATE UNIQUE INDEX IF NOT EXISTS uq_buy_rules_item_template ON buy_rules (watchlist_item_id, template_id)")
+            )
     except Exception as e:
         logger.warning("buy_rules template_id migration skipped: %s", e)
 

--- a/api/models/watchlist.py
+++ b/api/models/watchlist.py
@@ -16,6 +16,7 @@ from sqlalchemy import (
     JSON,
     String,
     Text,
+    UniqueConstraint,
 )
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship
@@ -71,6 +72,13 @@ class BuyRule(Base):
 
     watchlist_item = relationship("WatchlistItem", back_populates="buy_rules")
     template = relationship("BuyRuleTemplate", back_populates="linked_rules")
+
+    __table_args__ = (
+        UniqueConstraint(
+            "watchlist_item_id", "template_id",
+            name="uq_buy_rules_item_template",
+        ),
+    )
 
 
 class BuyRuleTemplate(Base):

--- a/api/routers/watchlist.py
+++ b/api/routers/watchlist.py
@@ -13,8 +13,12 @@ from fastapi import APIRouter, HTTPException
 from api.schemas.watchlist import (
     BuyRuleCreate,
     BuyRuleResponse,
+    BuyRuleTemplateCreate,
+    BuyRuleTemplateResponse,
+    BuyRuleTemplateUpdate,
     BuyRuleUpdate,
     BuySignalsResponse,
+    CreateRuleFromTemplate,
     WatchlistItemCreate,
     WatchlistItemResponse,
     WatchlistItemUpdate,
@@ -198,6 +202,124 @@ async def delete_buy_rule(rule_id: int) -> None:
         raise
     except Exception as e:
         logger.error("Failed to delete buy rule %d: %s", rule_id, e, exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+# ── BuyRuleTemplate endpoints ─────────────────────────────────────
+
+
+@router.get(
+    "/buy-rule-templates",
+    response_model=List[BuyRuleTemplateResponse],
+    summary="List Buy Rule Templates",
+)
+async def list_templates() -> List[BuyRuleTemplateResponse]:
+    """Get all buy rule templates."""
+    service = get_watchlist_service()
+    try:
+        return service.list_templates()
+    except Exception as e:
+        logger.error("Failed to list templates: %s", e, exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@router.post(
+    "/buy-rule-templates",
+    response_model=BuyRuleTemplateResponse,
+    status_code=201,
+    summary="Create Buy Rule Template",
+)
+async def create_template(data: BuyRuleTemplateCreate) -> BuyRuleTemplateResponse:
+    """Create a new buy rule template."""
+    service = get_watchlist_service()
+    try:
+        return service.create_template(data)
+    except ValueError as e:
+        msg = str(e)
+        if "already exists" in msg:
+            raise HTTPException(status_code=409, detail=msg)
+        raise HTTPException(status_code=422, detail=msg)
+    except Exception as e:
+        logger.error("Failed to create template: %s", e, exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@router.put(
+    "/buy-rule-templates/{template_id}",
+    response_model=BuyRuleTemplateResponse,
+    summary="Update Buy Rule Template",
+)
+async def update_template(
+    template_id: int, data: BuyRuleTemplateUpdate
+) -> BuyRuleTemplateResponse:
+    """Update a buy rule template."""
+    service = get_watchlist_service()
+    try:
+        result = service.update_template(template_id, data)
+        if result is None:
+            raise HTTPException(status_code=404, detail=f"Template {template_id} not found")
+        return result
+    except HTTPException:
+        raise
+    except ValueError as e:
+        msg = str(e)
+        if "already exists" in msg:
+            raise HTTPException(status_code=409, detail=msg)
+        raise HTTPException(status_code=422, detail=msg)
+    except Exception as e:
+        logger.error("Failed to update template %d: %s", template_id, e, exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@router.delete(
+    "/buy-rule-templates/{template_id}",
+    status_code=204,
+    summary="Delete Buy Rule Template",
+)
+async def delete_template(template_id: int) -> None:
+    """Delete a buy rule template. Linked rules will have template_id set to NULL."""
+    service = get_watchlist_service()
+    try:
+        success = service.delete_template(template_id)
+        if not success:
+            raise HTTPException(status_code=404, detail=f"Template {template_id} not found")
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("Failed to delete template %d: %s", template_id, e, exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+# ── From-template rule creation ───────────────────────────────────
+
+
+@router.post(
+    "/items/{item_id}/buy-rules/from-template",
+    response_model=BuyRuleResponse,
+    status_code=201,
+    summary="Create Rule from Template",
+)
+async def create_rule_from_template(
+    item_id: int, data: CreateRuleFromTemplate
+) -> BuyRuleResponse:
+    """Create a buy rule by copying params from a template."""
+    service = get_watchlist_service()
+    try:
+        return service.create_rule_from_template(
+            item_id, data.template_id, data.is_active
+        )
+    except ValueError as e:
+        msg = str(e)
+        if "not found" in msg:
+            raise HTTPException(status_code=404, detail=msg)
+        if "already linked" in msg:
+            raise HTTPException(status_code=409, detail=msg)
+        raise HTTPException(status_code=422, detail=msg)
+    except Exception as e:
+        logger.error(
+            "Failed to create rule from template for item %d: %s",
+            item_id, e, exc_info=True,
+        )
         raise HTTPException(status_code=500, detail="Internal server error")
 
 

--- a/api/schemas/watchlist.py
+++ b/api/schemas/watchlist.py
@@ -95,6 +95,7 @@ class BuyRuleUpdate(BaseModel):
 class BuyRuleResponse(BaseModel):
     id: int
     watchlist_item_id: int
+    template_id: Optional[int] = None
     rule_type: str
     params: Dict[str, Any]
     state_json: Optional[Dict[str, Any]] = None
@@ -102,6 +103,47 @@ class BuyRuleResponse(BaseModel):
     triggered_at: Optional[datetime] = None
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
+
+
+# ── BuyRuleTemplate schemas ───────────────────────────────────────
+
+
+class BuyRuleTemplateCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=255, description="Template name")
+    rule_type: str = Field(..., description="Rule type", examples=["target_price", "rsi_oversold"])
+    params: Dict[str, Any] = Field(..., description="Default rule parameters")
+    description: Optional[str] = Field(default=None, description="Optional description")
+
+    @field_validator("rule_type")
+    @classmethod
+    def validate_rule_type(cls, v: str) -> str:
+        if v not in BUY_RULE_TYPES:
+            raise ValueError(f"Invalid rule_type: {v}. Allowed: {BUY_RULE_TYPES}")
+        return v
+
+
+class BuyRuleTemplateUpdate(BaseModel):
+    name: Optional[str] = Field(default=None, min_length=1, max_length=255)
+    params: Optional[Dict[str, Any]] = None
+    description: Optional[str] = None
+    is_active: Optional[bool] = None
+
+
+class BuyRuleTemplateResponse(BaseModel):
+    id: int
+    name: str
+    rule_type: str
+    params: Dict[str, Any]
+    description: Optional[str] = None
+    is_active: bool
+    linked_rules_count: int = 0
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+
+class CreateRuleFromTemplate(BaseModel):
+    template_id: int = Field(..., description="Template ID to create rule from")
+    is_active: bool = Field(default=True, description="Whether the created rule is active")
 
 
 # ── Evaluation schemas ─────────────────────────────────────────────

--- a/api/services/watchlist_service.py
+++ b/api/services/watchlist_service.py
@@ -8,13 +8,18 @@ import logging
 from datetime import datetime
 from typing import Dict, List, Optional
 
+from sqlalchemy import func
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, joinedload
 
 from api.database import SessionLocal
-from api.models.watchlist import BuyRule, WatchlistItem
+from api.models.watchlist import BuyRule, BuyRuleTemplate, WatchlistItem
 from api.schemas.watchlist import (
     BuyRuleCreate,
     BuyRuleResponse,
+    BuyRuleTemplateCreate,
+    BuyRuleTemplateResponse,
+    BuyRuleTemplateUpdate,
     BuyRuleUpdate,
     BuySignal,
     WatchlistItemCreate,
@@ -243,6 +248,184 @@ class WatchlistService:
         finally:
             db.close()
 
+    # ── BuyRuleTemplate CRUD ──────────────────────────────────────
+
+    def list_templates(self) -> List[BuyRuleTemplateResponse]:
+        """Return all buy rule templates with linked rule counts."""
+        db: Session = SessionLocal()
+        try:
+            rows = (
+                db.query(BuyRuleTemplate)
+                .order_by(BuyRuleTemplate.created_at.desc())
+                .all()
+            )
+            if not rows:
+                return []
+
+            # Batch count to avoid N+1
+            count_rows = (
+                db.query(BuyRule.template_id, func.count(BuyRule.id))
+                .filter(BuyRule.template_id.isnot(None))
+                .group_by(BuyRule.template_id)
+                .all()
+            )
+            count_map = {tid: cnt for tid, cnt in count_rows}
+
+            return [
+                self._template_to_response(t, linked_count=count_map.get(t.id, 0))
+                for t in rows
+            ]
+        finally:
+            db.close()
+
+    def create_template(self, data: BuyRuleTemplateCreate) -> BuyRuleTemplateResponse:
+        """Create a new buy rule template."""
+        _validate_buy_rule_params(data.rule_type, data.params)
+
+        db: Session = SessionLocal()
+        try:
+            existing = (
+                db.query(BuyRuleTemplate)
+                .filter(BuyRuleTemplate.name == data.name)
+                .first()
+            )
+            if existing:
+                raise ValueError(f"Template name '{data.name}' already exists")
+
+            row = BuyRuleTemplate(
+                name=data.name,
+                rule_type=data.rule_type,
+                params=data.params,
+                description=data.description,
+            )
+            db.add(row)
+            db.commit()
+            db.refresh(row)
+            return self._template_to_response(row, db)
+        except IntegrityError:
+            db.rollback()
+            raise ValueError(f"Template name '{data.name}' already exists")
+        except ValueError:
+            db.rollback()
+            raise
+        except Exception:
+            db.rollback()
+            raise
+        finally:
+            db.close()
+
+    def update_template(
+        self, template_id: int, data: BuyRuleTemplateUpdate
+    ) -> Optional[BuyRuleTemplateResponse]:
+        """Update a template. Returns None if not found."""
+        db: Session = SessionLocal()
+        try:
+            row = db.query(BuyRuleTemplate).filter(BuyRuleTemplate.id == template_id).first()
+            if row is None:
+                return None
+
+            update_data = data.model_dump(exclude_unset=True)
+            if "params" in update_data and update_data["params"] is not None:
+                _validate_buy_rule_params(row.rule_type, update_data["params"])
+            if "name" in update_data and update_data["name"] is not None:
+                dup = (
+                    db.query(BuyRuleTemplate)
+                    .filter(BuyRuleTemplate.name == update_data["name"], BuyRuleTemplate.id != template_id)
+                    .first()
+                )
+                if dup:
+                    raise ValueError(f"Template name '{update_data['name']}' already exists")
+
+            for key, val in update_data.items():
+                setattr(row, key, val)
+
+            db.commit()
+            db.refresh(row)
+            return self._template_to_response(row, db)
+        except IntegrityError:
+            db.rollback()
+            raise ValueError(f"Template name '{data.name}' already exists")
+        except ValueError:
+            db.rollback()
+            raise
+        except Exception:
+            db.rollback()
+            raise
+        finally:
+            db.close()
+
+    def delete_template(self, template_id: int) -> bool:
+        """Delete a template. Returns False if not found."""
+        db: Session = SessionLocal()
+        try:
+            row = db.query(BuyRuleTemplate).filter(BuyRuleTemplate.id == template_id).first()
+            if row is None:
+                return False
+            db.delete(row)
+            db.commit()
+            return True
+        except Exception:
+            db.rollback()
+            raise
+        finally:
+            db.close()
+
+    def create_rule_from_template(
+        self, item_id: int, template_id: int, is_active: bool = True
+    ) -> BuyRuleResponse:
+        """Create a buy rule from a template, copying params and linking template_id."""
+        db: Session = SessionLocal()
+        try:
+            item = db.query(WatchlistItem).filter(WatchlistItem.id == item_id).first()
+            if item is None:
+                raise ValueError(f"Watchlist item {item_id} not found")
+
+            template = db.query(BuyRuleTemplate).filter(BuyRuleTemplate.id == template_id).first()
+            if template is None:
+                raise ValueError(f"Template {template_id} not found")
+
+            if not template.is_active:
+                raise ValueError(f"Template {template_id} is inactive")
+
+            # Prevent duplicate: same item + same template (app-level guard)
+            existing = (
+                db.query(BuyRule)
+                .filter(
+                    BuyRule.watchlist_item_id == item_id,
+                    BuyRule.template_id == template_id,
+                )
+                .first()
+            )
+            if existing:
+                raise ValueError(
+                    f"Template {template_id} is already linked to item {item_id} (rule #{existing.id})"
+                )
+
+            rule = BuyRule(
+                watchlist_item_id=item_id,
+                template_id=template_id,
+                rule_type=template.rule_type,
+                params=dict(template.params),  # copy params
+                is_active=is_active,
+            )
+            db.add(rule)
+            db.commit()
+            db.refresh(rule)
+            return self._rule_to_response(rule)
+        except IntegrityError:
+            db.rollback()
+            raise ValueError(
+                f"Template {template_id} is already linked to item {item_id}"
+            )
+        except ValueError:
+            db.rollback()
+            raise
+        except Exception:
+            db.rollback()
+            raise
+        finally:
+            db.close()
+
     # ── Buy Signal Evaluation ──────────────────────────────────────
 
     def evaluate_buy_signals(self) -> List[BuySignal]:
@@ -441,6 +624,7 @@ class WatchlistService:
         return BuyRuleResponse(
             id=rule.id,
             watchlist_item_id=rule.watchlist_item_id,
+            template_id=rule.template_id,
             rule_type=rule.rule_type,
             params=rule.params or {},
             state_json=rule.state_json,
@@ -448,6 +632,31 @@ class WatchlistService:
             triggered_at=rule.triggered_at,
             created_at=rule.created_at,
             updated_at=rule.updated_at,
+        )
+
+    @staticmethod
+    def _template_to_response(
+        template: BuyRuleTemplate,
+        db: Optional[Session] = None,
+        linked_count: Optional[int] = None,
+    ) -> BuyRuleTemplateResponse:
+        """Convert ORM BuyRuleTemplate to response schema."""
+        if linked_count is None and db is not None:
+            linked_count = (
+                db.query(BuyRule)
+                .filter(BuyRule.template_id == template.id)
+                .count()
+            )
+        return BuyRuleTemplateResponse(
+            id=template.id,
+            name=template.name,
+            rule_type=template.rule_type,
+            params=template.params or {},
+            description=template.description,
+            is_active=template.is_active,
+            linked_rules_count=linked_count or 0,
+            created_at=template.created_at,
+            updated_at=template.updated_at,
         )
 
 


### PR DESCRIPTION
## Summary
- Add `BuyRuleTemplate` CRUD endpoints: `GET/POST /buy-rule-templates`, `PUT/DELETE /buy-rule-templates/{id}`
- Add from-template rule creation: `POST /items/{item_id}/buy-rules/from-template`
- Add `template_id` field to `BuyRuleResponse` schema
- DB-level `UniqueConstraint(watchlist_item_id, template_id)` on `buy_rules` for race-safe duplicate prevention
- Batch count query on template listing to avoid N+1
- Inactive template blocked from rule creation

## Changes
| File | Description |
|------|-------------|
| `api/schemas/watchlist.py` | `BuyRuleTemplateCreate/Update/Response`, `CreateRuleFromTemplate`, `template_id` on `BuyRuleResponse` |
| `api/services/watchlist_service.py` | Template CRUD + from-template + IntegrityError handling + batch count |
| `api/routers/watchlist.py` | 5 new endpoints with proper HTTP status codes (201, 204, 404, 409, 422) |
| `api/models/watchlist.py` | `UniqueConstraint` on `(watchlist_item_id, template_id)` |
| `api/database.py` | Migration: `CREATE UNIQUE INDEX IF NOT EXISTS uq_buy_rules_item_template` |

## Parent issue
Part of #1027 (Buy Rule Templates epic)

Closes #1030

## Test plan
- [x] All code loads and passes import check
- [x] Codex code review: LGTM (3 rounds)
- [ ] curl test: template CRUD + from-template rule creation
- [ ] Verify duplicate template name → 409
- [ ] Verify duplicate item+template linkage → 409
- [ ] Verify inactive template → 422

🤖 Generated with [Claude Code](https://claude.com/claude-code)