### PR TITLE
feat(chat): node mapping and one-click canvas addition

### DIFF
--- a/api/routers/strategy.py
+++ b/api/routers/strategy.py
@@ -406,6 +406,7 @@ async def strategy_chat(request: StrategyChatRequest):
 
     def event_stream():
         from api.services.strategy_chat_service import parse_structured_payload
+        from api.services.strategy_node_mapper import map_suggestions_to_nodes
 
         try:
             full_text = ""
@@ -418,7 +419,13 @@ async def strategy_chat(request: StrategyChatRequest):
 
             clean_text, payload = parse_structured_payload(full_text)
             if payload:
-                yield f"data: {json.dumps({'type': 'structured_payload', 'payload': payload, 'clean_text': clean_text})}\n\n"
+                node_mappings = []
+                if payload.get("suggestions"):
+                    try:
+                        node_mappings = map_suggestions_to_nodes(payload["suggestions"])
+                    except Exception:
+                        logger.warning("Failed to map suggestions to nodes")
+                yield f"data: {json.dumps({'type': 'structured_payload', 'payload': payload, 'clean_text': clean_text, 'node_mappings': node_mappings})}\n\n"
 
             yield f"data: {json.dumps({'type': 'done'})}\n\n"
         except Exception as e:

--- a/api/services/strategy_node_mapper.py
+++ b/api/services/strategy_node_mapper.py
@@ -1,0 +1,60 @@
+"""
+Strategy Node Mapper.
+
+Maps structured condition suggestions to canvas node definitions.
+"""
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def map_suggestions_to_nodes(
+    suggestions: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Convert validated suggestions into canvas-ready node definitions.
+
+    Each suggestion produces a condition node definition that the frontend
+    can directly add to the React Flow canvas.
+
+    Returns list of node mapping dicts:
+        {
+            "condition_type": str,
+            "node_type": "condition",
+            "params": dict,
+            "label": str,
+        }
+    """
+    from screener.conditions.registry import get_condition_metadata
+
+    metadata = get_condition_metadata()
+    nodes = []
+
+    for s in suggestions:
+        ctype = s.get("condition_type", "")
+        params = s.get("params", {})
+
+        if ctype not in metadata:
+            continue
+
+        meta = metadata[ctype]
+        label = meta.get("label", ctype)
+
+        # Merge defaults for any missing params
+        param_defs = {p["name"]: p for p in meta.get("params", [])}
+        merged_params = {}
+        for pname, pdef in param_defs.items():
+            if pname in params:
+                merged_params[pname] = params[pname]
+            elif "default" in pdef:
+                merged_params[pname] = pdef["default"]
+
+        nodes.append({
+            "condition_type": ctype,
+            "node_type": "condition",
+            "params": merged_params,
+            "label": label,
+        })
+
+    return nodes

--- a/web/src/app/[locale]/strategy/page.tsx
+++ b/web/src/app/[locale]/strategy/page.tsx
@@ -36,7 +36,7 @@ import LabeledEdge from '@/components/strategy/edges/LabeledEdge';
 import NodePalette from '@/components/strategy/NodePalette';
 import IntermediateResultsPanel from '@/components/strategy/IntermediateResultsPanel';
 import SideInspectionPanel from '@/components/strategy/SideInspectionPanel';
-import ChatPanel from '@/components/strategy/ChatPanel';
+import ChatPanel, { type NodeMapping } from '@/components/strategy/ChatPanel';
 
 import BacktestPanel from '@/components/backtest/BacktestPanel';
 import { Toast, useToast, type ToastType } from '@/components/ui/Toast';
@@ -663,6 +663,24 @@ function StrategyPageInner() {
       setNodes((nds) => [...nds, newNode]);
     },
     [reactFlowInstance, setNodes, setEdges, findGroupAtPosition, nodes, getDefaultParams, showToast, t]
+  );
+
+  // Add condition nodes from chat assistant suggestions
+  const handleAddNodesFromChat = useCallback(
+    (mappings: NodeMapping[]) => {
+      const newNodes: Node[] = mappings.map((m, i) => ({
+        id: getNodeId(),
+        type: 'conditionNode',
+        position: { x: 100 + i * 50, y: 200 + i * 80 },
+        data: {
+          node_type: 'condition' as const,
+          condition_type: m.condition_type,
+          params: m.params,
+        } as unknown as Record<string, unknown>,
+      }));
+      setNodes((nds) => [...nds, ...newNodes]);
+    },
+    [setNodes],
   );
 
   // Auto-resize group nodes when children change (only expand, never shrink)
@@ -1340,7 +1358,10 @@ function StrategyPageInner() {
               className="dark:!opacity-20"
             />
           </ReactFlow>
-          <ChatPanel graph={serializeGraph(nodes as Node<StrategyNodeData>[], edges)} />
+          <ChatPanel
+            graph={serializeGraph(nodes as Node<StrategyNodeData>[], edges)}
+            onAddNodes={handleAddNodesFromChat}
+          />
         </div>
       </div>
 

--- a/web/src/components/strategy/ChatPanel.tsx
+++ b/web/src/components/strategy/ChatPanel.tsx
@@ -22,17 +22,26 @@ interface StructuredPayload {
   warnings?: string[];
 }
 
+export interface NodeMapping {
+  condition_type: string;
+  node_type: string;
+  params: Record<string, unknown>;
+  label: string;
+}
+
 interface ChatMessage {
   role: 'user' | 'assistant';
   content: string;
   structuredPayload?: StructuredPayload;
+  nodeMappings?: NodeMapping[];
 }
 
 interface ChatPanelProps {
   graph: { nodes: unknown[]; edges: unknown[] } | null;
+  onAddNodes?: (nodes: NodeMapping[]) => void;
 }
 
-export default function ChatPanel({ graph }: ChatPanelProps) {
+export default function ChatPanel({ graph, onAddNodes }: ChatPanelProps) {
   const t = useTranslations('strategy');
 
   const [isOpen, setIsOpen] = useState(false);
@@ -123,6 +132,7 @@ export default function ChatPanel({ graph }: ChatPanelProps) {
                     ...last,
                     content: data.clean_text || last.content.replace(/<!--\s*STRUCTURED_JSON[\s\S]*?-->/g, '').trimEnd(),
                     structuredPayload: data.payload,
+                    nodeMappings: data.node_mappings || undefined,
                   };
                 }
                 return updated;
@@ -237,7 +247,12 @@ export default function ChatPanel({ graph }: ChatPanelProps) {
                     {msg.role === 'user' ? (
                       msg.content
                     ) : msg.structuredPayload ? (
-                      <SectionedMessage content={msg.content} payload={msg.structuredPayload} />
+                      <SectionedMessage
+                        content={msg.content}
+                        payload={msg.structuredPayload}
+                        nodeMappings={msg.nodeMappings}
+                        onAddNodes={onAddNodes}
+                      />
                     ) : (
                       <MarkdownMessage content={msg.content} />
                     )}

--- a/web/src/components/strategy/chat/SectionedMessage.tsx
+++ b/web/src/components/strategy/chat/SectionedMessage.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import { memo } from 'react';
-import { ChevronDown, ChevronRight } from 'lucide-react';
-import { useState } from 'react';
+import { memo, useState } from 'react';
+import { ChevronDown, ChevronRight, Plus, Check } from 'lucide-react';
 import MarkdownMessage from './MarkdownMessage';
 
 interface StructuredSuggestion {
@@ -17,19 +16,35 @@ interface StructuredPayload {
   warnings?: string[];
 }
 
+interface NodeMapping {
+  condition_type: string;
+  node_type: string;
+  params: Record<string, unknown>;
+  label: string;
+}
+
 interface SectionedMessageProps {
   content: string;
   payload: StructuredPayload;
+  nodeMappings?: NodeMapping[];
+  onAddNodes?: (nodes: NodeMapping[]) => void;
 }
 
-function SectionedMessage({ content, payload }: SectionedMessageProps) {
+function SectionedMessage({ content, payload, nodeMappings, onAddNodes }: SectionedMessageProps) {
   const [expandedSections, setExpandedSections] = useState<Record<string, boolean>>({
     suggestions: true,
     warnings: true,
   });
+  const [added, setAdded] = useState(false);
 
   const toggle = (key: string) =>
     setExpandedSections(prev => ({ ...prev, [key]: !prev[key] }));
+
+  const handleAddAll = () => {
+    if (!nodeMappings?.length || !onAddNodes) return;
+    onAddNodes(nodeMappings);
+    setAdded(true);
+  };
 
   return (
     <div className="space-y-2">
@@ -47,18 +62,41 @@ function SectionedMessage({ content, payload }: SectionedMessageProps) {
       {/* Suggestions section */}
       {payload.suggestions && payload.suggestions.length > 0 && (
         <div className="rounded-lg border border-gray-200/80 dark:border-gray-700/60">
-          <button
-            type="button"
-            onClick={() => toggle('suggestions')}
-            className="flex w-full items-center gap-1.5 px-3 py-1.5 text-xs font-semibold text-gray-700 dark:text-gray-300"
-          >
-            {expandedSections.suggestions ? (
-              <ChevronDown className="h-3 w-3" />
-            ) : (
-              <ChevronRight className="h-3 w-3" />
+          <div className="flex items-center justify-between px-3 py-1.5">
+            <button
+              type="button"
+              onClick={() => toggle('suggestions')}
+              className="flex items-center gap-1.5 text-xs font-semibold text-gray-700 dark:text-gray-300"
+            >
+              {expandedSections.suggestions ? (
+                <ChevronDown className="h-3 w-3" />
+              ) : (
+                <ChevronRight className="h-3 w-3" />
+              )}
+              Conditions ({payload.suggestions.length})
+            </button>
+            {/* Add to Canvas button */}
+            {nodeMappings && nodeMappings.length > 0 && onAddNodes && (
+              <button
+                type="button"
+                onClick={handleAddAll}
+                disabled={added}
+                className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium text-blue-600 transition-colors hover:bg-blue-50 disabled:text-green-600 disabled:hover:bg-transparent dark:text-blue-400 dark:hover:bg-blue-900/20 dark:disabled:text-green-400"
+              >
+                {added ? (
+                  <>
+                    <Check className="h-3 w-3" />
+                    Added
+                  </>
+                ) : (
+                  <>
+                    <Plus className="h-3 w-3" />
+                    Add to Canvas
+                  </>
+                )}
+              </button>
             )}
-            Conditions ({payload.suggestions.length})
-          </button>
+          </div>
           {expandedSections.suggestions && (
             <div className="space-y-1 px-3 pb-2">
               {payload.suggestions.map((s, j) => (


### PR DESCRIPTION
## Summary
- Add `strategy_node_mapper.py` backend service to convert condition suggestions to canvas-ready node definitions (#1078)
- Include `node_mappings` in structured_payload SSE event
- Add "Add to Canvas" button in SectionedMessage to create condition nodes directly on the React Flow canvas (#1079)
- Wire `onAddNodes` callback from strategy page through ChatPanel to SectionedMessage

Closes #1078, closes #1079

## Test plan
- [ ] TypeScript compiles, ESLint passes
- [ ] Python syntax valid
- [ ] SSE structured_payload event includes node_mappings when suggestions present
- [ ] "Add to Canvas" button appears in suggestions section
- [ ] Clicking "Add to Canvas" creates condition nodes on the canvas
- [ ] Button shows "Added" state after clicking

🤖 Generated with [Claude Code](https://claude.com/claude-code)