### PR TITLE
feat(portfolio): sell rule CRUD + evaluate API endpoints

### DIFF
--- a/api/routers/portfolio.py
+++ b/api/routers/portfolio.py
@@ -24,6 +24,10 @@ from api.schemas.portfolio import (
     PortfolioResponse,
     SellSignal,
     SellSignalsResponse,
+    SellRuleCreate,
+    SellRuleUpdate,
+    SellRuleResponse,
+    SellRuleEvaluateResponse,
     SellRecordCreate,
     TradeResponse,
     TradeHistoryResponse,
@@ -569,6 +573,82 @@ async def get_sell_signals(
             status_code=500,
             detail=f"Failed to get sell signals: {str(e)}"
         )
+
+
+# ── Sell Rules CRUD + Evaluate ──────────────────────────────────────
+
+
+@router.get(
+    "/holdings/{ticker}/sell-rules",
+    response_model=List[SellRuleResponse],
+    summary="List Sell Rules",
+    description="Get all sell rules for a holding.",
+)
+async def list_sell_rules(ticker: str) -> List[SellRuleResponse]:
+    service = get_portfolio_service()
+    return service.get_sell_rules(ticker)
+
+
+@router.post(
+    "/holdings/{ticker}/sell-rules",
+    response_model=SellRuleResponse,
+    status_code=201,
+    summary="Create Sell Rule",
+    description="Add a sell rule to a holding.",
+)
+async def create_sell_rule(ticker: str, data: SellRuleCreate) -> SellRuleResponse:
+    service = get_portfolio_service()
+    try:
+        return service.create_sell_rule(ticker, data)
+    except ValueError as e:
+        msg = str(e)
+        status = 404 if "not found" in msg.lower() else 400
+        raise HTTPException(status_code=status, detail=msg)
+
+
+@router.put(
+    "/sell-rules/{rule_id}",
+    response_model=SellRuleResponse,
+    summary="Update Sell Rule",
+    description="Update a sell rule's params or active status.",
+)
+async def update_sell_rule(rule_id: int, data: SellRuleUpdate) -> SellRuleResponse:
+    service = get_portfolio_service()
+    try:
+        return service.update_sell_rule(rule_id, data)
+    except ValueError as e:
+        msg = str(e)
+        status = 404 if "not found" in msg.lower() else 400
+        raise HTTPException(status_code=status, detail=msg)
+
+
+@router.delete(
+    "/sell-rules/{rule_id}",
+    status_code=204,
+    summary="Delete Sell Rule",
+    description="Remove a sell rule.",
+)
+async def delete_sell_rule(rule_id: int) -> None:
+    service = get_portfolio_service()
+    if not service.delete_sell_rule(rule_id):
+        raise HTTPException(status_code=404, detail=f"Sell rule not found: {rule_id}")
+
+
+@router.post(
+    "/sell-rules/evaluate",
+    response_model=SellRuleEvaluateResponse,
+    summary="Evaluate Sell Rules",
+    description="Evaluate all active sell rules against current market data.",
+)
+async def evaluate_sell_rules(
+    ticker: Optional[str] = Query(default=None, description="Evaluate rules for this ticker only"),
+) -> SellRuleEvaluateResponse:
+    service = get_portfolio_service()
+    try:
+        return service.evaluate_sell_rules(ticker=ticker)
+    except Exception as e:
+        logger.error(f"Failed to evaluate sell rules: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to evaluate sell rules: {str(e)}")
 
 
 # ── Realtime websocket ─────────────────────────────────────────────

--- a/api/services/portfolio_service.py
+++ b/api/services/portfolio_service.py
@@ -24,10 +24,14 @@ from api.schemas.portfolio import (
     PortfolioSummary,
     SellSignal,
     SellRecordCreate,
+    SellRuleCreate,
+    SellRuleUpdate,
+    SellRuleResponse,
     SellRuleEvaluateResult,
     SellRuleEvaluateResponse,
     TradeResponse,
     TradeHistoryResponse,
+    _validate_sell_rule_params,
 )
 from portfolio.conditions import (
     TradingContext,
@@ -1249,6 +1253,109 @@ class PortfolioService:
                 signals.append(signal)
 
         return signals
+
+    # ── Sell-rule CRUD ───────────────────────────────────────────────
+
+    def get_sell_rules(self, ticker: str) -> List[SellRuleResponse]:
+        """Get all sell rules for a holding."""
+        db = SessionLocal()
+        try:
+            rules = (
+                db.query(SellRule)
+                .filter(SellRule.ticker == ticker)
+                .order_by(SellRule.created_at)
+                .all()
+            )
+            return [
+                SellRuleResponse(
+                    id=r.id, ticker=r.ticker, rule_type=r.rule_type,
+                    params=r.params, state_json=r.state_json, is_active=r.is_active,
+                    triggered_at=r.triggered_at, created_at=r.created_at,
+                    updated_at=r.updated_at,
+                )
+                for r in rules
+            ]
+        finally:
+            db.close()
+
+    def create_sell_rule(self, ticker: str, data: SellRuleCreate) -> SellRuleResponse:
+        """Create a sell rule for a holding. Raises ValueError if holding not found."""
+        db = SessionLocal()
+        try:
+            holding = db.query(Holding).filter(Holding.ticker == ticker).first()
+            if holding is None:
+                raise ValueError(f"Holding not found: {ticker}")
+
+            rule = SellRule(
+                ticker=ticker,
+                rule_type=data.rule_type,
+                params=data.params,
+                is_active=data.is_active,
+            )
+            db.add(rule)
+            db.commit()
+            db.refresh(rule)
+            return SellRuleResponse(
+                id=rule.id, ticker=rule.ticker, rule_type=rule.rule_type,
+                params=rule.params, state_json=rule.state_json, is_active=rule.is_active,
+                triggered_at=rule.triggered_at, created_at=rule.created_at,
+                updated_at=rule.updated_at,
+            )
+        except ValueError:
+            db.rollback()
+            raise
+        except Exception:
+            db.rollback()
+            raise
+        finally:
+            db.close()
+
+    def update_sell_rule(self, rule_id: int, data: SellRuleUpdate) -> SellRuleResponse:
+        """Update a sell rule. Raises ValueError if not found or invalid params."""
+        db = SessionLocal()
+        try:
+            rule = db.query(SellRule).filter(SellRule.id == rule_id).first()
+            if rule is None:
+                raise ValueError(f"Sell rule not found: {rule_id}")
+
+            if data.params is not None:
+                _validate_sell_rule_params(rule.rule_type, data.params)
+                rule.params = data.params
+            if data.is_active is not None:
+                rule.is_active = data.is_active
+
+            db.commit()
+            db.refresh(rule)
+            return SellRuleResponse(
+                id=rule.id, ticker=rule.ticker, rule_type=rule.rule_type,
+                params=rule.params, state_json=rule.state_json, is_active=rule.is_active,
+                triggered_at=rule.triggered_at, created_at=rule.created_at,
+                updated_at=rule.updated_at,
+            )
+        except ValueError:
+            db.rollback()
+            raise
+        except Exception:
+            db.rollback()
+            raise
+        finally:
+            db.close()
+
+    def delete_sell_rule(self, rule_id: int) -> bool:
+        """Delete a sell rule. Returns True if deleted, False if not found."""
+        db = SessionLocal()
+        try:
+            rule = db.query(SellRule).filter(SellRule.id == rule_id).first()
+            if rule is None:
+                return False
+            db.delete(rule)
+            db.commit()
+            return True
+        except Exception:
+            db.rollback()
+            raise
+        finally:
+            db.close()
 
     # ── Sell-rule evaluation engine ────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Add sell rule CRUD service methods: `get_sell_rules`, `create_sell_rule`, `update_sell_rule`, `delete_sell_rule`
- Add 5 API endpoints: list, create, update, delete, evaluate
- Update-time params validation via `_validate_sell_rule_params`
- Proper error mapping: ValueError → 404 (not found) or 400 (validation)

## Test plan
- [ ] `POST /api/portfolio/holdings/AAPL/sell-rules` with valid stop_loss params → 201
- [ ] `POST /api/portfolio/holdings/INVALID/sell-rules` → 404 (holding not found)
- [ ] `GET /api/portfolio/holdings/AAPL/sell-rules` → list of rules
- [ ] `PUT /api/portfolio/sell-rules/1` with invalid params → 400
- [ ] `DELETE /api/portfolio/sell-rules/999` → 404
- [ ] `POST /api/portfolio/sell-rules/evaluate` → evaluates active rules
- [ ] OpenAPI docs show all 5 endpoints

Closes #991

🤖 Generated with [Claude Code](https://claude.com/claude-code)