### PR TITLE
chore(dev): add Agentation visual feedback tool

### DIFF
--- a/docs/dev/AGENTATION_SETUP.md
+++ b/docs/dev/AGENTATION_SETUP.md
@@ -1,0 +1,104 @@
+# Agentation Setup Guide
+
+Visual feedback tool for AI agents. Click elements on the page to capture CSS selectors, React component hierarchy, and position info — then pass structured output to coding agents.
+
+- **GitHub**: https://github.com/benjitaylor/agentation
+- **Docs**: https://agentation.dev/faq
+- **npm**: https://www.npmjs.com/package/agentation
+
+## Requirements
+
+- React 18+
+- Desktop browser (mobile not supported)
+- Node.js (for MCP server)
+
+## Setup (3 steps)
+
+### 1. Install package
+
+```bash
+cd web
+npm install agentation -D
+```
+
+### 2. Add React component
+
+Create `web/src/components/dev/AgentationProvider.tsx`:
+
+```tsx
+'use client';
+
+import dynamic from 'next/dynamic';
+
+const AgentationLazy = dynamic(
+  () => import('agentation').then((m) => ({ default: m.Agentation })),
+  { ssr: false },
+);
+
+export default function AgentationProvider() {
+  if (process.env.NODE_ENV !== 'development') return null;
+  return <AgentationLazy />;
+}
+```
+
+Add to layout (`web/src/app/[locale]/layout.tsx`):
+
+```tsx
+import AgentationProvider from '@/components/dev/AgentationProvider';
+
+// Inside the layout JSX, after MainLayout:
+<MainLayout>{children}</MainLayout>
+<AgentationProvider />
+```
+
+> **Note**: Must be a Client Component with `dynamic({ ssr: false })` because Next.js Server Components don't support `next/dynamic` with `ssr: false`.
+
+### 3. Register MCP server (Claude Code)
+
+**Global** (recommended — works in all projects):
+
+```bash
+claude mcp add --scope user agentation -- npx agentation-mcp server
+```
+
+**Per-project** (alternative):
+
+```bash
+cd <project-root>
+npx agentation-mcp init
+```
+
+## Usage
+
+1. Run dev server: `cd web && npm run dev`
+2. Open browser — Agentation toolbar appears at bottom-right
+3. Click the toolbar to activate, then click any element
+4. Copy the structured output (CSS selector + component path + notes)
+5. Paste to AI agent prompt
+
+### Output Modes
+
+| Mode | Detail Level | Use Case |
+|------|-------------|----------|
+| Compact | Selector + memo | Quick fixes |
+| Standard | + bounding box | General use |
+| Detailed | + full context | Layout work |
+| Forensic | + computed styles | CSS debugging |
+
+### Agent Sync (MCP)
+
+Enable "Agent Sync" in the toolbar settings to stream annotations directly to Claude Code via MCP in real-time.
+
+## Production Safety
+
+- `AgentationProvider` checks `process.env.NODE_ENV !== 'development'` — returns `null` in production
+- `agentation` is installed as `devDependency` — not included in production bundle
+- No runtime overhead in production builds
+
+## Troubleshooting
+
+| Issue | Fix |
+|-------|-----|
+| Toolbar not visible | Check dev server is running (`npm run dev`, not `npm run build`) |
+| MCP not connecting | Run `claude mcp list` to verify registration |
+| SSR error | Ensure `AgentationProvider` is a Client Component (`'use client'`) with `ssr: false` |

--- a/docs/dev/ko/AGENTATION_SETUP.md
+++ b/docs/dev/ko/AGENTATION_SETUP.md
@@ -1,0 +1,104 @@
+# Agentation 설정 가이드
+
+AI 에이전트를 위한 시각 피드백 도구. 페이지에서 요소를 클릭하면 CSS 셀렉터, React 컴포넌트 계층, 위치 정보를 캡처하여 구조화된 출력을 코딩 에이전트에게 전달한다.
+
+- **GitHub**: https://github.com/benjitaylor/agentation
+- **문서**: https://agentation.dev/faq
+- **npm**: https://www.npmjs.com/package/agentation
+
+## 요구사항
+
+- React 18+
+- 데스크톱 브라우저 (모바일 미지원)
+- Node.js (MCP 서버용)
+
+## 설정 (3단계)
+
+### 1. 패키지 설치
+
+```bash
+cd web
+npm install agentation -D
+```
+
+### 2. React 컴포넌트 추가
+
+`web/src/components/dev/AgentationProvider.tsx` 생성:
+
+```tsx
+'use client';
+
+import dynamic from 'next/dynamic';
+
+const AgentationLazy = dynamic(
+  () => import('agentation').then((m) => ({ default: m.Agentation })),
+  { ssr: false },
+);
+
+export default function AgentationProvider() {
+  if (process.env.NODE_ENV !== 'development') return null;
+  return <AgentationLazy />;
+}
+```
+
+레이아웃에 추가 (`web/src/app/[locale]/layout.tsx`):
+
+```tsx
+import AgentationProvider from '@/components/dev/AgentationProvider';
+
+// 레이아웃 JSX 내부, MainLayout 다음에:
+<MainLayout>{children}</MainLayout>
+<AgentationProvider />
+```
+
+> **참고**: Next.js Server Component에서는 `next/dynamic`의 `ssr: false`를 사용할 수 없으므로 반드시 별도 Client Component로 분리해야 한다.
+
+### 3. MCP 서버 등록 (Claude Code)
+
+**글로벌** (권장 — 모든 프로젝트에서 사용 가능):
+
+```bash
+claude mcp add --scope user agentation -- npx agentation-mcp server
+```
+
+**프로젝트별** (대안):
+
+```bash
+cd <프로젝트 루트>
+npx agentation-mcp init
+```
+
+## 사용법
+
+1. 개발 서버 실행: `cd web && npm run dev`
+2. 브라우저 열기 — 우측 하단에 Agentation 툴바 표시
+3. 툴바 클릭하여 활성화 → 원하는 요소 클릭
+4. 구조화된 출력 복사 (CSS 셀렉터 + 컴포넌트 경로 + 메모)
+5. AI 에이전트 프롬프트에 붙여넣기
+
+### 출력 모드
+
+| 모드 | 상세 수준 | 용도 |
+|------|----------|------|
+| Compact | 셀렉터 + 메모 | 빠른 수정 |
+| Standard | + 바운딩 박스 | 일반 용도 |
+| Detailed | + 전체 컨텍스트 | 레이아웃 작업 |
+| Forensic | + 계산된 스타일 | CSS 디버깅 |
+
+### Agent Sync (MCP)
+
+툴바 설정에서 "Agent Sync"를 활성화하면 어노테이션이 MCP를 통해 실시간으로 Claude Code에 전달된다.
+
+## 프로덕션 안전성
+
+- `AgentationProvider`는 `process.env.NODE_ENV !== 'development'` 체크 — 프로덕션에서 `null` 반환
+- `agentation`은 `devDependency`로 설치 — 프로덕션 번들에 포함 안 됨
+- 프로덕션 빌드에서 런타임 오버헤드 없음
+
+## 문제 해결
+
+| 문제 | 해결 |
+|------|------|
+| 툴바가 안 보임 | 개발 서버 실행 중인지 확인 (`npm run dev`, `npm run build` 아님) |
+| MCP 연결 안 됨 | `claude mcp list`로 등록 확인 |
+| SSR 에러 | `AgentationProvider`가 Client Component (`'use client'`)이고 `ssr: false`인지 확인 |

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -27,6 +27,7 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "agentation": "^2.2.1",
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
         "tailwindcss": "^4",
@@ -2982,6 +2983,25 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agentation": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/agentation/-/agentation-2.2.1.tgz",
+      "integrity": "sha512-yV9P1DggI7M3SRaRwLwt+xqE5lXqg5l8xtqCr8KzEkbnH8Wa6eRATU97uKnD7cC8FrsJP62Mmw0Xf5Xi5KV50Q==",
+      "dev": true,
+      "license": "PolyForm-Shield-1.0.0",
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/ajv": {

--- a/web/package.json
+++ b/web/package.json
@@ -34,6 +34,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "agentation": "^2.2.1",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
     "tailwindcss": "^4",

--- a/web/src/app/[locale]/layout.tsx
+++ b/web/src/app/[locale]/layout.tsx
@@ -8,6 +8,7 @@ import '../globals.css';
 import MainLayout from '@/components/layout/MainLayout';
 import QueryProvider from '@/providers/QueryProvider';
 import { UserSettingsProvider } from '@/contexts/UserSettingsContext';
+import AgentationProvider from '@/components/dev/AgentationProvider';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -52,6 +53,7 @@ export default async function LocaleLayout({ children, params }: Props) {
           <QueryProvider>
             <UserSettingsProvider>
               <MainLayout>{children}</MainLayout>
+              <AgentationProvider />
             </UserSettingsProvider>
           </QueryProvider>
         </NextIntlClientProvider>

--- a/web/src/components/dev/AgentationProvider.tsx
+++ b/web/src/components/dev/AgentationProvider.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+
+const AgentationLazy = dynamic(
+  () => import('agentation').then((m) => ({ default: m.Agentation })),
+  { ssr: false },
+);
+
+export default function AgentationProvider() {
+  if (process.env.NODE_ENV !== 'development') return null;
+  return <AgentationLazy />;
+}


### PR DESCRIPTION
## Summary
- Install `agentation` as devDependency for visual UI feedback to AI agents
- Add `AgentationProvider` client component (dev mode only, tree-shaken in prod)
- Register MCP server globally for Claude Code integration
- Add setup guide docs (EN + KO)

## Changes
| File | Description |
|------|-------------|
| `web/package.json` | Add `agentation` devDependency |
| `web/src/components/dev/AgentationProvider.tsx` | Client component with dynamic import, dev-only |
| `web/src/app/[locale]/layout.tsx` | Add `<AgentationProvider />` to layout |
| `docs/dev/AGENTATION_SETUP.md` | English setup guide |
| `docs/dev/ko/AGENTATION_SETUP.md` | Korean setup guide |

## Test plan
- [ ] `cd web && npm run build` passes (no prod impact)
- [ ] `npm run dev` shows Agentation toolbar at bottom-right
- [ ] Click element → CSS selector + component hierarchy captured
- [ ] Production build excludes agentation (NODE_ENV check + devDependency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)