### PR TITLE
fix(strategy): NodePalette search, UniverseNode font, canvas layout

### DIFF
--- a/web/src/app/[locale]/strategy/page.tsx
+++ b/web/src/app/[locale]/strategy/page.tsx
@@ -1195,10 +1195,10 @@ function StrategyPageInner() {
   }
 
   return (
-    <div className="flex flex-col h-[calc(100vh-var(--header-height))]">
+    <div className="flex flex-col h-[calc(100vh-var(--header-height))] p-3 gap-3">
       <h1 className="sr-only">{t('title')}</h1>
       {/* Toolbar - Stitch-style */}
-      <div className="flex flex-wrap items-center gap-3 px-4 py-2 border-b border-[#e1e3e5] dark:border-[#2e2e30] bg-white dark:bg-[#0b0b0c]">
+      <div className="flex flex-wrap items-center gap-3 px-4 py-2 border border-[#e1e3e5] dark:border-[#2e2e30] bg-white dark:bg-[#0b0b0c] rounded-xl">
         {/* Breadcrumb */}
         <div className="flex items-center gap-2 text-sm">
           <Home className="h-4 w-4 text-[#1313ec]" />
@@ -1291,7 +1291,7 @@ function StrategyPageInner() {
       </div>
 
       {/* Main content */}
-      <div className="flex flex-1 overflow-hidden">
+      <div className="flex flex-1 overflow-hidden rounded-xl border border-[#e1e3e5] dark:border-[#2e2e30]">
         {/* Left palette */}
         <NodePalette nodeCount={nodeCount} />
 

--- a/web/src/components/strategy/NodePalette.tsx
+++ b/web/src/components/strategy/NodePalette.tsx
@@ -169,14 +169,16 @@ export default function NodePalette({ nodeCount }: NodePaletteProps) {
     const q = searchQuery.toLowerCase();
     const result: Record<string, StrategyConditionInfo[]> = {};
     for (const [cat, conditions] of Object.entries(conditionsByCategory)) {
-      const filtered = conditions.filter(
-        (c) =>
-          c.label.toLowerCase().includes(q) ||
-          c.description.toLowerCase().includes(q)
-      );
+      const filtered = conditions.filter((c) => {
+        const label = getConditionLabel(c).toLowerCase();
+        const desc = getConditionDesc(c).toLowerCase();
+        const key = c.key.toLowerCase();
+        return label.includes(q) || desc.includes(q) || key.includes(q);
+      });
       if (filtered.length > 0) result[cat] = filtered;
     }
     return result;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchQuery, conditionsByCategory]);
 
   return (

--- a/web/src/components/strategy/nodes/UniverseNode.tsx
+++ b/web/src/components/strategy/nodes/UniverseNode.tsx
@@ -78,13 +78,13 @@ function UniverseNode({ data, selected }: NodeProps) {
       </div>
       {/* Content */}
       <div className="p-3">
-        <div className="text-[13px] font-bold text-gray-900 dark:text-gray-100">
+        <div className="text-sm font-bold text-gray-900 dark:text-gray-100">
           {t('marketSelection')}
         </div>
-        <div className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+        <div className="text-[13px] text-slate-500 dark:text-slate-400 mt-1">
           {t('composite', { universe: selectedCountText.join(' + ') })}
         </div>
-        <div className="text-[11px] text-slate-500 dark:text-slate-400 mt-1">
+        <div className="text-xs text-slate-500 dark:text-slate-400 mt-1">
           {t('selectedUniverseTotal', {
             count: totalSelectedCount.toLocaleString(locale),
           })}


### PR DESCRIPTION
## Summary
- Fix NodePalette search to match i18n-translated labels (Korean/Chinese search now works)
- Increase UniverseNode font sizes for visual consistency with other nodes
- Add padding and rounded borders to strategy canvas for better layout separation

## Test plan
- [ ] Search in NodePalette with Korean text → results match correctly
- [ ] UniverseNode font size visually consistent with ConditionNode
- [ ] Strategy canvas has rounded border with spacing from main layout edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)