### PR TITLE
feat(watchlist): ticker click opens stock analysis popup

### DIFF
--- a/web/src/app/[locale]/watchlist/page.tsx
+++ b/web/src/app/[locale]/watchlist/page.tsx
@@ -20,6 +20,18 @@ export default function WatchlistPage() {
   const t = useTranslations('watchlist');
   const tCommon = useTranslations('common');
   const locale = useLocale();
+
+  const openPopup = useCallback((ticker: string) => {
+    const width = 900;
+    const height = 700;
+    const left = (screen.width - width) / 2;
+    const top = (screen.height - height) / 2;
+    window.open(
+      `/${locale}/analysis/${encodeURIComponent(ticker)}?popup=true`,
+      `analysis_${ticker}`,
+      `width=${width},height=${height},left=${left},top=${top},scrollbars=yes,resizable=yes`
+    );
+  }, [locale]);
   const [items, setItems] = useState<WatchlistItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -226,7 +238,13 @@ export default function WatchlistPage() {
                   return (
                     <tr key={item.id} className="hover:bg-[var(--background)] transition-colors">
                       <td className="px-4 py-3">
-                        <span className="font-semibold text-[var(--foreground)]">{item.ticker}</span>
+                        <button
+                          type="button"
+                          onClick={(e) => { e.stopPropagation(); openPopup(item.ticker); }}
+                          className="font-semibold text-[#1313ec] dark:text-blue-400 hover:underline cursor-pointer"
+                        >
+                          {item.ticker}
+                        </button>
                       </td>
                       <td className="px-4 py-3 text-[var(--foreground-muted)]">
                         {item.name || '--'}


### PR DESCRIPTION
## Summary
- Watchlist 테이블에서 종목코드(ticker) 클릭 시 분석 팝업(퀵뷰) 열림
- Portfolio, Strategy 페이지와 동일한 `window.open` → `/{locale}/analysis/{ticker}?popup=true` 패턴 사용
- `<button>` 태그 사용으로 키보드 접근성(Enter/Space) 자동 지원
- `e.stopPropagation()`으로 행 클릭 이벤트 충돌 방지

## Test plan
- [ ] `/watchlist`에서 종목코드 클릭 → 분석 팝업 열림
- [ ] 팝업 닫기/재오픈 안정적 동작
- [ ] 편집/삭제/규칙 아이콘 클릭과 충돌 없음
- [ ] 키보드(Tab → Enter)로 팝업 열기 가능

Closes #1035

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*Written by: Codex*