### PR TITLE
fix(search): update yfinance search API for v1.2.0

### DIFF
--- a/api/routers/search.py
+++ b/api/routers/search.py
@@ -102,10 +102,10 @@ def _search_yfinance(q: str) -> List[SearchResult]:
     except Exception:
         pass
 
-    # Search using yfinance search
+    # Search using yfinance Search class
     try:
-        search_results = yf.search(q, max_results=20)
-        quotes = search_results.get("quotes", [])
+        search_obj = yf.Search(q, max_results=20)
+        quotes = search_obj.quotes if hasattr(search_obj, "quotes") else []
         seen_tickers = {r.ticker for r in results}
 
         for item in quotes:


### PR DESCRIPTION
## Summary
- Fix ticker search by company name (e.g. "APPLE" → AAPL)
- yfinance 1.2.0 changed `yf.search()` (function returning dict) to `yf.Search()` (class with `.quotes` attribute)
- Updated `_search_yfinance()` to use the new API

## Test plan
- [ ] Search "APPLE" → returns AAPL as first result
- [ ] Search "AAPL" → direct ticker lookup still works
- [ ] Korean search (삼성전자) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)