### PR TITLE
feat: localize AI insight responses based on user locale

### DIFF
--- a/api/routers/analysis.py
+++ b/api/routers/analysis.py
@@ -113,7 +113,8 @@ def analyze_stock(request: AnalysisRequest) -> AnalysisResult:
     try:
         result = service.analyze_stock(
             ticker=request.ticker,
-            include_news=request.include_news
+            include_news=request.include_news,
+            locale=request.locale
         )
 
         if result is None:

--- a/api/schemas/analysis.py
+++ b/api/schemas/analysis.py
@@ -79,6 +79,10 @@ class AnalysisRequest(BaseModel):
         default=True,
         description="Whether to include news in analysis"
     )
+    locale: Optional[str] = Field(
+        default=None,
+        description="Response language locale (e.g., 'ko', 'zh'). None or 'en' = English."
+    )
 
 
 class AnalysisResult(BaseModel):

--- a/api/services/analysis_service.py
+++ b/api/services/analysis_service.py
@@ -183,7 +183,8 @@ class AnalysisService:
     def analyze_stock(
         self,
         ticker: str,
-        include_news: bool = True
+        include_news: bool = True,
+        locale: str = None
     ) -> Optional[AnalysisResult]:
         """
         Analyze a single stock using AI (Anthropic or OpenAI).
@@ -194,9 +195,10 @@ class AnalysisService:
         Args:
             ticker: Stock ticker symbol
             include_news: Whether to include news in analysis
+            locale: Response language locale (e.g., "ko", "zh")
 
         Returns:
-            AnalysisResult if Claude API is available, None otherwise
+            AnalysisResult if AI API is available, None otherwise
 
         Raises:
             ValueError: If ticker data cannot be fetched
@@ -207,7 +209,7 @@ class AnalysisService:
 
         try:
             # Use stock analyzer which handles all enrichment and analysis
-            result = self.stock_analyzer.analyze(ticker)
+            result = self.stock_analyzer.analyze(ticker, locale=locale)
 
             return AnalysisResult(
                 ticker=result.ticker,

--- a/llm/claude_client.py
+++ b/llm/claude_client.py
@@ -166,6 +166,12 @@ Be concise but thorough in your reasoning. Focus on actionable insights."""
                     )
         return self._client
 
+    # Language instructions appended to system prompt per locale
+    LOCALE_INSTRUCTIONS = {
+        "ko": "\n\nIMPORTANT: Write ALL text values (reasoning, key_risks, catalysts) in Korean. JSON keys must remain in English.",
+        "zh": "\n\nIMPORTANT: Write ALL text values (reasoning, key_risks, catalysts) in Chinese. JSON keys must remain in English.",
+    }
+
     def analyze_stock(
         self,
         ticker: str,
@@ -174,10 +180,11 @@ Be concise but thorough in your reasoning. Focus on actionable insights."""
         ma_240: float,
         technical: dict,
         fundamental: dict,
-        news: dict = None
+        news: dict = None,
+        locale: str = None
     ) -> AnalysisResult:
         """
-        Analyze a single stock using Claude.
+        Analyze a single stock using AI.
 
         Args:
             ticker: Stock ticker symbol (e.g., "AAPL")
@@ -187,6 +194,7 @@ Be concise but thorough in your reasoning. Focus on actionable insights."""
             technical: Technical indicators dict (e.g., {"rsi": 55, "macd": 0.5})
             fundamental: Fundamental data dict (e.g., {"pe_ratio": 28})
             news: News data dict (optional, e.g., {"sentiment": "positive", "headlines": [...]})
+            locale: Response language locale (e.g., "ko", "zh"). None or "en" = English.
 
         Returns:
             AnalysisResult with valuation, risk, and recommendation
@@ -208,7 +216,11 @@ Be concise but thorough in your reasoning. Focus on actionable insights."""
         logger.info(f"Analyzing stock: {ticker}")
         logger.debug(f"Analysis prompt for {ticker}: {prompt[:200]}...")
 
-        response = self._call_claude(prompt, system=self.SYSTEM_PROMPT)
+        system = self.SYSTEM_PROMPT
+        if locale and locale in self.LOCALE_INSTRUCTIONS:
+            system += self.LOCALE_INSTRUCTIONS[locale]
+
+        response = self._call_claude(prompt, system=system)
 
         return self._parse_analysis_response(ticker, response)
 

--- a/llm/stock_analyzer.py
+++ b/llm/stock_analyzer.py
@@ -259,6 +259,7 @@ class StockAnalyzer:
         name: str = None,
         current_price: float = None,
         ma_240: float = None,
+        locale: str = None,
     ) -> FullAnalysisResult:
         """
         Analyze a single stock (fetches all data automatically).
@@ -268,6 +269,7 @@ class StockAnalyzer:
             name: Company name (optional)
             current_price: Current price (optional, fetched if not provided)
             ma_240: 240-day MA (optional, calculated if not provided)
+            locale: Response language locale (e.g., "ko", "zh")
 
         Returns:
             FullAnalysisResult with complete analysis
@@ -275,20 +277,21 @@ class StockAnalyzer:
         # Enrich stock data
         profile = self.enrich_stock(ticker, name, current_price, ma_240)
 
-        # Analyze with Claude
-        return self.analyze_with_profile(profile)
+        # Analyze with AI
+        return self.analyze_with_profile(profile, locale=locale)
 
-    def analyze_with_profile(self, profile: StockProfile) -> FullAnalysisResult:
+    def analyze_with_profile(self, profile: StockProfile, locale: str = None) -> FullAnalysisResult:
         """
         Analyze a stock using pre-enriched profile.
 
         Args:
             profile: StockProfile with all data
+            locale: Response language locale (e.g., "ko", "zh")
 
         Returns:
             FullAnalysisResult
         """
-        # Call Claude for analysis
+        # Call AI for analysis
         result = self.claude.analyze_stock(
             ticker=profile.ticker,
             name=profile.name,
@@ -297,6 +300,7 @@ class StockAnalyzer:
             technical=profile.technical,
             fundamental=profile.fundamental,
             news=profile.news,
+            locale=locale,
         )
 
         return FullAnalysisResult(

--- a/web/src/app/[locale]/analysis/[ticker]/page.tsx
+++ b/web/src/app/[locale]/analysis/[ticker]/page.tsx
@@ -234,7 +234,7 @@ export default function TickerAnalysisPage() {
     setAiLoading(true);
     setAiError(null);
     try {
-      const result = await analyzeStock(ticker.toUpperCase());
+      const result = await analyzeStock(ticker.toUpperCase(), true, locale);
       setAiResult(result);
     } catch (err) {
       setAiError(err instanceof Error ? err.message : t('aiAnalysisError'));

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -483,10 +483,10 @@ export async function getTickerPrice(ticker: string): Promise<{ ticker: string; 
 /**
  * Run AI analysis on a stock (Claude API, may take 30+ seconds)
  */
-export async function analyzeStock(ticker: string, includeNews = true): Promise<AIAnalysisResult> {
+export async function analyzeStock(ticker: string, includeNews = true, locale?: string): Promise<AIAnalysisResult> {
   return fetchApi<AIAnalysisResult>('/api/analysis/analyze', {
     method: 'POST',
-    body: JSON.stringify({ ticker, include_news: includeNews }),
+    body: JSON.stringify({ ticker, include_news: includeNews, locale }),
   });
 }
 


### PR DESCRIPTION
## Summary
- Pass user locale (ko, zh) from frontend → API → LLM system prompt
- AI analysis text (reasoning, key_risks, catalysts) now returned in user's language
- JSON keys remain in English for parsing; `locale=None` or `en` keeps English (backward compat)

## Changes
| File | Description |
|------|-------------|
| `llm/claude_client.py` | `LOCALE_INSTRUCTIONS` dict + `locale` param on `analyze_stock()` |
| `llm/stock_analyzer.py` | Thread `locale` through `analyze()` → `analyze_with_profile()` |
| `api/schemas/analysis.py` | `locale: Optional[str]` on `AnalysisRequest` |
| `api/routers/analysis.py` | Pass `request.locale` to service |
| `api/services/analysis_service.py` | Pass `locale` to `stock_analyzer.analyze()` |
| `web/src/lib/api.ts` | Add `locale` param to `analyzeStock()` |
| `web/src/app/[locale]/analysis/[ticker]/page.tsx` | Pass `useLocale()` to `analyzeStock()` |

## Security
- `locale` is matched against a fixed dict (`ko`, `zh`) — arbitrary strings are ignored, no prompt injection risk

## Test plan
- [x] `locale=None` → English response (backward compat)
- [x] `LOCALE_INSTRUCTIONS["ko"]` correctly appends Korean instruction
- [x] Frontend build passes
- [x] Codex code review: LGTM

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*Reviewed by: Claude Code*