### PR TITLE
feat(strategy): categorized preset gallery in load dialog

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -684,6 +684,17 @@
     "builtInSample": "Built-in",
     "sampleStrategyLoaded": "Sample strategy loaded. Save it to copy into your own strategies.",
     "savedStrategies": "Saved Strategies",
+    "searchPresets": "Search presets...",
+    "presetCategories": {
+      "trend_following": "Trend Following",
+      "momentum": "Momentum",
+      "mean_reversion": "Mean Reversion",
+      "breakout": "Breakout",
+      "volume_flow": "Volume Flow",
+      "volatility": "Volatility",
+      "ichimoku": "Ichimoku",
+      "fundamental": "Fundamental"
+    },
     "loadSelected": "Load",
     "deleteConfirm": "Delete this strategy?",
     "unsavedChanges": "You have unsaved changes",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -684,6 +684,17 @@
     "builtInSample": "기본 제공",
     "sampleStrategyLoaded": "샘플 전략을 불러왔습니다. 저장하면 내 전략으로 복사됩니다.",
     "savedStrategies": "저장된 전략",
+    "searchPresets": "프리셋 검색...",
+    "presetCategories": {
+      "trend_following": "추세추종",
+      "momentum": "모멘텀",
+      "mean_reversion": "평균회귀",
+      "breakout": "돌파",
+      "volume_flow": "거래량 흐름",
+      "volatility": "변동성",
+      "ichimoku": "일목균형표",
+      "fundamental": "펀더멘탈"
+    },
     "loadSelected": "불러오기",
     "deleteConfirm": "이 전략을 삭제할까요?",
     "unsavedChanges": "저장되지 않은 변경 사항이 있습니다",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -684,6 +684,17 @@
     "builtInSample": "内置",
     "sampleStrategyLoaded": "已加载示例策略。保存后会复制到你的策略中。",
     "savedStrategies": "已保存策略",
+    "searchPresets": "搜索预设...",
+    "presetCategories": {
+      "trend_following": "趋势跟踪",
+      "momentum": "动量",
+      "mean_reversion": "均值回归",
+      "breakout": "突破",
+      "volume_flow": "量价分析",
+      "volatility": "波动率",
+      "ichimoku": "一目均衡表",
+      "fundamental": "基本面"
+    },
     "loadSelected": "加载",
     "deleteConfirm": "删除该策略？",
     "unsavedChanges": "您有未保存的更改",

--- a/web/src/app/[locale]/strategy/page.tsx
+++ b/web/src/app/[locale]/strategy/page.tsx
@@ -25,7 +25,7 @@ import '@xyflow/react/dist/style.css';
 
 import {
   Loader2, Zap, RotateCcw, Save, TestTube, FolderOpen, X,
-  ChevronRight, Home, Calendar,
+  ChevronRight, ChevronDown, Home, Calendar, Search,
 } from 'lucide-react';
 import UniverseNode from '@/components/strategy/nodes/UniverseNode';
 import ConditionNode from '@/components/strategy/nodes/ConditionNode';
@@ -43,7 +43,7 @@ import { Toast, useToast, type ToastType } from '@/components/ui/Toast';
 import type { StrategyNodeData } from '@/lib/strategy/graphSerializer';
 import { serializeGraph, getDownstreamNodeIds } from '@/lib/strategy/graphSerializer';
 import { validateGraph } from '@/lib/strategy/graphValidator';
-import { SAMPLE_STRATEGY_PRESETS, type SampleStrategyPreset } from '@/lib/strategy/sampleStrategies';
+import { SAMPLE_STRATEGY_PRESETS, PRESET_CATEGORY_ORDER, type SampleStrategyPreset, type PresetCategory } from '@/lib/strategy/sampleStrategies';
 import { ConditionsProvider, useConditions } from '@/contexts/ConditionsContext';
 import { useSavedStrategies, useSaveStrategy, useUpdateStrategy } from '@/hooks/useStrategy';
 import type { StrategyResultItem, SavedStrategy, NodeIntermediateResult } from '@/lib/api';
@@ -298,6 +298,8 @@ function StrategyPageInner() {
   // Save/Load state
   const [showSaveDialog, setShowSaveDialog] = useState(false);
   const [showLoadDialog, setShowLoadDialog] = useState(false);
+  const [presetSearch, setPresetSearch] = useState('');
+  const [collapsedCategories, setCollapsedCategories] = useState<Set<PresetCategory>>(new Set());
   const [strategyName, setStrategyName] = useState('');
   const [strategyDescription, setStrategyDescription] = useState('');
   const [currentStrategyId, setCurrentStrategyId] = useState<string | null>(null);
@@ -1461,42 +1463,96 @@ function StrategyPageInner() {
       )}
 
       {/* Load dialog */}
-      {showLoadDialog && (
+      {showLoadDialog && (() => {
+        const searchLower = presetSearch.toLowerCase();
+        const filteredPresets = presetSearch
+          ? SAMPLE_STRATEGY_PRESETS.filter((s) => {
+              const name = tScreening.has(`samplePresetNames.${s.key}`) ? tScreening(`samplePresetNames.${s.key}` as never) : s.name;
+              const desc = tScreening.has(`samplePresetDescriptions.${s.key}`) ? tScreening(`samplePresetDescriptions.${s.key}` as never) : s.description;
+              return name.toLowerCase().includes(searchLower) || desc.toLowerCase().includes(searchLower);
+            })
+          : SAMPLE_STRATEGY_PRESETS;
+        const grouped = PRESET_CATEGORY_ORDER.reduce<Record<PresetCategory, SampleStrategyPreset[]>>((acc, cat) => {
+          const items = filteredPresets.filter((p) => p.category === cat);
+          if (items.length > 0) acc[cat] = items;
+          return acc;
+        }, {} as Record<PresetCategory, SampleStrategyPreset[]>);
+        return (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
           <div className="bg-white dark:bg-[#1e1e1f] rounded-xl shadow-2xl border border-[#e1e3e5] dark:border-[#2e2e30] w-full max-w-lg mx-4">
             <div className="flex items-center justify-between px-5 py-3 border-b border-[#e1e3e5] dark:border-[#2e2e30]">
               <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
-                {t('savedStrategies')}
+                {t('loadStrategy')}
               </h3>
-              <button type="button" onClick={() => setShowLoadDialog(false)} className="text-gray-400 hover:text-gray-600">
+              <button type="button" onClick={() => { setShowLoadDialog(false); setPresetSearch(''); }} className="text-gray-400 hover:text-gray-600">
                 <X className="h-4 w-4" />
               </button>
             </div>
-            <div className="px-5 py-4 max-h-80 overflow-y-auto">
+            <div className="px-5 py-3 border-b border-[#e1e3e5] dark:border-[#2e2e30]">
+              <div className="relative">
+                <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-gray-400" />
+                <input
+                  type="text"
+                  value={presetSearch}
+                  onChange={(e) => setPresetSearch(e.target.value)}
+                  placeholder={t('searchPresets')}
+                  className="w-full pl-8 pr-3 py-1.5 text-sm rounded-lg border border-[#e1e3e5] dark:border-[#2e2e30] bg-gray-50 dark:bg-white/5 text-gray-900 dark:text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-[#1313ec]/40"
+                />
+              </div>
+            </div>
+            <div className="px-5 py-4 max-h-[60vh] overflow-y-auto">
               <div className="mb-4">
                 <h4 className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-2">
                   {t('sampleStrategies')}
                 </h4>
-                {SAMPLE_STRATEGY_PRESETS.map((sample) => (
-                  <button
-                    key={sample.key}
-                    type="button"
-                    onClick={() => handleLoadSampleStrategy(sample)}
-                    className="w-full text-left px-3 py-2.5 rounded-lg hover:bg-gray-50 dark:hover:bg-white/5 transition-colors mb-1"
-                  >
-                    <div className="flex items-center justify-between gap-2">
-                      <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
-                        {tScreening.has(`samplePresetNames.${sample.key}`) ? tScreening(`samplePresetNames.${sample.key}` as never) : sample.name}
-                      </span>
-                      <span className="text-[10px] px-1.5 py-0.5 rounded border border-[#1313ec]/30 text-[#1313ec] bg-[#1313ec]/5">
-                        {t('builtInSample')}
-                      </span>
+                {(Object.keys(grouped) as PresetCategory[]).map((cat) => {
+                  const items = grouped[cat];
+                  const isCollapsed = collapsedCategories.has(cat);
+                  return (
+                    <div key={cat} className="mb-2">
+                      <button
+                        type="button"
+                        onClick={() => setCollapsedCategories((prev) => {
+                          const next = new Set(prev);
+                          if (next.has(cat)) next.delete(cat); else next.add(cat);
+                          return next;
+                        })}
+                        className="flex items-center gap-1.5 w-full text-left px-2 py-1.5 rounded-md hover:bg-gray-50 dark:hover:bg-white/5 transition-colors"
+                      >
+                        {isCollapsed
+                          ? <ChevronRight className="h-3.5 w-3.5 text-gray-400 shrink-0" />
+                          : <ChevronDown className="h-3.5 w-3.5 text-gray-400 shrink-0" />}
+                        <span className="text-xs font-semibold text-gray-700 dark:text-gray-300">
+                          {t(`presetCategories.${cat}` as never)}
+                        </span>
+                        <span className="text-[10px] text-gray-400 ml-auto">{items.length}</span>
+                      </button>
+                      {!isCollapsed && items.map((sample) => (
+                        <button
+                          key={sample.key}
+                          type="button"
+                          onClick={() => handleLoadSampleStrategy(sample)}
+                          className="w-full text-left pl-7 pr-3 py-2 rounded-lg hover:bg-gray-50 dark:hover:bg-white/5 transition-colors mb-0.5"
+                        >
+                          <div className="flex items-center justify-between gap-2">
+                            <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                              {tScreening.has(`samplePresetNames.${sample.key}`) ? tScreening(`samplePresetNames.${sample.key}` as never) : sample.name}
+                            </span>
+                            <span className="text-[10px] px-1.5 py-0.5 rounded border border-[#1313ec]/30 text-[#1313ec] bg-[#1313ec]/5 shrink-0">
+                              {t('builtInSample')}
+                            </span>
+                          </div>
+                          <p className="text-xs text-gray-400 mt-0.5 truncate">
+                            {tScreening.has(`samplePresetDescriptions.${sample.key}`) ? tScreening(`samplePresetDescriptions.${sample.key}` as never) : sample.description}
+                          </p>
+                        </button>
+                      ))}
                     </div>
-                    <p className="text-xs text-gray-400 mt-0.5 truncate">
-                      {tScreening.has(`samplePresetDescriptions.${sample.key}`) ? tScreening(`samplePresetDescriptions.${sample.key}` as never) : sample.description}
-                    </p>
-                  </button>
-                ))}
+                  );
+                })}
+                {Object.keys(grouped).length === 0 && presetSearch && (
+                  <p className="text-sm text-gray-400 text-center py-4">{t('noSavedStrategies')}</p>
+                )}
               </div>
               <div className="h-px bg-[#e1e3e5] dark:bg-[#2e2e30] mb-3" />
               <h4 className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-2">
@@ -1531,7 +1587,8 @@ function StrategyPageInner() {
             </div>
           </div>
         </div>
-      )}
+        );
+      })()}
 
       {/* Side inspection panel (double-click a node) */}
       <SideInspectionPanel

--- a/web/src/lib/strategy/sampleStrategies.ts
+++ b/web/src/lib/strategy/sampleStrategies.ts
@@ -1,12 +1,34 @@
 import type { StrategyGraph } from './graphSerializer';
 
+export type PresetCategory =
+  | 'trend_following'
+  | 'momentum'
+  | 'mean_reversion'
+  | 'breakout'
+  | 'volume_flow'
+  | 'volatility'
+  | 'ichimoku'
+  | 'fundamental';
+
 export interface SampleStrategyPreset {
   key: string;
+  category: PresetCategory;
   name: string;
   description: string;
   reference?: string;
   graph: StrategyGraph;
 }
+
+export const PRESET_CATEGORY_ORDER: PresetCategory[] = [
+  'trend_following',
+  'momentum',
+  'mean_reversion',
+  'breakout',
+  'volume_flow',
+  'volatility',
+  'ichimoku',
+  'fundamental',
+];
 
 type ConditionSpec = {
   condition_type: string;
@@ -61,6 +83,7 @@ function buildLinearGraph(universe: string, conditions: ConditionSpec[]): Strate
 export const SAMPLE_STRATEGY_PRESETS: SampleStrategyPreset[] = [
   {
     key: 'trend_following_52w_breakout',
+    category: 'breakout',
     name: '52주 신고가 돌파 (추세추종)',
     description: '52주 고점 근접 + 거래량 급증 조합으로 돌파 추세를 추종합니다.',
     reference: 'Trend following / 52-week breakout',
@@ -71,6 +94,7 @@ export const SAMPLE_STRATEGY_PRESETS: SampleStrategyPreset[] = [
   },
   {
     key: 'dual_momentum_relative_strength',
+    category: 'momentum',
     name: '듀얼 모멘텀 (상대강도)',
     description: '시장 대비 상대 강도 + 12-1 모멘텀으로 강한 종목만 선별합니다.',
     reference: 'Dual momentum',
@@ -81,6 +105,7 @@ export const SAMPLE_STRATEGY_PRESETS: SampleStrategyPreset[] = [
   },
   {
     key: 'rsi_mean_reversion',
+    category: 'mean_reversion',
     name: 'RSI 과매도 평균회귀',
     description: '과매도 구간에서 거래량 확인을 추가해 반등 후보를 찾습니다.',
     reference: 'RSI mean reversion',
@@ -91,6 +116,7 @@ export const SAMPLE_STRATEGY_PRESETS: SampleStrategyPreset[] = [
   },
   {
     key: 'golden_cross_trend',
+    category: 'trend_following',
     name: '골든크로스 추세 전략',
     description: '50/200 이평선 골든크로스와 거래대금 필터를 결합합니다.',
     reference: 'Golden cross',
@@ -101,6 +127,7 @@ export const SAMPLE_STRATEGY_PRESETS: SampleStrategyPreset[] = [
   },
   {
     key: 'bollinger_squeeze_breakout',
+    category: 'volatility',
     name: '볼린저 스퀴즈 돌파',
     description: '변동성 압축 후 돌파 구간을 포착합니다.',
     reference: 'Bollinger squeeze breakout',
@@ -111,6 +138,7 @@ export const SAMPLE_STRATEGY_PRESETS: SampleStrategyPreset[] = [
   },
   {
     key: 'turtle_donchian_breakout',
+    category: 'breakout',
     name: '터틀 돈치안 돌파',
     description: '돈치안 채널 돌파에 ATR 기반 변동성 확인을 추가합니다.',
     reference: 'Turtle trading',
@@ -121,6 +149,7 @@ export const SAMPLE_STRATEGY_PRESETS: SampleStrategyPreset[] = [
   },
   {
     key: 'value_quality_combo',
+    category: 'fundamental',
     name: '밸류 + 퀄리티',
     description: '저평가(PE/PB)와 재무건전성(ROE/피오트로스키)을 결합합니다.',
     reference: 'Value + quality factors',
@@ -133,6 +162,7 @@ export const SAMPLE_STRATEGY_PRESETS: SampleStrategyPreset[] = [
   },
   {
     key: 'low_volatility_defensive',
+    category: 'fundamental',
     name: '로우볼(저변동성) 방어형',
     description: '낮은 변동성과 낮은 베타 조합으로 방어형 종목을 찾습니다.',
     reference: 'Low volatility anomaly',
@@ -143,6 +173,7 @@ export const SAMPLE_STRATEGY_PRESETS: SampleStrategyPreset[] = [
   },
   {
     key: 'post_earnings_drift',
+    category: 'fundamental',
     name: '실적 발표 후 드리프트',
     description: '실적 발표 후 모멘텀 지속 구간을 포착합니다.',
     reference: 'Post-earnings announcement drift',
@@ -153,6 +184,7 @@ export const SAMPLE_STRATEGY_PRESETS: SampleStrategyPreset[] = [
   },
   {
     key: 'short_term_breakout_liquidity',
+    category: 'breakout',
     name: '단기 돌파 + 유동성 필터',
     description: '신규 고점 돌파와 충분한 거래량/거래대금을 동시에 확인합니다.',
     reference: 'Breakout + liquidity filter',
@@ -164,6 +196,7 @@ export const SAMPLE_STRATEGY_PRESETS: SampleStrategyPreset[] = [
   },
   {
     key: 'ema_cross_momentum',
+    category: 'momentum',
     name: 'EMA 크로스 모멘텀',
     description: 'EMA 골든크로스와 상대거래량으로 추세 전환 초기를 포착합니다.',
     reference: 'EMA crossover momentum',
@@ -174,6 +207,7 @@ export const SAMPLE_STRATEGY_PRESETS: SampleStrategyPreset[] = [
   },
   {
     key: 'macd_cross_trend',
+    category: 'momentum',
     name: 'MACD 시그널 크로스',
     description: 'MACD 상향 교차 후 거래량이 동반되는 종목을 선별합니다.',
     reference: 'MACD signal crossover',
@@ -184,6 +218,7 @@ export const SAMPLE_STRATEGY_PRESETS: SampleStrategyPreset[] = [
   },
   {
     key: 'stochastic_oversold_rebound',
+    category: 'mean_reversion',
     name: '스토캐스틱 과매도 반등',
     description: '스토캐스틱 과매도 구간과 단기 가격 반전을 함께 확인합니다.',
     reference: 'Stochastic oversold rebound',
@@ -194,6 +229,7 @@ export const SAMPLE_STRATEGY_PRESETS: SampleStrategyPreset[] = [
   },
   {
     key: 'williams_reversal_setup',
+    category: 'mean_reversion',
     name: '윌리엄스 %R 리버설',
     description: '과매도 리버설 신호와 낮은 변동성 환경을 결합합니다.',
     reference: 'Williams %R reversal',
@@ -204,6 +240,7 @@ export const SAMPLE_STRATEGY_PRESETS: SampleStrategyPreset[] = [
   },
   {
     key: 'vwap_pullback_reentry',
+    category: 'volume_flow',
     name: 'VWAP 눌림 재진입',
     description: 'VWAP 근접 눌림 구간에서 재상승 가능성을 노립니다.',
     reference: 'VWAP pullback',
@@ -214,6 +251,7 @@ export const SAMPLE_STRATEGY_PRESETS: SampleStrategyPreset[] = [
   },
   {
     key: 'atr_volatility_compression_break',
+    category: 'volatility',
     name: 'ATR 변동성 수축 후 확장',
     description: '낮은 ATR 백분위 이후 확장 돌파를 탐색합니다.',
     reference: 'Volatility compression breakout',
@@ -224,6 +262,7 @@ export const SAMPLE_STRATEGY_PRESETS: SampleStrategyPreset[] = [
   },
   {
     key: 'bollinger_midband_reclaim',
+    category: 'mean_reversion',
     name: '볼린저 중단 회복',
     description: '볼린저 밴드 중심선 회복과 가격 탄력을 함께 확인합니다.',
     reference: 'Bollinger mid-band reclaim',
@@ -234,6 +273,7 @@ export const SAMPLE_STRATEGY_PRESETS: SampleStrategyPreset[] = [
   },
   {
     key: 'keltner_channel_expansion',
+    category: 'volatility',
     name: '켈트너 채널 돌파',
     description: '켈트너 채널 상단 돌파와 상대거래량을 결합한 추세 전략입니다.',
     reference: 'Keltner channel breakout',
@@ -244,6 +284,7 @@ export const SAMPLE_STRATEGY_PRESETS: SampleStrategyPreset[] = [
   },
   {
     key: 'ichimoku_cloud_breakout_trend',
+    category: 'ichimoku',
     name: '일목균형표 구름 돌파',
     description: '구름대 돌파 종목 중 추세 강도가 유지되는 종목을 찾습니다.',
     reference: 'Ichimoku cloud breakout',
@@ -254,6 +295,7 @@ export const SAMPLE_STRATEGY_PRESETS: SampleStrategyPreset[] = [
   },
   {
     key: 'tenkan_kijun_cross_continuation',
+    category: 'ichimoku',
     name: '전환선-기준선 크로스',
     description: '전환선 상향교차 후 가격이 이평선 위에 있는 종목을 선별합니다.',
     reference: 'Ichimoku tenkan-kijun cross',
@@ -264,6 +306,7 @@ export const SAMPLE_STRATEGY_PRESETS: SampleStrategyPreset[] = [
   },
   {
     key: 'ma_slope_trend_follow',
+    category: 'trend_following',
     name: '이평선 기울기 추세',
     description: '중장기 이평선 우상향과 거래대금 조건으로 추세 종목을 추립니다.',
     reference: 'Moving average slope trend following',
@@ -274,6 +317,7 @@ export const SAMPLE_STRATEGY_PRESETS: SampleStrategyPreset[] = [
   },
   {
     key: 'ma_cross_upswing',
+    category: 'trend_following',
     name: '단기/중기 이평 상향교차',
     description: '단기 이평이 중기 이평을 상향 돌파한 초기 구간을 노립니다.',
     reference: 'MA crossover upswing',
@@ -284,6 +328,7 @@ export const SAMPLE_STRATEGY_PRESETS: SampleStrategyPreset[] = [
   },
   {
     key: 'obv_accumulation_trend',
+    category: 'volume_flow',
     name: 'OBV 누적 매집 추세',
     description: 'OBV 상승 추세와 가격 지지 확인으로 매집 구간을 탐지합니다.',
     reference: 'OBV accumulation',
@@ -294,6 +339,7 @@ export const SAMPLE_STRATEGY_PRESETS: SampleStrategyPreset[] = [
   },
   {
     key: 'resistance_break_then_retest',
+    category: 'breakout',
     name: '저항 돌파 후 리테스트',
     description: '저항 돌파 이후 리테스트 성공 패턴을 필터링합니다.',
     reference: 'Breakout retest setup',
@@ -304,6 +350,7 @@ export const SAMPLE_STRATEGY_PRESETS: SampleStrategyPreset[] = [
   },
   {
     key: 'opening_range_breakout',
+    category: 'breakout',
     name: '시가 범위 돌파',
     description: '시가 범위 상단 돌파 종목 중 거래량이 동반된 케이스를 선별합니다.',
     reference: 'Opening range breakout',
@@ -314,6 +361,7 @@ export const SAMPLE_STRATEGY_PRESETS: SampleStrategyPreset[] = [
   },
   {
     key: 'pivot_breakout_followthrough',
+    category: 'breakout',
     name: '피벗 포인트 돌파',
     description: '피벗 상향 돌파 후 단기 추세 지속 가능성을 확인합니다.',
     reference: 'Pivot point breakout',
@@ -324,6 +372,7 @@ export const SAMPLE_STRATEGY_PRESETS: SampleStrategyPreset[] = [
   },
   {
     key: 'parabolic_sar_flip',
+    category: 'volatility',
     name: '파라볼릭 SAR 전환',
     description: 'SAR 상승 전환과 과도한 변동성 배제를 함께 적용합니다.',
     reference: 'Parabolic SAR reversal',
@@ -334,6 +383,7 @@ export const SAMPLE_STRATEGY_PRESETS: SampleStrategyPreset[] = [
   },
   {
     key: 'trix_signal_bullish',
+    category: 'momentum',
     name: 'TRIX 상승 신호',
     description: 'TRIX 상향 교차 이후 추세 지속 종목을 선별합니다.',
     reference: 'TRIX bullish crossover',
@@ -344,6 +394,7 @@ export const SAMPLE_STRATEGY_PRESETS: SampleStrategyPreset[] = [
   },
   {
     key: 'ppo_momentum_continuation',
+    category: 'momentum',
     name: 'PPO 모멘텀 지속',
     description: 'PPO 시그널 상향 교차와 상대강도 필터를 결합합니다.',
     reference: 'PPO momentum continuation',
@@ -354,6 +405,7 @@ export const SAMPLE_STRATEGY_PRESETS: SampleStrategyPreset[] = [
   },
   {
     key: 'stochrsi_reentry',
+    category: 'mean_reversion',
     name: 'StochRSI 재진입',
     description: 'StochRSI 과매도권 반등 구간을 빠르게 포착합니다.',
     reference: 'StochRSI reentry',
@@ -364,6 +416,7 @@ export const SAMPLE_STRATEGY_PRESETS: SampleStrategyPreset[] = [
   },
   {
     key: 'chaikin_money_flow_accumulation',
+    category: 'volume_flow',
     name: '차이킨 자금흐름 매집',
     description: '양(+)의 자금 유입과 가격 추세를 함께 확인합니다.',
     reference: 'Chaikin money flow',
@@ -374,6 +427,7 @@ export const SAMPLE_STRATEGY_PRESETS: SampleStrategyPreset[] = [
   },
   {
     key: 'chaikin_oscillator_break',
+    category: 'volume_flow',
     name: '차이킨 오실레이터 돌파',
     description: '차이킨 오실레이터 양전환과 거래량 급증을 결합합니다.',
     reference: 'Chaikin oscillator breakout',
@@ -384,6 +438,7 @@ export const SAMPLE_STRATEGY_PRESETS: SampleStrategyPreset[] = [
   },
   {
     key: 'adline_breadth_confirmation',
+    category: 'volume_flow',
     name: 'AD라인 확산 확인',
     description: '시장 확산 강도(AD라인)와 종목 추세를 함께 반영합니다.',
     reference: 'A/D line breadth confirmation',
@@ -394,6 +449,7 @@ export const SAMPLE_STRATEGY_PRESETS: SampleStrategyPreset[] = [
   },
   {
     key: 'quality_growth_compounder',
+    category: 'fundamental',
     name: '퀄리티 성장주',
     description: '높은 ROIC와 이익 성장률이 동반되는 종목을 찾습니다.',
     reference: 'Quality growth compounding',
@@ -405,6 +461,7 @@ export const SAMPLE_STRATEGY_PRESETS: SampleStrategyPreset[] = [
   },
   {
     key: 'free_cashflow_quality',
+    category: 'fundamental',
     name: '현금흐름 퀄리티',
     description: 'FCF 수익률과 현금흐름 기반 안정성을 중시하는 전략입니다.',
     reference: 'FCF quality factor',
@@ -416,6 +473,7 @@ export const SAMPLE_STRATEGY_PRESETS: SampleStrategyPreset[] = [
   },
   {
     key: 'shareholder_yield_value',
+    category: 'fundamental',
     name: '주주환원 밸류',
     description: '배당/자사주 환원률이 높고 과도한 밸류에이션이 아닌 종목을 선별합니다.',
     reference: 'Shareholder yield',
@@ -427,6 +485,7 @@ export const SAMPLE_STRATEGY_PRESETS: SampleStrategyPreset[] = [
   },
   {
     key: 'deep_value_reversion',
+    category: 'fundamental',
     name: '딥밸류 리버전',
     description: '저PBR/저PS 구간에서 회복 가능성이 높은 종목을 찾습니다.',
     reference: 'Deep value mean reversion',
@@ -438,6 +497,7 @@ export const SAMPLE_STRATEGY_PRESETS: SampleStrategyPreset[] = [
   },
   {
     key: 'profitability_value_screen',
+    category: 'fundamental',
     name: '수익성 + 밸류 스크린',
     description: '밸류와 수익성 지표를 동시에 만족하는 종목을 선별합니다.',
     reference: 'Profitability value blend',
@@ -449,6 +509,7 @@ export const SAMPLE_STRATEGY_PRESETS: SampleStrategyPreset[] = [
   },
   {
     key: 'defensive_balance_sheet',
+    category: 'fundamental',
     name: '재무안정 방어형',
     description: '낮은 부채비율과 높은 유동비율의 안정 종목을 찾습니다.',
     reference: 'Defensive balance sheet filter',
@@ -460,6 +521,7 @@ export const SAMPLE_STRATEGY_PRESETS: SampleStrategyPreset[] = [
   },
   {
     key: 'analyst_revision_momentum',
+    category: 'fundamental',
     name: '애널리스트 상향 모멘텀',
     description: '실적 추정치 상향 종목과 가격 모멘텀을 결합합니다.',
     reference: 'Analyst revision momentum',


### PR DESCRIPTION
## Summary
- Add `category` field to `SampleStrategyPreset` with 8 categories: trend following, momentum, mean reversion, breakout, volume flow, volatility, ichimoku, fundamental
- Group 40 sample strategies by category with collapsible sections and count badges in the Load Strategy dialog
- Add search input to filter presets by name/description
- Add i18n keys for category names (en/ko/zh)

## Test plan
- [ ] Open Strategy page → click Load button → verify categories are visible with correct grouping
- [ ] Collapse/expand category sections
- [ ] Type in search box → verify filtering works across name and description
- [ ] Load a preset from a category → verify it loads correctly
- [ ] `npm run lint` passes
- [ ] `npx tsc --noEmit` passes

Closes #1063

🤖 Generated with [Claude Code](https://claude.com/claude-code)