### PR TITLE
feat(portfolio): add sell rule management UI

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -408,7 +408,21 @@
     "preview": "Preview",
     "updateHolding": "Update Holding",
     "addPurchaseSubmit": "Add Purchase",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "sellRulesTitle": "Sell Rules",
+    "noSellRules": "No sell rules configured yet.",
+    "addSellRule": "Add Sell Rule",
+    "sellRuleType": "Rule Type",
+    "sellRulePercent": "Percentage (%)",
+    "sellRuleMaxDays": "Max Days",
+    "sellRuleInvalidValue": "Please enter a valid number.",
+    "sellRuleMaxDaysPositive": "Max days must be a positive integer.",
+    "sellRuleAddFailed": "Failed to add sell rule.",
+    "sellRuleActive": "Active",
+    "sellRuleInactive": "Inactive",
+    "sellRuleTriggered": "Triggered",
+    "sellRuleDays": "days",
+    "sellRuleHint": "Stop loss: negative %, Take profit / Trailing stop: positive %, Holding period: days"
   },
   "brokerOrderDesk": {
     "title": "Broker Order Desk",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -408,7 +408,21 @@
     "preview": "미리보기",
     "updateHolding": "수정 완료",
     "addPurchaseSubmit": "추가 매수",
-    "cancel": "취소"
+    "cancel": "취소",
+    "sellRulesTitle": "매도 규칙",
+    "noSellRules": "설정된 매도 규칙이 없습니다.",
+    "addSellRule": "매도 규칙 추가",
+    "sellRuleType": "규칙 유형",
+    "sellRulePercent": "비율 (%)",
+    "sellRuleMaxDays": "최대 보유일",
+    "sellRuleInvalidValue": "유효한 숫자를 입력해주세요.",
+    "sellRuleMaxDaysPositive": "최대 보유일은 양의 정수여야 합니다.",
+    "sellRuleAddFailed": "매도 규칙 추가에 실패했습니다.",
+    "sellRuleActive": "활성",
+    "sellRuleInactive": "비활성",
+    "sellRuleTriggered": "발동됨",
+    "sellRuleDays": "일",
+    "sellRuleHint": "손절: 음수 %, 익절 / 추적 손절: 양수 %, 보유 기간: 일수"
   },
   "brokerOrderDesk": {
     "title": "통합 주문 데스크",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -408,7 +408,21 @@
     "preview": "预览",
     "updateHolding": "更新持仓",
     "addPurchaseSubmit": "追加买入",
-    "cancel": "取消"
+    "cancel": "取消",
+    "sellRulesTitle": "卖出规则",
+    "noSellRules": "尚未配置卖出规则。",
+    "addSellRule": "添加卖出规则",
+    "sellRuleType": "规则类型",
+    "sellRulePercent": "百分比 (%)",
+    "sellRuleMaxDays": "最大天数",
+    "sellRuleInvalidValue": "请输入有效数字。",
+    "sellRuleMaxDaysPositive": "最大天数必须为正整数。",
+    "sellRuleAddFailed": "添加卖出规则失败。",
+    "sellRuleActive": "活跃",
+    "sellRuleInactive": "未激活",
+    "sellRuleTriggered": "已触发",
+    "sellRuleDays": "天",
+    "sellRuleHint": "止损: 负百分比, 止盈/追踪止损: 正百分比, 持仓期限: 天数"
   },
   "brokerOrderDesk": {
     "title": "统一下单台",

--- a/web/src/app/[locale]/portfolio/page.tsx
+++ b/web/src/app/[locale]/portfolio/page.tsx
@@ -14,6 +14,7 @@ import {
   OrderDesk,
   BrokerOrderDesk,
   SellModal,
+  SellRuleModal,
   TradeHistory,
   AllocationCharts,
 } from '@/components/portfolio';
@@ -124,6 +125,9 @@ export default function PortfolioPage() {
 
   // Sell modal state
   const [sellTarget, setSellTarget] = useState<Holding | null>(null);
+
+  // Sell rules modal state
+  const [sellRulesTarget, setSellRulesTarget] = useState<Holding | null>(null);
 
   // Trade history section state
   const [isTradeHistoryOpen, setIsTradeHistoryOpen] = useState(false);
@@ -552,6 +556,10 @@ export default function PortfolioPage() {
     setSellTarget(holding);
   }, []);
 
+  const handleSellRulesClick = useCallback((holding: Holding) => {
+    setSellRulesTarget(holding);
+  }, []);
+
   const handleAnalyzeClick = useCallback((holding: Holding) => {
     const width = 900;
     const height = 700;
@@ -820,6 +828,7 @@ export default function PortfolioPage() {
           onEdit={handleEditClick}
           onDelete={handleDeleteClick}
           onSell={handleSellClick}
+          onSellRules={handleSellRulesClick}
           priceChangeDirection={priceChangeDirection}
         />
       </Card>
@@ -907,6 +916,15 @@ export default function PortfolioPage() {
         onClose={() => setSellTarget(null)}
         onSellComplete={() => fetchData(false)}
       />
+
+      {/* Sell Rules Modal */}
+      {sellRulesTarget && (
+        <SellRuleModal
+          holding={sellRulesTarget}
+          onClose={() => setSellRulesTarget(null)}
+          onUpdate={() => fetchData(false)}
+        />
+      )}
 
     </div>
   );

--- a/web/src/components/portfolio/HoldingsTable.tsx
+++ b/web/src/components/portfolio/HoldingsTable.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useMemo, useCallback } from 'react';
 import { useTranslations, useLocale } from 'next-intl';
-import { ArrowUpDown, Edit2, Trash2, TrendingUp, TrendingDown, BarChart3, Banknote } from 'lucide-react';
+import { ArrowUpDown, Edit2, Trash2, TrendingUp, TrendingDown, BarChart3, Banknote, Shield } from 'lucide-react';
 import type { Holding } from '@/lib/types';
 import { formatCurrency as formatCurrencyUtil, formatQuantity as formatQuantityUtil, formatPercent as formatPercentUtil } from '@/lib/format';
 import { classifyMarket, normalizeSector, MARKET_COLORS, SECTOR_COLORS } from './AllocationCharts';
@@ -25,6 +25,8 @@ interface HoldingsTableProps {
   onAnalyze?: (holding: Holding) => void;
   /** Callback when sell button is clicked */
   onSell?: (holding: Holding) => void;
+  /** Callback when sell rules button is clicked */
+  onSellRules?: (holding: Holding) => void;
   /** Per-ticker current price change direction for transient highlight */
   priceChangeDirection?: Record<string, 'up' | 'down'>;
 }
@@ -104,6 +106,7 @@ export default function HoldingsTable({
   onDelete,
   onAnalyze,
   onSell,
+  onSellRules,
   priceChangeDirection,
 }: HoldingsTableProps) {
   const t = useTranslations('portfolio');
@@ -337,6 +340,17 @@ export default function HoldingsTable({
                         <BarChart3 className="h-4 w-4" />
                       </button>
                     )}
+                    {onSellRules && (
+                      <button
+                        type="button"
+                        onClick={() => onSellRules(holding)}
+                        className="rounded p-1.5 text-[var(--foreground-muted)] hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/30 dark:hover:text-red-400 transition-colors"
+                        aria-label={`${t('sellRulesTitle')} ${holding.ticker}`}
+                        title={t('sellRulesTitle')}
+                      >
+                        <Shield className="h-4 w-4" />
+                      </button>
+                    )}
                     {onSell && (
                       <button
                         type="button"
@@ -376,6 +390,7 @@ export default function HoldingsTable({
             onDelete={onDelete}
             onAnalyze={onAnalyze}
             onSell={onSell}
+            onSellRules={onSellRules}
             priceChangeDirection={priceChangeDirection}
           />
         ))}
@@ -391,13 +406,14 @@ interface MobileCardProps {
   onDelete?: (holding: Holding) => void;
   onAnalyze?: (holding: Holding) => void;
   onSell?: (holding: Holding) => void;
+  onSellRules?: (holding: Holding) => void;
   priceChangeDirection?: Record<string, 'up' | 'down'>;
 }
 
 /**
  * Mobile card component for responsive display
  */
-function MobileCard({ holding, onRowClick, onEdit, onDelete, onAnalyze, onSell, priceChangeDirection }: MobileCardProps) {
+function MobileCard({ holding, onRowClick, onEdit, onDelete, onAnalyze, onSell, onSellRules, priceChangeDirection }: MobileCardProps) {
   const t = useTranslations('portfolio');
   const locale = useLocale();
   const formatCurrency = (value: number | null, currency?: string) => formatCurrencyUtil(value, currency, locale);
@@ -434,6 +450,17 @@ function MobileCard({ holding, onRowClick, onEdit, onDelete, onAnalyze, onSell, 
               aria-label={`Edit ${holding.ticker}`}
             >
               <Edit2 className="h-4 w-4" />
+            </button>
+          )}
+          {onSellRules && (
+            <button
+              type="button"
+              onClick={() => onSellRules(holding)}
+              className="rounded p-1.5 text-[var(--foreground-muted)] hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/30 dark:hover:text-red-400 transition-colors"
+              aria-label={`${t('sellRulesTitle')} ${holding.ticker}`}
+              title={t('sellRulesTitle')}
+            >
+              <Shield className="h-4 w-4" />
             </button>
           )}
           {onSell && (

--- a/web/src/components/portfolio/SellRuleModal.tsx
+++ b/web/src/components/portfolio/SellRuleModal.tsx
@@ -1,0 +1,296 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Plus, Trash2, X, Shield } from 'lucide-react';
+import { Button } from '@/components/ui';
+import {
+  getSellRules,
+  createSellRule,
+  updateSellRule,
+  deleteSellRule,
+} from '@/lib/api';
+import type { Holding, SellRule, SellRuleCreate, SellRuleType } from '@/lib/types';
+
+interface SellRuleModalProps {
+  holding: Holding;
+  onClose: () => void;
+  onUpdate: () => void;
+}
+
+const RULE_TYPES: SellRuleType[] = ['stop_loss', 'take_profit', 'trailing_stop', 'holding_period'];
+
+export default function SellRuleModal({ holding, onClose, onUpdate }: SellRuleModalProps) {
+  const t = useTranslations('portfolio');
+  const [rules, setRules] = useState<SellRule[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  // New rule form
+  const [newRuleType, setNewRuleType] = useState<SellRuleType>('stop_loss');
+  const [newRuleValue, setNewRuleValue] = useState('');
+  const [addError, setAddError] = useState<string | null>(null);
+  const [isMutating, setIsMutating] = useState(false);
+
+  const fetchRules = async () => {
+    try {
+      const data = await getSellRules(holding.ticker);
+      setRules(data);
+    } catch {
+      // Fail silently
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchRules();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [holding.ticker]);
+
+  const paramLabel = (type: SellRuleType): string => {
+    if (type === 'holding_period') return t('sellRuleMaxDays');
+    return t('sellRulePercent');
+  };
+
+  const paramPlaceholder = (type: SellRuleType): string => {
+    switch (type) {
+      case 'stop_loss': return '-10';
+      case 'take_profit': return '20';
+      case 'trailing_stop': return '8';
+      case 'holding_period': return '90';
+    }
+  };
+
+  const buildParams = (type: SellRuleType, value: number): Record<string, unknown> => {
+    if (type === 'holding_period') return { max_days: Math.round(value) };
+    if (type === 'stop_loss') return { pct: value > 0 ? -value : value };
+    return { pct: Math.abs(value) };
+  };
+
+  const validateValue = (type: SellRuleType, value: number): string | null => {
+    if (!Number.isFinite(value) || value === 0) return t('sellRuleInvalidValue');
+    if (type === 'holding_period' && (value < 1 || !Number.isInteger(value))) {
+      return t('sellRuleMaxDaysPositive');
+    }
+    return null;
+  };
+
+  const handleAdd = async () => {
+    const val = parseFloat(newRuleValue);
+    const error = validateValue(newRuleType, val);
+    if (error) {
+      setAddError(error);
+      return;
+    }
+
+    setAddError(null);
+    setIsMutating(true);
+    const data: SellRuleCreate = {
+      rule_type: newRuleType,
+      params: buildParams(newRuleType, val),
+    };
+
+    try {
+      await createSellRule(holding.ticker, data);
+      setNewRuleValue('');
+      await fetchRules();
+      onUpdate();
+    } catch (err) {
+      setAddError(err instanceof Error ? err.message : t('sellRuleAddFailed'));
+    } finally {
+      setIsMutating(false);
+    }
+  };
+
+  const handleToggle = async (rule: SellRule) => {
+    setIsMutating(true);
+    try {
+      await updateSellRule(rule.id, { is_active: !rule.is_active });
+      await fetchRules();
+      onUpdate();
+    } catch {
+      // Fail silently
+    } finally {
+      setIsMutating(false);
+    }
+  };
+
+  const handleDelete = async (ruleId: number) => {
+    setIsMutating(true);
+    try {
+      await deleteSellRule(ruleId);
+      await fetchRules();
+      onUpdate();
+    } catch {
+      // Fail silently
+    } finally {
+      setIsMutating(false);
+    }
+  };
+
+  const ruleTypeLabel = (type: string) => {
+    const labels: Record<string, string> = {
+      stop_loss: t('stopLoss'),
+      take_profit: t('takeProfit'),
+      trailing_stop: t('trailingStop'),
+      holding_period: t('holdingPeriod'),
+    };
+    return labels[type] || type;
+  };
+
+  const ruleTypeColor = (type: string) => {
+    const colors: Record<string, string> = {
+      stop_loss: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
+      take_profit: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+      trailing_stop: 'bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200',
+      holding_period: 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200',
+    };
+    return colors[type] || 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200';
+  };
+
+  const formatRuleValue = (rule: SellRule) => {
+    if (rule.rule_type === 'holding_period') {
+      const maxDays = rule.params?.max_days;
+      return maxDays != null ? `${maxDays} ${t('sellRuleDays')}` : '--';
+    }
+    const pct = rule.params?.pct;
+    return pct != null ? `${Number(pct) > 0 ? '+' : ''}${pct}%` : '--';
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={onClose}>
+      <div
+        className="mx-4 w-full max-w-lg rounded-xl bg-[var(--background-secondary)] shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-[var(--border)] px-6 py-4">
+          <div className="flex items-center gap-3">
+            <div className="rounded-lg bg-red-100 p-2 dark:bg-red-900/30">
+              <Shield className="h-5 w-5 text-red-600 dark:text-red-400" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold text-[var(--foreground)]">
+                {t('sellRulesTitle')} - {holding.ticker}
+              </h2>
+              {holding.name && (
+                <p className="text-sm text-[var(--foreground-muted)]">{holding.name}</p>
+              )}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md p-1 text-[var(--foreground-muted)] hover:bg-[var(--background)] transition-colors"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        {/* Rules List */}
+        <div className="max-h-64 overflow-y-auto px-6 py-4">
+          {loading ? (
+            <div className="space-y-2 animate-pulse">
+              <div className="h-10 rounded bg-[var(--border)]" />
+              <div className="h-10 rounded bg-[var(--border)]" />
+            </div>
+          ) : rules.length === 0 ? (
+            <p className="text-center text-sm text-[var(--foreground-muted)] py-4">
+              {t('noSellRules')}
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {rules.map((rule) => (
+                <div
+                  key={rule.id}
+                  className="flex items-center justify-between rounded-lg border border-[var(--border)] px-3 py-2"
+                >
+                  <div className="flex items-center gap-2">
+                    <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${ruleTypeColor(rule.rule_type)}`}>
+                      {ruleTypeLabel(rule.rule_type)}
+                    </span>
+                    <span className="text-sm font-mono text-[var(--foreground)]">
+                      {formatRuleValue(rule)}
+                    </span>
+                    {rule.triggered_at && (
+                      <span className="rounded-full bg-yellow-100 px-2 py-0.5 text-xs text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200">
+                        {t('sellRuleTriggered')}
+                      </span>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={() => handleToggle(rule)}
+                      disabled={isMutating}
+                      className={`rounded-full px-2 py-0.5 text-xs font-medium transition-colors disabled:opacity-50 ${
+                        rule.is_active
+                          ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+                          : 'bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-500'
+                      }`}
+                    >
+                      {rule.is_active ? t('sellRuleActive') : t('sellRuleInactive')}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(rule.id)}
+                      disabled={isMutating}
+                      className="rounded-md p-1 text-[var(--foreground-muted)] hover:bg-red-100 hover:text-red-600 dark:hover:bg-red-900/30 dark:hover:text-red-400 transition-colors disabled:opacity-50"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Add Rule Form */}
+        <div className="border-t border-[var(--border)] px-6 py-4">
+          <p className="text-sm font-medium text-[var(--foreground)] mb-2">{t('addSellRule')}</p>
+          <div className="flex items-end gap-2">
+            <div className="flex-1">
+              <label className="block text-xs text-[var(--foreground-muted)] mb-1">{t('sellRuleType')}</label>
+              <select
+                value={newRuleType}
+                onChange={(e) => {
+                  setNewRuleType(e.target.value as SellRuleType);
+                  setNewRuleValue('');
+                  setAddError(null);
+                }}
+                className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)]"
+              >
+                {RULE_TYPES.map((type) => (
+                  <option key={type} value={type}>
+                    {ruleTypeLabel(type)}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="flex-1">
+              <label className="block text-xs text-[var(--foreground-muted)] mb-1">
+                {paramLabel(newRuleType)}
+              </label>
+              <input
+                type="number"
+                value={newRuleValue}
+                onChange={(e) => setNewRuleValue(e.target.value)}
+                placeholder={paramPlaceholder(newRuleType)}
+                className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)]"
+                step="any"
+              />
+            </div>
+            <Button size="sm" onClick={handleAdd} disabled={isMutating}>
+              <Plus className="h-4 w-4" />
+            </Button>
+          </div>
+          {addError && <p className="mt-1 text-xs text-red-500">{addError}</p>}
+          <p className="mt-2 text-xs text-[var(--foreground-muted)]">
+            {t('sellRuleHint')}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/portfolio/index.ts
+++ b/web/src/components/portfolio/index.ts
@@ -9,3 +9,4 @@ export { default as BrokerOrderDesk } from './BrokerOrderDesk';
 export { default as SellModal } from './SellModal';
 export { default as TradeHistory } from './TradeHistory';
 export { default as AllocationCharts } from './AllocationCharts';
+export { default as SellRuleModal } from './SellRuleModal';

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -42,6 +42,10 @@ import type {
   BuyRuleUpdate,
   BuyRuleTemplate,
   BuySignal,
+  SellRule,
+  SellRuleCreate,
+  SellRuleUpdate,
+  SellRuleEvaluateResult,
 } from './types';
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
@@ -329,6 +333,39 @@ export async function recordSell(data: SellRecordCreate): Promise<Trade> {
 export async function getTradeHistory(ticker?: string): Promise<TradeHistoryResponse> {
   const params = ticker ? `?ticker=${encodeURIComponent(ticker)}` : '';
   return fetchApi<TradeHistoryResponse>(`/api/portfolio/trades${params}`);
+}
+
+// Sell Rule API functions
+
+export async function getSellRules(ticker: string): Promise<SellRule[]> {
+  return fetchApi<SellRule[]>(`/api/portfolio/holdings/${encodeURIComponent(ticker)}/sell-rules`);
+}
+
+export async function createSellRule(ticker: string, data: SellRuleCreate): Promise<SellRule> {
+  return fetchApi<SellRule>(`/api/portfolio/holdings/${encodeURIComponent(ticker)}/sell-rules`, {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+}
+
+export async function updateSellRule(ruleId: number, data: SellRuleUpdate): Promise<SellRule> {
+  return fetchApi<SellRule>(`/api/portfolio/sell-rules/${ruleId}`, {
+    method: 'PUT',
+    body: JSON.stringify(data),
+  });
+}
+
+export async function deleteSellRule(ruleId: number): Promise<void> {
+  return fetchApi<void>(`/api/portfolio/sell-rules/${ruleId}`, {
+    method: 'DELETE',
+  });
+}
+
+export async function evaluateSellRules(ticker?: string): Promise<{ results: SellRuleEvaluateResult[]; checked_at: string }> {
+  const params = ticker ? `?ticker=${encodeURIComponent(ticker)}` : '';
+  return fetchApi<{ results: SellRuleEvaluateResult[]; checked_at: string }>(`/api/portfolio/sell-rules/evaluate${params}`, {
+    method: 'POST',
+  });
 }
 
 /**

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -429,6 +429,42 @@ export interface SellRecordCreate {
   note?: string;
 }
 
+// Sell rule types
+export type SellRuleType = 'stop_loss' | 'take_profit' | 'trailing_stop' | 'holding_period';
+
+export interface SellRule {
+  id: number;
+  ticker: string;
+  rule_type: SellRuleType;
+  params: Record<string, unknown>;
+  state_json: Record<string, unknown> | null;
+  is_active: boolean;
+  triggered_at: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+export interface SellRuleCreate {
+  rule_type: SellRuleType;
+  params: Record<string, unknown>;
+  is_active?: boolean;
+}
+
+export interface SellRuleUpdate {
+  params?: Record<string, unknown>;
+  is_active?: boolean;
+}
+
+export interface SellRuleEvaluateResult {
+  rule_id: number;
+  ticker: string;
+  rule_type: string;
+  triggered: boolean;
+  reason: string | null;
+  current_price: number | null;
+  trigger_value: number | null;
+}
+
 // Watchlist types
 export interface WatchlistItem {
   id: number;


### PR DESCRIPTION
## Summary
- Add `SellRuleModal` component for per-holding sell rule CRUD (stop loss, take profit, trailing stop, holding period)
- Add sell rule TypeScript types and 5 API client functions matching backend endpoints
- Integrate Shield icon button in `HoldingsTable` actions (desktop + mobile)
- Wire modal into portfolio page with state management
- Add i18n keys in en/ko/zh (15 keys each)

## Test plan
- [ ] Navigate to Portfolio page, verify Shield icon appears in holdings table action column
- [ ] Click Shield icon on any holding, verify SellRuleModal opens with correct ticker
- [ ] Add a stop loss rule (e.g. -10%), verify it appears in the list
- [ ] Toggle rule active/inactive, verify status changes
- [ ] Delete a rule, verify it's removed from the list
- [ ] Add take profit (+20%), trailing stop (8%), holding period (90 days) rules
- [ ] Verify mobile responsiveness (Shield button in mobile card)
- [ ] Test i18n: switch to ko/zh locale, verify all sell rule labels are translated
- [ ] Verify no console errors during all interactions

Closes #994

🤖 Generated with [Claude Code](https://claude.com/claude-code)