### PR TITLE
feat: add OpenAI provider support for AI insight analysis

### DIFF
--- a/api/routers/analysis.py
+++ b/api/routers/analysis.py
@@ -77,8 +77,8 @@ def enrich_stock(request: EnrichRequest) -> EnrichedStock:
     "/analyze",
     response_model=AnalysisResult,
     summary="Analyze Stock with AI",
-    description="Analyze a single stock using Claude AI for valuation and risk assessment. "
-                "Requires ANTHROPIC_API_KEY environment variable. May take 30+ seconds.",
+    description="Analyze a single stock using AI for valuation and risk assessment. "
+                "Requires ANTHROPIC_API_KEY or OPENAI_API_KEY. May take 30+ seconds.",
 )
 def analyze_stock(request: AnalysisRequest) -> AnalysisResult:
     """
@@ -90,7 +90,7 @@ def analyze_stock(request: AnalysisRequest) -> AnalysisResult:
     - Entry recommendation (BUY, WAIT, AVOID)
     - Key risks and catalysts
 
-    Note: Requires ANTHROPIC_API_KEY environment variable.
+    Note: Requires ANTHROPIC_API_KEY or OPENAI_API_KEY environment variable.
     This operation may take 30+ seconds due to API calls.
 
     Args:
@@ -104,10 +104,10 @@ def analyze_stock(request: AnalysisRequest) -> AnalysisResult:
     """
     service = get_analysis_service()
 
-    if not service.is_claude_available():
+    if not service.is_ai_available():
         raise HTTPException(
             status_code=503,
-            detail="Claude API not available. Please set ANTHROPIC_API_KEY environment variable."
+            detail="AI API not available. Please set ANTHROPIC_API_KEY or OPENAI_API_KEY environment variable."
         )
 
     try:
@@ -308,6 +308,8 @@ def get_status() -> dict:
     service = get_analysis_service()
 
     return {
+        "ai_available": service.is_ai_available(),
+        "provider": service.provider,
         "claude_available": service.is_claude_available(),
         "cache_available": service.cache is not None,
         "enrichers": {

--- a/api/services/analysis_service.py
+++ b/api/services/analysis_service.py
@@ -45,8 +45,13 @@ class AnalysisService:
         self._cache = None
         self._stock_analyzer = None
 
-        # Check if Claude API is available
-        self._claude_available = bool(os.environ.get("ANTHROPIC_API_KEY"))
+        # Detect AI provider: Anthropic > OpenAI
+        has_anthropic = bool(os.environ.get("ANTHROPIC_API_KEY"))
+        has_openai = bool(os.environ.get("OPENAI_API_KEY"))
+        self._ai_available = has_anthropic or has_openai
+        self._provider = "anthropic" if has_anthropic else ("openai" if has_openai else None)
+        # Anthropic-specific flag (backward compat for is_claude_available)
+        self._claude_available = has_anthropic
 
     @property
     def cache(self):
@@ -82,8 +87,8 @@ class AnalysisService:
 
     @property
     def stock_analyzer(self):
-        """Get or create stock analyzer instance (requires Claude API)."""
-        if self._stock_analyzer is None and self._claude_available:
+        """Get or create stock analyzer instance (requires AI API key)."""
+        if self._stock_analyzer is None and self._ai_available:
             try:
                 from llm import StockAnalyzer
                 self._stock_analyzer = StockAnalyzer()
@@ -181,9 +186,9 @@ class AnalysisService:
         include_news: bool = True
     ) -> Optional[AnalysisResult]:
         """
-        Analyze a single stock using Claude AI.
+        Analyze a single stock using AI (Anthropic or OpenAI).
 
-        This operation requires ANTHROPIC_API_KEY environment variable.
+        Requires ANTHROPIC_API_KEY or OPENAI_API_KEY environment variable.
         May take 30+ seconds due to API calls.
 
         Args:
@@ -196,8 +201,8 @@ class AnalysisService:
         Raises:
             ValueError: If ticker data cannot be fetched
         """
-        if not self._claude_available or self.stock_analyzer is None:
-            logger.warning("Claude API not available for analysis")
+        if not self._ai_available or self.stock_analyzer is None:
+            logger.warning("AI API not available for analysis")
             return None
 
         try:
@@ -424,8 +429,17 @@ class AnalysisService:
 
         return files
 
+    def is_ai_available(self) -> bool:
+        """Check if any AI API (Anthropic or OpenAI) is available."""
+        return self._ai_available
+
+    @property
+    def provider(self) -> Optional[str]:
+        """Return the active AI provider name, or None."""
+        return self._provider
+
     def is_claude_available(self) -> bool:
-        """Check if Claude API is available for analysis."""
+        """Check if Anthropic Claude API specifically is available."""
         return self._claude_available
 
 

--- a/llm/claude_client.py
+++ b/llm/claude_client.py
@@ -96,7 +96,7 @@ Be concise but thorough in your reasoning. Focus on actionable insights."""
     def __init__(
         self,
         api_key: str = None,
-        model: str = "claude-sonnet-4-20250514",
+        model: str = None,
         max_tokens: int = 1500,
         max_retries: int = 3,
         retry_delay: float = 1.0
@@ -104,19 +104,39 @@ Be concise but thorough in your reasoning. Focus on actionable insights."""
         """
         Initialize Claude analyzer.
 
+        Automatically detects provider based on available API keys.
+        Priority: ANTHROPIC_API_KEY > OPENAI_API_KEY.
+
         Args:
-            api_key: Anthropic API key (defaults to ANTHROPIC_API_KEY env var)
-            model: Claude model to use
+            api_key: API key (defaults to env var based on provider detection)
+            model: Model to use (defaults based on provider)
             max_tokens: Max tokens for response
             max_retries: Maximum number of retry attempts for transient failures
             retry_delay: Base delay between retries in seconds (exponential backoff)
         """
-        self.api_key = api_key or os.environ.get("ANTHROPIC_API_KEY")
-        if not self.api_key:
+        anthropic_key = os.environ.get("ANTHROPIC_API_KEY")
+        openai_key = os.environ.get("OPENAI_API_KEY")
+
+        if api_key:
+            # Explicit key provided — assume anthropic unless only openai key matches
+            self.api_key = api_key
+            self._provider = "anthropic"
+        elif anthropic_key:
+            self.api_key = anthropic_key
+            self._provider = "anthropic"
+        elif openai_key:
+            self.api_key = openai_key
+            self._provider = "openai"
+        else:
             raise APIKeyMissingError(
-                "ANTHROPIC_API_KEY not found. Set it as environment variable or pass api_key parameter."
+                "No AI API key found. Set ANTHROPIC_API_KEY or OPENAI_API_KEY environment variable."
             )
-        self.model = model
+
+        default_models = {
+            "anthropic": "claude-sonnet-4-20250514",
+            "openai": "gpt-4o",
+        }
+        self.model = model or default_models[self._provider]
         self.max_tokens = max_tokens
         self.max_retries = max_retries
         self.retry_delay = retry_delay
@@ -124,16 +144,26 @@ Be concise but thorough in your reasoning. Focus on actionable insights."""
 
     @property
     def client(self):
-        """Lazy initialization of Anthropic client"""
+        """Lazy initialization of API client based on provider"""
         if self._client is None:
-            try:
-                import anthropic
-                self._client = anthropic.Anthropic(api_key=self.api_key)
-                logger.debug(f"Initialized Anthropic client with model: {self.model}")
-            except ImportError:
-                raise ImportError(
-                    "anthropic package not installed. Run: pip install anthropic"
-                )
+            if self._provider == "openai":
+                try:
+                    import openai
+                    self._client = openai.OpenAI(api_key=self.api_key)
+                    logger.debug(f"Initialized OpenAI client with model: {self.model}")
+                except ImportError:
+                    raise ImportError(
+                        "openai package not installed. Run: pip install openai"
+                    )
+            else:
+                try:
+                    import anthropic
+                    self._client = anthropic.Anthropic(api_key=self.api_key)
+                    logger.debug(f"Initialized Anthropic client with model: {self.model}")
+                except ImportError:
+                    raise ImportError(
+                        "anthropic package not installed. Run: pip install anthropic"
+                    )
         return self._client
 
     def analyze_stock(
@@ -331,25 +361,31 @@ Be concise but thorough in your reasoning. Focus on actionable insights."""
 
     def _call_claude(self, prompt: str, system: str = None) -> str:
         """
-        Make API call to Claude with retry logic.
+        Make API call with retry logic. Dispatches to the correct provider.
 
         Args:
             prompt: User prompt to send
             system: System prompt (optional)
 
         Returns:
-            Response text from Claude
+            Response text from the AI model
 
         Raises:
             APICallError: If all retries fail
         """
+        if self._provider == "openai":
+            return self._call_openai(prompt, system)
+        return self._call_anthropic(prompt, system)
+
+    def _call_anthropic(self, prompt: str, system: str = None) -> str:
+        """Make API call to Anthropic Claude with retry logic."""
         import anthropic
 
         last_error = None
 
         for attempt in range(self.max_retries):
             try:
-                logger.debug(f"API call attempt {attempt + 1}/{self.max_retries}")
+                logger.debug(f"Anthropic API call attempt {attempt + 1}/{self.max_retries}")
 
                 message = self.client.messages.create(
                     model=self.model,
@@ -393,6 +429,62 @@ Be concise but thorough in your reasoning. Focus on actionable insights."""
                 raise APICallError(f"Unexpected error: {e}")
 
         # All retries exhausted
+        logger.error(f"All {self.max_retries} retries failed. Last error: {last_error}")
+        raise APICallError(f"API call failed after {self.max_retries} retries: {last_error}")
+
+    def _call_openai(self, prompt: str, system: str = None) -> str:
+        """Make API call to OpenAI with retry logic."""
+        import openai
+
+        last_error = None
+        messages = []
+        if system:
+            messages.append({"role": "system", "content": system})
+        messages.append({"role": "user", "content": prompt})
+
+        for attempt in range(self.max_retries):
+            try:
+                logger.debug(f"OpenAI API call attempt {attempt + 1}/{self.max_retries}")
+
+                response = self.client.chat.completions.create(
+                    model=self.model,
+                    max_tokens=self.max_tokens,
+                    messages=messages,
+                )
+
+                response_text = response.choices[0].message.content
+                if not response_text:
+                    raise APICallError("OpenAI returned empty response content")
+                logger.debug(f"API response received: {len(response_text)} chars")
+
+                return response_text
+
+            except openai.RateLimitError as e:
+                last_error = e
+                delay = self.retry_delay * (2 ** attempt)
+                logger.warning(f"Rate limit hit. Retrying in {delay:.1f}s...")
+                time.sleep(delay)
+
+            except openai.APIConnectionError as e:
+                last_error = e
+                delay = self.retry_delay * (2 ** attempt)
+                logger.warning(f"Connection error. Retrying in {delay:.1f}s...")
+                time.sleep(delay)
+
+            except openai.APIStatusError as e:
+                if e.status_code < 500 and e.status_code != 429:
+                    logger.error(f"API error (non-retryable): {e}")
+                    raise APICallError(f"API error: {e}")
+
+                last_error = e
+                delay = self.retry_delay * (2 ** attempt)
+                logger.warning(f"Server error ({e.status_code}). Retrying in {delay:.1f}s...")
+                time.sleep(delay)
+
+            except Exception as e:
+                logger.error(f"Unexpected error during API call: {e}")
+                raise APICallError(f"Unexpected error: {e}")
+
         logger.error(f"All {self.max_retries} retries failed. Last error: {last_error}")
         raise APICallError(f"API call failed after {self.max_retries} retries: {last_error}")
 

--- a/llm/stock_analyzer.py
+++ b/llm/stock_analyzer.py
@@ -121,7 +121,7 @@ class StockAnalyzer:
 
     def __init__(
         self,
-        claude_model: str = "claude-sonnet-4-20250514",
+        claude_model: str = None,
         max_tokens: int = 1500,
         use_cache: bool = True
     ):
@@ -129,8 +129,8 @@ class StockAnalyzer:
         Initialize stock analyzer.
 
         Args:
-            claude_model: Claude model to use
-            max_tokens: Max tokens for Claude response
+            claude_model: Model to use (None = auto-detect based on provider)
+            max_tokens: Max tokens for AI response
             use_cache: Use OHLCV cache
         """
         self.claude = ClaudeAnalyzer(model=claude_model, max_tokens=max_tokens)

--- a/web/src/app/[locale]/analysis/[ticker]/page.tsx
+++ b/web/src/app/[locale]/analysis/[ticker]/page.tsx
@@ -190,7 +190,7 @@ export default function TickerAnalysisPage() {
   // Check AI availability on mount
   useEffect(() => {
     getAnalysisStatus()
-      .then((status) => setAiAvailable(status.claude_available))
+      .then((status) => setAiAvailable(status.ai_available ?? status.claude_available))
       .catch(() => setAiAvailable(false));
   }, []);
 

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -264,7 +264,9 @@ export interface AIAnalysisResult {
 
 // Analysis service status
 export interface AnalysisStatus {
-  claude_available: boolean;
+  ai_available: boolean;
+  provider: 'anthropic' | 'openai' | null;
+  claude_available: boolean; // backward compat
   cache_available: boolean;
   enrichers: {
     technical: boolean;


### PR DESCRIPTION
## Summary
- Add dual-provider (Anthropic/OpenAI) support to AI stock analysis, matching the existing strategy chat pattern
- Auto-detect provider from env vars with priority: `ANTHROPIC_API_KEY` > `OPENAI_API_KEY`
- Backward-compatible: existing `claude_available` field preserved in API and frontend

## Changes
| File | Description |
|------|-------------|
| `llm/claude_client.py` | Provider auto-detection, `_call_openai()` with retry, null response guard |
| `llm/stock_analyzer.py` | Model default → `None` (auto-detect per provider) |
| `api/services/analysis_service.py` | `is_ai_available()`, `provider` property |
| `api/routers/analysis.py` | `/status` returns `ai_available` + `provider` |
| `web/src/lib/types.ts` | `AnalysisStatus` type updated |
| `web/src/app/[locale]/analysis/[ticker]/page.tsx` | `ai_available ?? claude_available` fallback |

## Test plan
- [x] `OPENAI_API_KEY` only → provider=openai, model=gpt-4o
- [x] Both keys → provider=anthropic (priority)
- [x] No keys → proper error message
- [x] `is_claude_available()` returns Anthropic-specific result
- [x] Frontend build passes clean
- [x] Codex code review: LGTM

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*Reviewed by: Claude Code*