### PR TITLE
feat(chat): add per-block copy and validate actions

### DIFF
--- a/web/src/components/strategy/ChatPanel.tsx
+++ b/web/src/components/strategy/ChatPanel.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect, useCallback } from 'react';
 import { MessageCircle, X, Send, Loader2 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import MarkdownMessage from './chat/MarkdownMessage';
+import MessageActions from './chat/MessageActions';
 import SectionedMessage from './chat/SectionedMessage';
 import { normalizeChunk, finalizeStreamText } from './chat/streamTextFormatter';
 
@@ -252,6 +253,14 @@ export default function ChatPanel({ graph }: ChatPanelProps) {
                         <Loader2 className="inline h-3 w-3 animate-spin text-gray-400" />
                       )}
                   </div>
+                  {msg.role === 'assistant' &&
+                    msg.content &&
+                    !(i === messages.length - 1 && isStreaming) && (
+                      <MessageActions
+                        content={msg.content}
+                        payload={msg.structuredPayload}
+                      />
+                    )}
                 </div>
               ))}
               <div ref={messagesEndRef} />

--- a/web/src/components/strategy/chat/MessageActions.tsx
+++ b/web/src/components/strategy/chat/MessageActions.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import { memo, useState, useCallback } from 'react';
+import { Copy, Check, ClipboardCheck, Loader2 } from 'lucide-react';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+
+interface StructuredSuggestion {
+  condition_type: string;
+  params: Record<string, unknown>;
+  rationale: string;
+}
+
+interface StructuredPayload {
+  summary?: string;
+  suggestions?: StructuredSuggestion[];
+  warnings?: string[];
+}
+
+interface MessageActionsProps {
+  content: string;
+  payload?: StructuredPayload;
+}
+
+function MessageActions({ content, payload }: MessageActionsProps) {
+  const [copied, setCopied] = useState(false);
+  const [validating, setValidating] = useState(false);
+  const [validationResult, setValidationResult] = useState<
+    { allValid: boolean; errors: string[] } | null
+  >(null);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(content);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Fallback for browsers that don't support clipboard API
+    }
+  }, [content]);
+
+  const handleValidate = useCallback(async () => {
+    if (!payload?.suggestions?.length) return;
+    setValidating(true);
+    setValidationResult(null);
+    try {
+      const res = await fetch(`${API_BASE_URL}/api/strategy/chat/validate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          suggestions: payload.suggestions.map(s => ({
+            condition_type: s.condition_type,
+            params: s.params && typeof s.params === 'object' && !Array.isArray(s.params)
+              ? s.params
+              : {},
+          })),
+        }),
+      });
+      if (!res.ok) throw new Error(`API ${res.status}`);
+      const data = await res.json();
+      const errors: string[] = [];
+      for (const r of data.results) {
+        if (!r.valid) {
+          for (const e of r.errors) {
+            errors.push(`${r.condition_type}.${e.param}: ${e.message}`);
+          }
+        }
+      }
+      setValidationResult({ allValid: data.all_valid, errors });
+    } catch {
+      setValidationResult({ allValid: false, errors: ['Validation request failed'] });
+    } finally {
+      setValidating(false);
+    }
+  }, [payload]);
+
+  const hasSuggestions = payload?.suggestions && payload.suggestions.length > 0;
+
+  return (
+    <div className="mt-1">
+      <div className="flex items-center gap-1">
+        {/* Copy button */}
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"
+          title="Copy message"
+        >
+          {copied ? (
+            <Check className="h-3 w-3 text-green-500" />
+          ) : (
+            <Copy className="h-3 w-3" />
+          )}
+          {copied ? 'Copied' : 'Copy'}
+        </button>
+
+        {/* Validate button — only when suggestions exist */}
+        {hasSuggestions && (
+          <button
+            type="button"
+            onClick={handleValidate}
+            disabled={validating}
+            className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 disabled:opacity-50 dark:hover:bg-gray-800 dark:hover:text-gray-300"
+            title="Validate conditions"
+          >
+            {validating ? (
+              <Loader2 className="h-3 w-3 animate-spin" />
+            ) : (
+              <ClipboardCheck className="h-3 w-3" />
+            )}
+            Validate
+          </button>
+        )}
+      </div>
+
+      {/* Validation result */}
+      {validationResult && (
+        <div
+          className={`mt-1 rounded px-2 py-1 text-[10px] ${
+            validationResult.allValid
+              ? 'bg-green-50 text-green-700 dark:bg-green-900/20 dark:text-green-300'
+              : 'bg-red-50 text-red-700 dark:bg-red-900/20 dark:text-red-300'
+          }`}
+        >
+          {validationResult.allValid ? (
+            'All conditions are valid'
+          ) : (
+            <ul className="list-inside list-disc space-y-0.5">
+              {validationResult.errors.map((e, i) => (
+                <li key={i}>{e}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default memo(MessageActions);


### PR DESCRIPTION
## Summary
- Add `MessageActions` component with Copy and Validate buttons below assistant messages
- Copy: copies message text to clipboard with visual feedback
- Validate: calls `/api/strategy/chat/validate` endpoint to check condition suggestions against registry, displays inline pass/fail result

Closes #1076

## Test plan
- [ ] TypeScript compiles, ESLint passes
- [ ] Copy button copies text and shows checkmark feedback
- [ ] Validate button appears only when suggestions are present
- [ ] Validate calls API and displays result inline
- [ ] Actions don't appear during streaming

🤖 Generated with [Claude Code](https://claude.com/claude-code)