### PR TITLE
feat(chatbot): add OpenAI fallback for strategy chat

### DIFF
--- a/api/routers/strategy.py
+++ b/api/routers/strategy.py
@@ -397,7 +397,7 @@ async def strategy_chat(request: StrategyChatRequest):
     if not service.is_available():
         raise HTTPException(
             status_code=503,
-            detail="Strategy chat not available. Set ANTHROPIC_API_KEY.",
+            detail="Strategy chat not available. Set ANTHROPIC_API_KEY or OPENAI_API_KEY.",
         )
 
     def event_stream():

--- a/api/services/strategy_chat_service.py
+++ b/api/services/strategy_chat_service.py
@@ -1,7 +1,8 @@
 """
 Strategy Chat Service.
 
-Provides streaming chat with Claude for strategy building assistance.
+Provides streaming chat for strategy building assistance.
+Supports Anthropic (preferred) and OpenAI (fallback) providers.
 """
 
 import json
@@ -79,19 +80,38 @@ def _get_system_prompt() -> str:
     return _cached_system_prompt
 
 
-class StrategyChatService:
-    """Streaming chat service using Anthropic API."""
+def _build_system_with_graph(graph: Optional[dict[str, Any]] = None) -> str:
+    """Return system prompt, optionally appending the current graph context."""
+    system = _get_system_prompt()
+    if graph:
+        graph_json = json.dumps(graph, ensure_ascii=False, indent=2)
+        if len(graph_json) > _MAX_GRAPH_CHARS:
+            graph_json = graph_json[:_MAX_GRAPH_CHARS] + "\n... (truncated)"
+        system += f"\n\n## Current Strategy Graph\n```json\n{graph_json}\n```"
+    return system
 
-    def __init__(self, api_key: str):
+
+class StrategyChatService:
+    """Streaming chat service with Anthropic/OpenAI provider selection."""
+
+    def __init__(self, provider: str, api_key: str):
+        self._provider = provider
         self._api_key = api_key
         self._client = None
 
     @property
+    def provider(self) -> str:
+        return self._provider
+
+    @property
     def client(self):
         if self._client is None:
-            import anthropic
-
-            self._client = anthropic.Anthropic(api_key=self._api_key)
+            if self._provider == "anthropic":
+                import anthropic
+                self._client = anthropic.Anthropic(api_key=self._api_key)
+            else:
+                import openai
+                self._client = openai.OpenAI(api_key=self._api_key)
         return self._client
 
     def is_available(self) -> bool:
@@ -102,7 +122,7 @@ class StrategyChatService:
         messages: list[dict[str, str]],
         graph: Optional[dict[str, Any]] = None,
     ) -> Generator[str, None, None]:
-        """Stream chat response chunks from Claude.
+        """Stream chat response chunks.
 
         Args:
             messages: Conversation history [{"role": ..., "content": ...}]
@@ -110,42 +130,76 @@ class StrategyChatService:
 
         Yields:
             Text chunks as they arrive from the API.
-
-        Raises:
-            Exception: Re-raised after logging if the Anthropic API call fails.
         """
-        import anthropic
-
-        system = _get_system_prompt()
-        if graph:
-            graph_json = json.dumps(graph, ensure_ascii=False, indent=2)
-            if len(graph_json) > _MAX_GRAPH_CHARS:
-                graph_json = graph_json[:_MAX_GRAPH_CHARS] + "\n... (truncated)"
-            system += f"\n\n## Current Strategy Graph\n```json\n{graph_json}\n```"
-
         api_messages = [{"role": m["role"], "content": m["content"]} for m in messages]
 
         logger.info(
-            "Strategy chat: %d messages, graph=%s", len(api_messages), bool(graph)
+            "Strategy chat [%s]: %d messages, graph=%s",
+            self._provider, len(api_messages), bool(graph),
         )
+
+        if self._provider == "anthropic":
+            yield from self._stream_anthropic(api_messages, graph)
+        else:
+            yield from self._stream_openai(api_messages, graph)
+
+    def _stream_anthropic(
+        self,
+        messages: list[dict[str, str]],
+        graph: Optional[dict[str, Any]],
+    ) -> Generator[str, None, None]:
+        import anthropic
+
+        system = _build_system_with_graph(graph)
 
         try:
             with self.client.messages.stream(
                 model="claude-sonnet-4-20250514",
                 max_tokens=1024,
                 system=system,
-                messages=api_messages,
+                messages=messages,
             ) as stream:
                 for text in stream.text_stream:
                     yield text
         except anthropic.RateLimitError:
-            logger.warning("Strategy chat: rate limit hit")
+            logger.warning("Strategy chat: Anthropic rate limit hit")
             raise
         except anthropic.APIConnectionError:
-            logger.warning("Strategy chat: connection error")
+            logger.warning("Strategy chat: Anthropic connection error")
             raise
         except anthropic.APIStatusError as e:
-            logger.error("Strategy chat: API status error %s", e.status_code)
+            logger.error("Strategy chat: Anthropic API error %s", e.status_code)
+            raise
+
+    def _stream_openai(
+        self,
+        messages: list[dict[str, str]],
+        graph: Optional[dict[str, Any]],
+    ) -> Generator[str, None, None]:
+        import openai
+
+        system = _build_system_with_graph(graph)
+        oai_messages = [{"role": "system", "content": system}] + messages
+
+        try:
+            stream = self.client.chat.completions.create(
+                model="gpt-4o",
+                max_tokens=1024,
+                messages=oai_messages,
+                stream=True,
+            )
+            for chunk in stream:
+                delta = chunk.choices[0].delta if chunk.choices else None
+                if delta and delta.content:
+                    yield delta.content
+        except openai.RateLimitError:
+            logger.warning("Strategy chat: OpenAI rate limit hit")
+            raise
+        except openai.APIConnectionError:
+            logger.warning("Strategy chat: OpenAI connection error")
+            raise
+        except openai.APIStatusError as e:
+            logger.error("Strategy chat: OpenAI API error %s", e.status_code)
             raise
 
 
@@ -153,9 +207,22 @@ _instance: Optional[StrategyChatService] = None
 
 
 def get_strategy_chat_service() -> StrategyChatService:
-    """Return singleton StrategyChatService instance."""
+    """Return singleton StrategyChatService instance.
+
+    Provider priority: ANTHROPIC_API_KEY > OPENAI_API_KEY.
+    """
     global _instance
     if _instance is None:
-        api_key = os.environ.get("ANTHROPIC_API_KEY", "")
-        _instance = StrategyChatService(api_key=api_key)
+        anthropic_key = os.environ.get("ANTHROPIC_API_KEY", "")
+        openai_key = os.environ.get("OPENAI_API_KEY", "")
+
+        if anthropic_key:
+            _instance = StrategyChatService(provider="anthropic", api_key=anthropic_key)
+            logger.info("Strategy chat: using Anthropic provider")
+        elif openai_key:
+            _instance = StrategyChatService(provider="openai", api_key=openai_key)
+            logger.info("Strategy chat: using OpenAI provider")
+        else:
+            _instance = StrategyChatService(provider="none", api_key="")
+            logger.warning("Strategy chat: no API key configured")
     return _instance

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,3 +42,4 @@ tigeropen>=3.5.0
 
 # AI/LLM
 anthropic>=0.18.0
+openai>=1.0.0


### PR DESCRIPTION
## Summary
- Add OpenAI API as fallback provider when Anthropic credits are unavailable
- Provider priority: `ANTHROPIC_API_KEY` (preferred) > `OPENAI_API_KEY` (fallback)
- Extract `_build_system_with_graph()` helper to eliminate duplication
- Same system prompt and SSE streaming format for both providers

## Changes
- `api/services/strategy_chat_service.py`: Add provider-based architecture with `_stream_anthropic()` / `_stream_openai()` methods
- `api/routers/strategy.py`: Update error message to mention both API key options
- `requirements.txt`: Add `openai>=1.0.0`

## Test plan
- [ ] Set only `OPENAI_API_KEY` → chatbot responds via GPT-4o
- [ ] Set only `ANTHROPIC_API_KEY` → chatbot responds via Claude (existing behavior)
- [ ] Set both keys → chatbot uses Anthropic (priority)
- [ ] Set neither key → 503 error with message mentioning both options

Closes #1057

🤖 Generated with [Claude Code](https://claude.com/claude-code)