### PR TITLE
feat(watchlist): add template selection tab to BuyRuleModal

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -2755,7 +2755,19 @@
     "rsiThreshold": "RSI Threshold",
     "active": "Active",
     "inactive": "Inactive",
-    "signals": "Signals"
+    "signals": "Signals",
+    "manualInput": "Manual Input",
+    "savedTemplates": "Saved Templates",
+    "noTemplates": "No saved templates yet",
+    "linkTemplate": "Link",
+    "alreadyLinked": "Linked",
+    "templateInactive": "Inactive",
+    "linkedCount": "{count} linked",
+    "invalidValue": "Enter a valid positive number",
+    "addRuleFailed": "Failed to add rule",
+    "linkFailed": "Failed to link template",
+    "loadFailed": "Failed to load templates",
+    "retry": "Retry"
   },
   "settings": {
     "title": "Settings",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -2755,7 +2755,19 @@
     "rsiThreshold": "RSI 임계값",
     "active": "활성",
     "inactive": "비활성",
-    "signals": "신호"
+    "signals": "신호",
+    "manualInput": "직접 입력",
+    "savedTemplates": "저장된 규칙",
+    "noTemplates": "저장된 규칙 템플릿이 없습니다",
+    "linkTemplate": "연결",
+    "alreadyLinked": "연결됨",
+    "templateInactive": "비활성",
+    "linkedCount": "{count}개 연결",
+    "invalidValue": "유효한 양수를 입력하세요",
+    "addRuleFailed": "규칙 추가에 실패했습니다",
+    "linkFailed": "템플릿 연결에 실패했습니다",
+    "loadFailed": "템플릿을 불러오지 못했습니다",
+    "retry": "다시 시도"
   },
   "settings": {
     "title": "설정",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -2755,7 +2755,19 @@
     "rsiThreshold": "RSI阈值",
     "active": "启用",
     "inactive": "停用",
-    "signals": "信号"
+    "signals": "信号",
+    "manualInput": "手动输入",
+    "savedTemplates": "已保存规则",
+    "noTemplates": "暂无已保存的规则模板",
+    "linkTemplate": "关联",
+    "alreadyLinked": "已关联",
+    "templateInactive": "未启用",
+    "linkedCount": "{count}个关联",
+    "invalidValue": "请输入有效的正数",
+    "addRuleFailed": "添加规则失败",
+    "linkFailed": "关联模板失败",
+    "loadFailed": "加载模板失败",
+    "retry": "重试"
   },
   "settings": {
     "title": "设置",

--- a/web/src/components/watchlist/BuyRuleModal.tsx
+++ b/web/src/components/watchlist/BuyRuleModal.tsx
@@ -2,10 +2,19 @@
 
 import { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
-import { Plus, Trash2, X } from 'lucide-react';
+import { Link2, Plus, Trash2, X } from 'lucide-react';
 import { Button } from '@/components/ui';
-import { getBuyRules, createBuyRule, updateBuyRule, deleteBuyRule } from '@/lib/api';
-import type { WatchlistItem, BuyRule, BuyRuleCreate } from '@/lib/types';
+import {
+  getBuyRules,
+  createBuyRule,
+  updateBuyRule,
+  deleteBuyRule,
+  getBuyRuleTemplates,
+  createRuleFromTemplate,
+} from '@/lib/api';
+import type { WatchlistItem, BuyRule, BuyRuleCreate, BuyRuleTemplate } from '@/lib/types';
+
+type Tab = 'manual' | 'templates';
 
 interface BuyRuleModalProps {
   item: WatchlistItem;
@@ -17,6 +26,14 @@ export default function BuyRuleModal({ item, onClose, onUpdate }: BuyRuleModalPr
   const t = useTranslations('watchlist');
   const [rules, setRules] = useState<BuyRule[]>([]);
   const [loading, setLoading] = useState(true);
+  const [activeTab, setActiveTab] = useState<Tab>('manual');
+
+  // Templates
+  const [templates, setTemplates] = useState<BuyRuleTemplate[]>([]);
+  const [templatesLoading, setTemplatesLoading] = useState(false);
+  const [templatesError, setTemplatesError] = useState(false);
+  const [linkingId, setLinkingId] = useState<number | null>(null);
+  const [linkError, setLinkError] = useState<string | null>(null);
 
   // New rule form
   const [newRuleType, setNewRuleType] = useState<'target_price' | 'rsi_oversold'>('target_price');
@@ -34,15 +51,39 @@ export default function BuyRuleModal({ item, onClose, onUpdate }: BuyRuleModalPr
     }
   };
 
+  const fetchTemplates = async () => {
+    setTemplatesLoading(true);
+    setTemplatesError(false);
+    try {
+      const data = await getBuyRuleTemplates();
+      setTemplates(data);
+    } catch {
+      setTemplatesError(true);
+    } finally {
+      setTemplatesLoading(false);
+    }
+  };
+
   useEffect(() => {
     fetchRules();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [item.id]);
 
+  useEffect(() => {
+    if (activeTab === 'templates' && templates.length === 0 && !templatesLoading && !templatesError) {
+      fetchTemplates();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeTab]);
+
+  const linkedTemplateIds = new Set(
+    rules.filter((r) => r.template_id != null).map((r) => r.template_id as number)
+  );
+
   const handleAdd = async () => {
     const val = parseFloat(newRuleValue);
     if (isNaN(val) || val <= 0) {
-      setAddError('Enter a valid positive number');
+      setAddError(t('invalidValue'));
       return;
     }
 
@@ -58,7 +99,21 @@ export default function BuyRuleModal({ item, onClose, onUpdate }: BuyRuleModalPr
       fetchRules();
       onUpdate();
     } catch (err) {
-      setAddError(err instanceof Error ? err.message : 'Failed to add rule');
+      setAddError(err instanceof Error ? err.message : t('addRuleFailed'));
+    }
+  };
+
+  const handleLinkTemplate = async (templateId: number) => {
+    setLinkingId(templateId);
+    setLinkError(null);
+    try {
+      await createRuleFromTemplate(item.id, templateId);
+      await fetchRules();
+      onUpdate();
+    } catch (err) {
+      setLinkError(err instanceof Error ? err.message : t('linkFailed'));
+    } finally {
+      setLinkingId(null);
     }
   };
 
@@ -101,6 +156,18 @@ export default function BuyRuleModal({ item, onClose, onUpdate }: BuyRuleModalPr
     }
     if (rule.rule_type === 'rsi_oversold') {
       const rsi = rule.params?.rsi;
+      return rsi != null ? `RSI ≤ ${rsi}` : '--';
+    }
+    return '--';
+  };
+
+  const formatTemplateValue = (tmpl: BuyRuleTemplate) => {
+    if (tmpl.rule_type === 'target_price') {
+      const price = tmpl.params?.price;
+      return price != null ? `${Number(price).toLocaleString()}` : '--';
+    }
+    if (tmpl.rule_type === 'rsi_oversold') {
+      const rsi = tmpl.params?.rsi;
       return rsi != null ? `RSI ≤ ${rsi}` : '--';
     }
     return '--';
@@ -156,6 +223,9 @@ export default function BuyRuleModal({ item, onClose, onUpdate }: BuyRuleModalPr
                     <span className="text-sm font-mono text-[var(--foreground)]">
                       {formatRuleValue(rule)}
                     </span>
+                    {rule.template_id != null && (
+                      <Link2 className="h-3 w-3 text-[var(--foreground-muted)]" />
+                    )}
                   </div>
                   <div className="flex items-center gap-2">
                     <button
@@ -183,40 +253,156 @@ export default function BuyRuleModal({ item, onClose, onUpdate }: BuyRuleModalPr
           )}
         </div>
 
-        {/* Add Rule Form */}
-        <div className="border-t border-[var(--border)] px-6 py-4">
-          <p className="text-sm font-medium text-[var(--foreground)] mb-2">{t('addBuyRule')}</p>
-          <div className="flex items-end gap-2">
-            <div className="flex-1">
-              <label className="block text-xs text-[var(--foreground-muted)] mb-1">{t('ruleType')}</label>
-              <select
-                value={newRuleType}
-                onChange={(e) => setNewRuleType(e.target.value as 'target_price' | 'rsi_oversold')}
-                className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)]"
-              >
-                <option value="target_price">{t('targetPriceRule')}</option>
-                <option value="rsi_oversold">{t('rsiOversoldRule')}</option>
-              </select>
+        {/* Tab bar */}
+        <div className="flex border-t border-b border-[var(--border)]">
+          <button
+            type="button"
+            onClick={() => setActiveTab('manual')}
+            className={`flex-1 px-4 py-2.5 text-sm font-medium transition-colors ${
+              activeTab === 'manual'
+                ? 'text-[var(--color-primary)] border-b-2 border-[var(--color-primary)]'
+                : 'text-[var(--foreground-muted)] hover:text-[var(--foreground)]'
+            }`}
+          >
+            {t('manualInput')}
+          </button>
+          <button
+            type="button"
+            onClick={() => setActiveTab('templates')}
+            className={`flex-1 px-4 py-2.5 text-sm font-medium transition-colors ${
+              activeTab === 'templates'
+                ? 'text-[var(--color-primary)] border-b-2 border-[var(--color-primary)]'
+                : 'text-[var(--foreground-muted)] hover:text-[var(--foreground)]'
+            }`}
+          >
+            {t('savedTemplates')}
+          </button>
+        </div>
+
+        {/* Tab content */}
+        <div className="px-6 py-4">
+          {activeTab === 'manual' ? (
+            /* Manual Input */
+            <div>
+              <p className="text-sm font-medium text-[var(--foreground)] mb-2">{t('addBuyRule')}</p>
+              <div className="flex items-end gap-2">
+                <div className="flex-1">
+                  <label className="block text-xs text-[var(--foreground-muted)] mb-1">{t('ruleType')}</label>
+                  <select
+                    value={newRuleType}
+                    onChange={(e) => setNewRuleType(e.target.value as 'target_price' | 'rsi_oversold')}
+                    className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)]"
+                  >
+                    <option value="target_price">{t('targetPriceRule')}</option>
+                    <option value="rsi_oversold">{t('rsiOversoldRule')}</option>
+                  </select>
+                </div>
+                <div className="flex-1">
+                  <label className="block text-xs text-[var(--foreground-muted)] mb-1">
+                    {newRuleType === 'target_price' ? t('price') : t('rsiThreshold')}
+                  </label>
+                  <input
+                    type="number"
+                    value={newRuleValue}
+                    onChange={(e) => setNewRuleValue(e.target.value)}
+                    placeholder={newRuleType === 'target_price' ? '50000' : '30'}
+                    className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)]"
+                    step="any"
+                    min="0"
+                  />
+                </div>
+                <Button size="sm" onClick={handleAdd}>
+                  <Plus className="h-4 w-4" />
+                </Button>
+              </div>
+              {addError && <p className="mt-1 text-xs text-red-500">{addError}</p>}
             </div>
-            <div className="flex-1">
-              <label className="block text-xs text-[var(--foreground-muted)] mb-1">
-                {newRuleType === 'target_price' ? t('price') : t('rsiThreshold')}
-              </label>
-              <input
-                type="number"
-                value={newRuleValue}
-                onChange={(e) => setNewRuleValue(e.target.value)}
-                placeholder={newRuleType === 'target_price' ? '50000' : '30'}
-                className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)]"
-                step="any"
-                min="0"
-              />
+          ) : (
+            /* Templates Tab */
+            <div>
+              {templatesLoading ? (
+                <div className="space-y-2 animate-pulse">
+                  <div className="h-10 rounded bg-[var(--border)]" />
+                  <div className="h-10 rounded bg-[var(--border)]" />
+                </div>
+              ) : templatesError ? (
+                <div className="flex flex-col items-center gap-2 py-4">
+                  <p className="text-sm text-red-500">{t('loadFailed')}</p>
+                  <button
+                    type="button"
+                    onClick={fetchTemplates}
+                    className="text-xs text-[var(--color-primary)] hover:underline"
+                  >
+                    {t('retry') ?? 'Retry'}
+                  </button>
+                </div>
+              ) : templates.length === 0 ? (
+                <p className="text-center text-sm text-[var(--foreground-muted)] py-4">
+                  {t('noTemplates')}
+                </p>
+              ) : (
+                <div className="space-y-2">
+                  {templates.map((tmpl) => {
+                    const isLinked = linkedTemplateIds.has(tmpl.id);
+                    const isInactive = !tmpl.is_active;
+                    const isLinking = linkingId === tmpl.id;
+                    const disabled = isLinked || isInactive || isLinking;
+
+                    return (
+                      <div
+                        key={tmpl.id}
+                        className={`flex items-center justify-between rounded-lg border border-[var(--border)] px-3 py-2 ${
+                          disabled ? 'opacity-60' : ''
+                        }`}
+                      >
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-center gap-2">
+                            <span className={`shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${ruleTypeColor(tmpl.rule_type)}`}>
+                              {ruleTypeLabel(tmpl.rule_type)}
+                            </span>
+                            <span className="text-sm font-medium text-[var(--foreground)] truncate">
+                              {tmpl.name}
+                            </span>
+                          </div>
+                          <div className="flex items-center gap-2 mt-0.5">
+                            <span className="text-xs font-mono text-[var(--foreground-muted)]">
+                              {formatTemplateValue(tmpl)}
+                            </span>
+                            {tmpl.description && (
+                              <span className="text-xs text-[var(--foreground-muted)] truncate">
+                                · {tmpl.description}
+                              </span>
+                            )}
+                          </div>
+                        </div>
+                        <div className="shrink-0 ml-2">
+                          {isLinked ? (
+                            <span className="rounded-full bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-500 dark:bg-gray-800 dark:text-gray-500">
+                              {t('alreadyLinked')}
+                            </span>
+                          ) : isInactive ? (
+                            <span className="rounded-full bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-500 dark:bg-gray-800 dark:text-gray-500">
+                              {t('templateInactive')}
+                            </span>
+                          ) : (
+                            <Button
+                              size="sm"
+                              onClick={() => handleLinkTemplate(tmpl.id)}
+                              disabled={isLinking}
+                            >
+                              <Link2 className="h-3.5 w-3.5 mr-1" />
+                              {t('linkTemplate')}
+                            </Button>
+                          )}
+                        </div>
+                      </div>
+                    );
+                  })}
+                  {linkError && <p className="mt-1 text-xs text-red-500">{linkError}</p>}
+                </div>
+              )}
             </div>
-            <Button size="sm" onClick={handleAdd}>
-              <Plus className="h-4 w-4" />
-            </Button>
-          </div>
-          {addError && <p className="mt-1 text-xs text-red-500">{addError}</p>}
+          )}
         </div>
       </div>
     </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -40,6 +40,7 @@ import type {
   BuyRule,
   BuyRuleCreate,
   BuyRuleUpdate,
+  BuyRuleTemplate,
   BuySignal,
 } from './types';
 
@@ -898,6 +899,18 @@ export async function updateBuyRule(ruleId: number, data: BuyRuleUpdate): Promis
 export async function deleteBuyRule(ruleId: number): Promise<void> {
   return fetchApi<void>(`/api/watchlist/buy-rules/${ruleId}`, {
     method: 'DELETE',
+  });
+}
+
+// Buy Rule Template API
+export async function getBuyRuleTemplates(): Promise<BuyRuleTemplate[]> {
+  return fetchApi<BuyRuleTemplate[]>('/api/watchlist/buy-rule-templates');
+}
+
+export async function createRuleFromTemplate(itemId: number, templateId: number): Promise<BuyRule> {
+  return fetchApi<BuyRule>(`/api/watchlist/items/${itemId}/buy-rules/from-template`, {
+    method: 'POST',
+    body: JSON.stringify({ template_id: templateId }),
   });
 }
 

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -465,11 +465,24 @@ export type BuyRuleType = 'target_price' | 'rsi_oversold';
 export interface BuyRule {
   id: number;
   watchlist_item_id: number;
+  template_id: number | null;
   rule_type: BuyRuleType;
   params: Record<string, unknown>;
   state_json: Record<string, unknown> | null;
   is_active: boolean;
   triggered_at: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+export interface BuyRuleTemplate {
+  id: number;
+  name: string;
+  rule_type: BuyRuleType;
+  params: Record<string, unknown>;
+  description: string | null;
+  is_active: boolean;
+  linked_rules_count: number;
   created_at: string | null;
   updated_at: string | null;
 }


### PR DESCRIPTION
## Summary
- Add tab-based UI to BuyRuleModal: "Manual Input" (existing) and "Saved Templates" (new)
- Template tab shows list with type badge, params preview, and "Link" button
- Already-linked templates show "Linked" badge, inactive templates show "Inactive" badge
- Link icon on rules list indicates template-linked rules
- Error handling: load failure with retry, link failure, all messages i18n-ized

## Changes
| File | Description |
|------|-------------|
| `web/src/components/watchlist/BuyRuleModal.tsx` | Tab UI, template list, link handler, error states |
| `web/src/lib/types.ts` | `BuyRuleTemplate` interface, `template_id` on `BuyRule` |
| `web/src/lib/api.ts` | `getBuyRuleTemplates()`, `createRuleFromTemplate()` |
| `web/messages/{en,ko,zh}.json` | 12 new i18n keys each |

## Parent issue
Part of #1027 (Buy Rule Templates epic). Completes the epic.

Closes #1031

## Test plan
- [x] TypeScript compilation passes (no errors in our files)
- [x] Codex code review: LGTM (2 rounds)
- [ ] Manual: Open BuyRuleModal → verify "Manual Input" tab works as before
- [ ] Manual: Switch to "Saved Templates" tab → verify template list loads
- [ ] Manual: Click "Link" → verify rule created + template shows "Linked"
- [ ] Manual: Verify ko/zh locales display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)