### PR TITLE
fix(chat): address Codex review — streaming perf, hard break, code block

### DIFF
--- a/web/src/components/strategy/ChatPanel.tsx
+++ b/web/src/components/strategy/ChatPanel.tsx
@@ -4,7 +4,7 @@ import { useState, useRef, useEffect, useCallback } from 'react';
 import { MessageCircle, X, Send, Loader2 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import MarkdownMessage from './chat/MarkdownMessage';
-import { normalizeStreamText } from './chat/streamTextFormatter';
+import { normalizeChunk, finalizeStreamText } from './chat/streamTextFormatter';
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
 
@@ -94,7 +94,7 @@ export default function ChatPanel({ graph }: ChatPanelProps) {
                 if (last?.role === 'assistant') {
                   updated[updated.length - 1] = {
                     ...last,
-                    content: normalizeStreamText(last.content + data.content),
+                    content: last.content + normalizeChunk(data.content),
                   };
                 }
                 return updated;
@@ -128,6 +128,14 @@ export default function ChatPanel({ graph }: ChatPanelProps) {
         return updated;
       });
     } finally {
+      setMessages(prev => {
+        const updated = [...prev];
+        const last = updated[updated.length - 1];
+        if (last?.role === 'assistant' && last.content) {
+          updated[updated.length - 1] = { ...last, content: finalizeStreamText(last.content) };
+        }
+        return updated;
+      });
       setIsStreaming(false);
     }
   }, [input, isStreaming, messages, graph, chatError]);

--- a/web/src/components/strategy/chat/MarkdownMessage.tsx
+++ b/web/src/components/strategy/chat/MarkdownMessage.tsx
@@ -30,11 +30,12 @@ function MarkdownMessage({ content }: MarkdownMessageProps) {
           <ol className="list-decimal pl-4 mb-1.5 space-y-0.5">{children}</ol>
         ),
         li: ({ children }) => <li className="leading-relaxed">{children}</li>,
-        code: ({ children, className }) => {
-          const isBlock = className?.startsWith('language-');
+        code: ({ children, className, node }) => {
+          const isBlock = className?.startsWith('language-') ||
+            node?.position?.start.column === 1;
           if (isBlock) {
             return (
-              <code className="block bg-black/10 dark:bg-white/10 rounded px-2 py-1.5 text-xs font-mono overflow-x-auto my-1.5">
+              <code className="block bg-black/10 dark:bg-white/10 rounded px-2 py-1.5 text-xs font-mono overflow-x-auto">
                 {children}
               </code>
             );

--- a/web/src/components/strategy/chat/streamTextFormatter.ts
+++ b/web/src/components/strategy/chat/streamTextFormatter.ts
@@ -1,12 +1,28 @@
 /**
  * Normalize streamed text to prevent excessive whitespace accumulation.
  * - Collapse 3+ consecutive newlines to 2 (preserve paragraph breaks)
- * - Trim trailing whitespace on each line
+ * - Trim trailing whitespace on each line, preserving markdown hard breaks (2+ trailing spaces)
  * - Normalize Windows-style line endings
  */
 export function normalizeStreamText(text: string): string {
   return text
     .replace(/\r\n/g, '\n')
-    .replace(/[ \t]+$/gm, '')
+    .replace(/[ \t]{3,}$/gm, '  ')
     .replace(/\n{3,}/g, '\n\n');
+}
+
+/**
+ * Lightweight normalizer for appending a single chunk.
+ * Only fixes CRLF in the new chunk to avoid O(n²) full-text passes.
+ * Full normalization is applied once at stream end.
+ */
+export function normalizeChunk(chunk: string): string {
+  return chunk.replace(/\r\n/g, '\n');
+}
+
+/**
+ * Final normalization pass applied once when streaming completes.
+ */
+export function finalizeStreamText(text: string): string {
+  return normalizeStreamText(text);
 }


### PR DESCRIPTION
## Summary
Fixes 3 issues from Codex code review on #1072:

1. **O(n²) streaming cost** — Replace per-chunk full-text normalization with lightweight chunk-only CRLF fix + single finalize pass at stream end
2. **Markdown hard break regression** — Preserve 2-space trailing whitespace while collapsing 3+ spaces
3. **Code block detection** — Improve fenced code block detection for language-unspecified blocks using AST position

## Part of #1066

## Test plan
- [ ] Long streaming responses don't cause UI lag
- [ ] Markdown hard line breaks render correctly
- [ ] Fenced code blocks without language spec display as blocks (not inline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)