### PR TITLE
fix: handle sell-rule ticker aliases to prevent 404

### DIFF
--- a/api/services/portfolio_service.py
+++ b/api/services/portfolio_service.py
@@ -12,7 +12,7 @@ import math
 import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, date
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, Set
 
 from api.database import SessionLocal
 from api.models.portfolio import Holding, SellRule, Trade
@@ -1283,13 +1283,44 @@ class PortfolioService:
 
     # ── Sell-rule CRUD ───────────────────────────────────────────────
 
+    @staticmethod
+    def _ticker_aliases(ticker: str) -> List[str]:
+        """Build candidate ticker aliases for legacy/non-suffixed rows."""
+        normalized = (ticker or "").strip().upper()
+        if not normalized:
+            return []
+
+        aliases: Set[str] = {normalized}
+        if normalized.endswith(".KS") or normalized.endswith(".KQ"):
+            aliases.add(normalized.split(".")[0])
+        elif "." not in normalized:
+            aliases.add(f"{normalized}.KS")
+            aliases.add(f"{normalized}.KQ")
+        return list(aliases)
+
+    def _resolve_holding_ticker(self, db, ticker: str) -> Optional[str]:
+        """Resolve input ticker to an existing Holding.ticker value."""
+        aliases = self._ticker_aliases(ticker)
+        if not aliases:
+            return None
+
+        holding = db.query(Holding).filter(Holding.ticker == ticker).first()
+        if holding is not None:
+            return holding.ticker
+
+        holding = db.query(Holding).filter(Holding.ticker.in_(aliases)).first()
+        return holding.ticker if holding is not None else None
+
     def get_sell_rules(self, ticker: str) -> List[SellRuleResponse]:
         """Get all sell rules for a holding."""
         db = SessionLocal()
         try:
+            aliases = self._ticker_aliases(ticker)
+            if not aliases:
+                return []
             rules = (
                 db.query(SellRule)
-                .filter(SellRule.ticker == ticker)
+                .filter(SellRule.ticker.in_(aliases))
                 .order_by(SellRule.created_at)
                 .all()
             )
@@ -1309,12 +1340,12 @@ class PortfolioService:
         """Create a sell rule for a holding. Raises ValueError if holding not found."""
         db = SessionLocal()
         try:
-            holding = db.query(Holding).filter(Holding.ticker == ticker).first()
-            if holding is None:
+            resolved_ticker = self._resolve_holding_ticker(db, ticker)
+            if resolved_ticker is None:
                 raise ValueError(f"Holding not found: {ticker}")
 
             rule = SellRule(
-                ticker=ticker,
+                ticker=resolved_ticker,
                 rule_type=data.rule_type,
                 params=data.params,
                 is_active=data.is_active,
@@ -1418,7 +1449,10 @@ class PortfolioService:
                 SellRule.triggered_at.is_(None),
             )
             if ticker:
-                q = q.filter(SellRule.ticker == ticker)
+                aliases = self._ticker_aliases(ticker)
+                if not aliases:
+                    return SellRuleEvaluateResponse(results=[])
+                q = q.filter(SellRule.ticker.in_(aliases))
             rules: List[SellRule] = q.all()
 
             if not rules:

--- a/tests/test_sell_rules.py
+++ b/tests/test_sell_rules.py
@@ -303,6 +303,31 @@ class TestSellRuleCRUD:
         with pytest.raises(ValueError, match="Holding not found"):
             service.create_sell_rule("NONEXISTENT", data)
 
+    def test_create_with_market_suffix_alias(self, service, db_session):
+        """Legacy holdings without suffix should accept .KS/.KQ ticker input."""
+        h = Holding(
+            ticker="021240",
+            name="코웨이",
+            quantity=10,
+            avg_price=50000,
+            currency="KRW",
+            bought_at=date(2025, 1, 15),
+        )
+        db_session.add(h)
+        db_session.commit()
+
+        created = service.create_sell_rule(
+            "021240.KS",
+            SellRuleCreate(rule_type="stop_loss", params={"pct": -10}),
+        )
+        assert created.ticker == "021240"
+
+        by_alias = service.get_sell_rules("021240.KS")
+        by_raw = service.get_sell_rules("021240")
+        assert len(by_alias) == 1
+        assert len(by_raw) == 1
+        assert by_alias[0].id == by_raw[0].id
+
     def test_create_multiple_rules(self, service, holding, db_session):
         service.create_sell_rule(holding.ticker, SellRuleCreate(
             rule_type="stop_loss", params={"pct": -10},


### PR DESCRIPTION
## Summary
- add ticker alias resolution for sell-rule CRUD/evaluation (`021240` ↔ `021240.KS/.KQ`)
- make sell-rule creation bind to canonical holding ticker when alias input is used
- add regression test for legacy non-suffixed holding + suffixed API input

## Why
Sell-rule create endpoint returned `404 Holding not found` when UI passed market-suffixed ticker but DB held legacy non-suffixed ticker.

## Test plan
- [x] `venv/bin/pytest tests/test_sell_rules.py -q`

Closes #1046