### PR TITLE
feat(chat): sectioned message renderer and validation endpoint

### DIFF
--- a/api/routers/strategy.py
+++ b/api/routers/strategy.py
@@ -13,7 +13,11 @@ import time
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import StreamingResponse
 
-from api.schemas.strategy_chat import StrategyChatRequest
+from api.schemas.strategy_chat import (
+    StrategyChatRequest,
+    ValidatePayloadRequest,
+    ValidatePayloadResponse,
+)
 from api.schemas.strategy import (
     ConditionsListResponse,
     SavedStrategiesListResponse,
@@ -428,4 +432,25 @@ async def strategy_chat(request: StrategyChatRequest):
             "Cache-Control": "no-cache",
             "X-Accel-Buffering": "no",
         },
+    )
+
+
+@router.post(
+    "/chat/validate",
+    response_model=ValidatePayloadResponse,
+    summary="Validate assistant suggestions",
+    description="Validate condition suggestions from the AI assistant against the registry.",
+)
+async def validate_chat_payload(
+    request: ValidatePayloadRequest,
+) -> ValidatePayloadResponse:
+    """Validate structured suggestions against condition registry."""
+    from api.services.strategy_chat_service import validate_suggestions
+
+    results = validate_suggestions(
+        [s.model_dump() for s in request.suggestions]
+    )
+    return ValidatePayloadResponse(
+        results=results,
+        all_valid=all(r["valid"] for r in results),
     )

--- a/api/schemas/strategy_chat.py
+++ b/api/schemas/strategy_chat.py
@@ -30,3 +30,42 @@ class StrategyChatRequest(BaseModel):
         None,
         description="Current strategy graph (serialized nodes and edges)",
     )
+
+
+class SuggestionValidation(BaseModel):
+    """A single condition suggestion to validate."""
+
+    condition_type: str = Field(..., description="Condition key from registry")
+    params: dict[str, Any] = Field(
+        default_factory=dict, description="Parameter key-value pairs"
+    )
+
+
+class ValidatePayloadRequest(BaseModel):
+    """Request to validate a structured payload from the assistant."""
+
+    suggestions: list[SuggestionValidation] = Field(
+        ..., max_length=20, description="Conditions to validate"
+    )
+
+
+class ParamError(BaseModel):
+    """A single parameter validation error."""
+
+    param: str
+    message: str
+
+
+class SuggestionResult(BaseModel):
+    """Validation result for one suggestion."""
+
+    condition_type: str
+    valid: bool
+    errors: list[ParamError] = Field(default_factory=list)
+
+
+class ValidatePayloadResponse(BaseModel):
+    """Response from payload validation."""
+
+    results: list[SuggestionResult]
+    all_valid: bool

--- a/api/services/strategy_chat_service.py
+++ b/api/services/strategy_chat_service.py
@@ -409,6 +409,61 @@ def parse_structured_payload(text: str) -> tuple[str, Optional[dict]]:
     return clean, payload
 
 
+def validate_suggestions(
+    suggestions: list[dict],
+) -> list[dict]:
+    """Validate condition suggestions against the condition registry.
+
+    Returns a list of result dicts with 'condition_type', 'valid', 'errors'.
+    """
+    from screener.conditions.registry import get_condition_metadata
+
+    metadata = get_condition_metadata()
+    results = []
+
+    for s in suggestions:
+        ctype = s.get("condition_type", "")
+        params = s.get("params", {})
+        errors: list[dict] = []
+
+        if ctype not in metadata:
+            results.append({
+                "condition_type": ctype,
+                "valid": False,
+                "errors": [{"param": "condition_type", "message": f"Unknown condition: {ctype}"}],
+            })
+            continue
+
+        meta = metadata[ctype]
+        param_defs = {p["name"]: p for p in meta.get("params", [])}
+
+        for pname, pval in params.items():
+            if pname not in param_defs:
+                errors.append({"param": pname, "message": f"Unknown parameter: {pname}"})
+                continue
+            pdef = param_defs[pname]
+            ptype = pdef.get("type", "")
+            if ptype in ("int", "integer") and not isinstance(pval, (int, float)):
+                errors.append({"param": pname, "message": f"Expected number, got {type(pval).__name__}"})
+            elif ptype == "float" and not isinstance(pval, (int, float)):
+                errors.append({"param": pname, "message": f"Expected number, got {type(pval).__name__}"})
+            elif ptype == "bool" and not isinstance(pval, bool):
+                errors.append({"param": pname, "message": f"Expected boolean, got {type(pval).__name__}"})
+
+            if "min" in pdef and isinstance(pval, (int, float)) and pval < pdef["min"]:
+                errors.append({"param": pname, "message": f"Value {pval} below minimum {pdef['min']}"})
+            if "max" in pdef and isinstance(pval, (int, float)) and pval > pdef["max"]:
+                errors.append({"param": pname, "message": f"Value {pval} above maximum {pdef['max']}"})
+
+        results.append({
+            "condition_type": ctype,
+            "valid": len(errors) == 0,
+            "errors": errors,
+        })
+
+    return results
+
+
 _instance: Optional[StrategyChatService] = None
 
 

--- a/web/src/components/strategy/ChatPanel.tsx
+++ b/web/src/components/strategy/ChatPanel.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect, useCallback } from 'react';
 import { MessageCircle, X, Send, Loader2 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import MarkdownMessage from './chat/MarkdownMessage';
+import SectionedMessage from './chat/SectionedMessage';
 import { normalizeChunk, finalizeStreamText } from './chat/streamTextFormatter';
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
@@ -234,6 +235,8 @@ export default function ChatPanel({ graph }: ChatPanelProps) {
                   >
                     {msg.role === 'user' ? (
                       msg.content
+                    ) : msg.structuredPayload ? (
+                      <SectionedMessage content={msg.content} payload={msg.structuredPayload} />
                     ) : (
                       <MarkdownMessage content={msg.content} />
                     )}
@@ -249,30 +252,6 @@ export default function ChatPanel({ graph }: ChatPanelProps) {
                         <Loader2 className="inline h-3 w-3 animate-spin text-gray-400" />
                       )}
                   </div>
-                  {msg.structuredPayload?.suggestions && msg.structuredPayload.suggestions.length > 0 && (
-                    <div className="mt-1.5 max-w-[80%] space-y-1">
-                      {msg.structuredPayload.suggestions.map((s, j) => (
-                        <div
-                          key={j}
-                          className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg bg-blue-50 dark:bg-blue-900/20 border border-blue-200/60 dark:border-blue-500/20 text-xs"
-                        >
-                          <span className="font-mono font-semibold text-blue-700 dark:text-blue-300">
-                            {s.condition_type}
-                          </span>
-                          {s.params && typeof s.params === 'object' && !Array.isArray(s.params) && Object.entries(s.params).map(([k, v]) => (
-                            <span key={k} className="px-1 py-0.5 rounded bg-blue-100 dark:bg-blue-800/30 text-blue-600 dark:text-blue-400 text-[10px]">
-                              {k}={String(v)}
-                            </span>
-                          ))}
-                        </div>
-                      ))}
-                      {msg.structuredPayload.warnings?.map((w, j) => (
-                        <div key={j} className="px-2.5 py-1.5 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200/60 dark:border-amber-500/20 text-xs text-amber-700 dark:text-amber-300">
-                          {w}
-                        </div>
-                      ))}
-                    </div>
-                  )}
                 </div>
               ))}
               <div ref={messagesEndRef} />

--- a/web/src/components/strategy/chat/SectionedMessage.tsx
+++ b/web/src/components/strategy/chat/SectionedMessage.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import { memo } from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { useState } from 'react';
+import MarkdownMessage from './MarkdownMessage';
+
+interface StructuredSuggestion {
+  condition_type: string;
+  params: Record<string, unknown>;
+  rationale: string;
+}
+
+interface StructuredPayload {
+  summary?: string;
+  suggestions?: StructuredSuggestion[];
+  warnings?: string[];
+}
+
+interface SectionedMessageProps {
+  content: string;
+  payload: StructuredPayload;
+}
+
+function SectionedMessage({ content, payload }: SectionedMessageProps) {
+  const [expandedSections, setExpandedSections] = useState<Record<string, boolean>>({
+    suggestions: true,
+    warnings: true,
+  });
+
+  const toggle = (key: string) =>
+    setExpandedSections(prev => ({ ...prev, [key]: !prev[key] }));
+
+  return (
+    <div className="space-y-2">
+      {/* Main text content */}
+      <MarkdownMessage content={content} />
+
+      {/* Summary card */}
+      {payload.summary && (
+        <div className="rounded-lg border border-blue-200/60 bg-blue-50/50 px-3 py-2 text-xs text-blue-800 dark:border-blue-500/20 dark:bg-blue-900/10 dark:text-blue-200">
+          <span className="font-semibold">Summary: </span>
+          {payload.summary}
+        </div>
+      )}
+
+      {/* Suggestions section */}
+      {payload.suggestions && payload.suggestions.length > 0 && (
+        <div className="rounded-lg border border-gray-200/80 dark:border-gray-700/60">
+          <button
+            type="button"
+            onClick={() => toggle('suggestions')}
+            className="flex w-full items-center gap-1.5 px-3 py-1.5 text-xs font-semibold text-gray-700 dark:text-gray-300"
+          >
+            {expandedSections.suggestions ? (
+              <ChevronDown className="h-3 w-3" />
+            ) : (
+              <ChevronRight className="h-3 w-3" />
+            )}
+            Conditions ({payload.suggestions.length})
+          </button>
+          {expandedSections.suggestions && (
+            <div className="space-y-1 px-3 pb-2">
+              {payload.suggestions.map((s, j) => (
+                <div
+                  key={j}
+                  className="rounded-lg border border-blue-200/60 bg-blue-50 px-2.5 py-1.5 dark:border-blue-500/20 dark:bg-blue-900/20"
+                >
+                  <div className="flex flex-wrap items-center gap-1.5 text-xs">
+                    <span className="font-mono font-semibold text-blue-700 dark:text-blue-300">
+                      {s.condition_type}
+                    </span>
+                    {s.params &&
+                      typeof s.params === 'object' &&
+                      !Array.isArray(s.params) &&
+                      Object.entries(s.params).map(([k, v]) => (
+                        <span
+                          key={k}
+                          className="rounded bg-blue-100 px-1 py-0.5 text-[10px] text-blue-600 dark:bg-blue-800/30 dark:text-blue-400"
+                        >
+                          {k}={String(v)}
+                        </span>
+                      ))}
+                  </div>
+                  {s.rationale && (
+                    <p className="mt-1 text-[11px] leading-snug text-gray-600 dark:text-gray-400">
+                      {s.rationale}
+                    </p>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Warnings section */}
+      {payload.warnings && payload.warnings.length > 0 && (
+        <div className="rounded-lg border border-amber-200/60 dark:border-amber-500/20">
+          <button
+            type="button"
+            onClick={() => toggle('warnings')}
+            className="flex w-full items-center gap-1.5 px-3 py-1.5 text-xs font-semibold text-amber-700 dark:text-amber-300"
+          >
+            {expandedSections.warnings ? (
+              <ChevronDown className="h-3 w-3" />
+            ) : (
+              <ChevronRight className="h-3 w-3" />
+            )}
+            Warnings ({payload.warnings.length})
+          </button>
+          {expandedSections.warnings && (
+            <div className="space-y-1 px-3 pb-2">
+              {payload.warnings.map((w, j) => (
+                <div
+                  key={j}
+                  className="rounded-lg bg-amber-50 px-2.5 py-1.5 text-xs text-amber-700 dark:bg-amber-900/20 dark:text-amber-300"
+                >
+                  {w}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default memo(SectionedMessage);


### PR DESCRIPTION
## Summary
- Add `SectionedMessage` component with collapsible sections for suggestions and warnings (#1071)
- Replace inline chip rendering with `SectionedMessage` when `structuredPayload` is present
- Add `/api/strategy/chat/validate` endpoint to validate condition suggestions against registry (#1077)
- Add `validate_suggestions()` service function with type/range checking

Closes #1071, closes #1077

## Test plan
- [ ] TypeScript compiles without errors
- [ ] ESLint passes
- [ ] Python syntax valid
- [ ] Chat panel renders markdown normally when no structured payload
- [ ] Chat panel renders sectioned view with collapsible sections when structured payload present
- [ ] POST /api/strategy/chat/validate returns validation results
- [ ] Unknown conditions return valid=false with error message
- [ ] Invalid param types return appropriate error messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)