### PR TITLE
feat: add macro bundle contract scaffolding (Phase A)

### DIFF
--- a/web/src/hooks/useMarket.ts
+++ b/web/src/hooks/useMarket.ts
@@ -2,7 +2,7 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { queryKeys } from '@/lib/queryKeys';
-import { searchTickers } from '@/lib/api';
+import { getMacroBundle, getMacroHistory, searchTickers } from '@/lib/api';
 
 export function useSearchTickers(query: string) {
   return useQuery({
@@ -10,5 +10,22 @@ export function useSearchTickers(query: string) {
     queryFn: () => searchTickers(query),
     enabled: query.length >= 1,
     staleTime: 30 * 1000, // 30 seconds
+  });
+}
+
+export function useMacroBundle() {
+  return useQuery({
+    queryKey: queryKeys.market.macroBundle(),
+    queryFn: () => getMacroBundle(),
+    refetchInterval: 30 * 1000,
+    staleTime: 10 * 1000,
+  });
+}
+
+export function useMacroHistory(window: string = '60m') {
+  return useQuery({
+    queryKey: queryKeys.market.macroHistory(window),
+    queryFn: () => getMacroHistory(window),
+    staleTime: 30 * 1000,
   });
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -17,6 +17,8 @@ import type {
   TickerAnalysis,
   AIAnalysisResult,
   AnalysisStatus,
+  MacroBundle,
+  MacroHistoryResponse,
   KiwoomConnectionStatus,
   KiwoomConnectionState,
   KiwoomCondition,
@@ -401,6 +403,20 @@ export async function getTickerAnalysis(ticker: string, period: string = '6mo'):
  */
 export async function searchTickers(query: string): Promise<Array<{ ticker: string; name: string }>> {
   return fetchApi<Array<{ ticker: string; name: string }>>(`/api/search?q=${encodeURIComponent(query)}`);
+}
+
+/**
+ * Get macro bundle snapshot (FX + futures + investor flow + regime signal)
+ */
+export async function getMacroBundle(): Promise<MacroBundle> {
+  return fetchApi<MacroBundle>('/api/market/macro/bundle');
+}
+
+/**
+ * Get macro history for a given window (e.g. 60m, 1d)
+ */
+export async function getMacroHistory(window: string = '60m'): Promise<MacroHistoryResponse> {
+  return fetchApi<MacroHistoryResponse>(`/api/market/macro/history?window=${encodeURIComponent(window)}`);
 }
 
 /**

--- a/web/src/lib/queryKeys.ts
+++ b/web/src/lib/queryKeys.ts
@@ -20,6 +20,8 @@ export const queryKeys = {
   market: {
     all: ['market'] as const,
     search: (query: string) => [...queryKeys.market.all, 'search', query] as const,
+    macroBundle: () => [...queryKeys.market.all, 'macro-bundle'] as const,
+    macroHistory: (window: string) => [...queryKeys.market.all, 'macro-history', window] as const,
   },
   strategy: {
     all: ['strategy'] as const,

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -274,6 +274,68 @@ export interface AnalysisStatus {
   data_dir: string | null;
 }
 
+// Macro monitoring types (FX + futures + investor flow)
+export type MacroRegime = 'risk_on' | 'neutral' | 'risk_off' | 'unknown';
+
+export interface MacroFxSnapshot {
+  pair: string; // e.g. USD/KRW
+  value: number | null;
+  change_pct: number | null;
+  updated_at: string | null;
+}
+
+export interface MacroFuturesSnapshot {
+  symbol: string; // e.g. KOSPI200_FUT
+  value: number | null;
+  basis: number | null;
+  change_pct: number | null;
+  updated_at: string | null;
+}
+
+export interface MacroInvestorFlowSnapshot {
+  market: string; // e.g. KOSPI
+  foreign_net: number | null;
+  institution_net: number | null;
+  individual_net: number | null;
+  window_min: number | null;
+  updated_at: string | null;
+}
+
+export interface MacroSignal {
+  macro_score: number | null;
+  regime: MacroRegime;
+  reason: string | null;
+  updated_at: string | null;
+}
+
+export interface MacroFreshness {
+  fx_age_sec: number | null;
+  futures_age_sec: number | null;
+  flow_age_sec: number | null;
+}
+
+export interface MacroBundle {
+  fx: MacroFxSnapshot;
+  futures: MacroFuturesSnapshot;
+  flow: MacroInvestorFlowSnapshot;
+  signal: MacroSignal;
+  freshness: MacroFreshness;
+}
+
+export interface MacroHistoryPoint {
+  timestamp: string;
+  fx_value: number | null;
+  futures_value: number | null;
+  foreign_net: number | null;
+  macro_score: number | null;
+  regime: MacroRegime;
+}
+
+export interface MacroHistoryResponse {
+  window: string;
+  points: MacroHistoryPoint[];
+}
+
 // Broker-agnostic types (unified broker router)
 export type BrokerOrderSide = 'BUY' | 'SELL';
 export type BrokerOrderType = 'MARKET' | 'LIMIT';


### PR DESCRIPTION
## Summary
- add macro monitoring types (`MacroBundle`, `MacroSignal`, freshness/history models)
- add API client functions for macro bundle and history endpoints
- add query keys + React Query hooks (`useMacroBundle`, `useMacroHistory`)

## Test plan
- [x] `npm run lint`

## Related
- Closes #1113
- Parent #1110

🤖 Generated with [Claude Code](https://claude.com/claude-code)