### PR TITLE
test: strengthen macro QA and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Primary goal: move from idea to executable strategy with one connected toolchain
 | Portfolio | `/[locale]/portfolio` | Holdings, positions, sell rules, PnL treemap, order desk |
 | Watchlist | `/[locale]/watchlist` | Track target stocks, set target prices, buy rules, quick-view popup |
 | Analysis | `/[locale]/analysis` | Chart/indicator context, ticker-based analysis popup |
+| Macro Monitor | `/[locale]/macro` | Combined FX + futures + investor-flow regime monitor |
 | Reports | `/[locale]/reports` | Generated analysis reports with target date tracking |
 | Settings | `/[locale]/settings` | App preferences and configuration |
 
@@ -165,6 +166,9 @@ docker compose up -d db
 | `ANTHROPIC_API_KEY` | AI analysis integration |
 | `FINNHUB_API_KEY` | Optional news/data source |
 | `MARKETAUX_API_KEY` | Optional news/data source |
+| `MACRO_FUTURES_TICKER` | Futures/proxy ticker for macro monitor (default: `069500.KS`) |
+| `MACRO_SPOT_TICKER` | Spot proxy ticker for basis calc (default: `^KS11`) |
+| `MACRO_INVESTOR_FLOW_PATH` | Optional investor-flow JSON adapter path (default: `data/market/investor_flow_latest.json`) |
 
 ## API Endpoints
 
@@ -178,6 +182,7 @@ docker compose up -d db
 | Analysis | `/api/analysis` | Stock analysis and AI insights |
 | Reports | `/api/reports` | Analysis report management |
 | Market | `/api/market` | Market calendar, exchange rates |
+| Macro | `/api/market/macro/*` | Macro bundle and history (`/bundle`, `/history`) |
 | Backtest | `/api/backtest` | Backtest execution |
 
 Full interactive docs: `http://localhost:8001/docs`
@@ -212,6 +217,7 @@ npm --prefix web run check:strategy-i18n
 - **i18n key errors** (`MISSING_MESSAGE`): Run `npm --prefix web run check:strategy-i18n` / `check:condition-i18n`
 - **Strategy run returns empty results**: Confirm universe/condition thresholds are not overly strict
 - **Korean stock names not showing**: Ensure pykrx is installed and KRX master CSVs are up to date
+- **Macro panel shows unknown/unavailable**: check exchange-rate upstream, futures ticker symbol, and `MACRO_INVESTOR_FLOW_PATH` file freshness
 
 ## Roadmap / Limitations
 

--- a/api/services/macro_market_service.py
+++ b/api/services/macro_market_service.py
@@ -261,12 +261,15 @@ class MacroMarketService:
 
     def _parse_window(self, window: str) -> timedelta:
         value = (window or "60m").strip().lower()
-        if value.endswith("m"):
-            return timedelta(minutes=max(int(value[:-1] or "60"), 1))
-        if value.endswith("h"):
-            return timedelta(hours=max(int(value[:-1] or "1"), 1))
-        if value.endswith("d"):
-            return timedelta(days=max(int(value[:-1] or "1"), 1))
+        try:
+            if value.endswith("m"):
+                return timedelta(minutes=max(int(value[:-1] or "60"), 1))
+            if value.endswith("h"):
+                return timedelta(hours=max(int(value[:-1] or "1"), 1))
+            if value.endswith("d"):
+                return timedelta(days=max(int(value[:-1] or "1"), 1))
+        except ValueError:
+            logger.warning("Invalid macro history window: %s. Falling back to 60m.", value)
         return timedelta(minutes=60)
 
     def _age_sec(self, value: Any, now: datetime) -> Optional[int]:

--- a/api/tests/test_macro_market_service.py
+++ b/api/tests/test_macro_market_service.py
@@ -1,0 +1,63 @@
+from datetime import datetime, timezone
+
+from api.services.macro_market_service import MacroMarketService
+
+
+class StubExchangeService:
+    def get_rates(self, base: str = "USD"):
+        assert base == "USD"
+        return {
+            "base": "USD",
+            "rates": {"KRW": 1340.0},
+            "updated_at": datetime(2026, 3, 8, 0, 0, tzinfo=timezone.utc),
+        }
+
+
+class StubMarketService:
+    def get_quote(self, ticker: str):
+        if ticker == "069500.KS":
+            return {
+                "ticker": ticker,
+                "current_price": 402.0,
+                "change_pct": -0.4,
+                "timestamp": "2026-03-08T00:00:00+00:00",
+            }
+        if ticker == "^KS11":
+            return {
+                "ticker": ticker,
+                "current_price": 400.0,
+                "change_pct": -0.2,
+                "timestamp": "2026-03-08T00:00:00+00:00",
+            }
+        return None
+
+
+def test_bundle_returns_regime_and_history_point(tmp_path):
+    svc = MacroMarketService(
+        market_service=StubMarketService(),
+        exchange_service=StubExchangeService(),
+    )
+    svc.investor_flow_path = tmp_path / "investor_flow_latest.json"
+
+    bundle = svc.get_bundle()
+
+    assert "signal" in bundle
+    assert bundle["signal"]["regime"] in {"risk_on", "neutral", "risk_off", "unknown"}
+
+    history = svc.get_history("60m")
+    assert history["window"] == "60m"
+    assert len(history["points"]) >= 1
+
+
+def test_invalid_window_falls_back_without_crash(tmp_path):
+    svc = MacroMarketService(
+        market_service=StubMarketService(),
+        exchange_service=StubExchangeService(),
+    )
+    svc.investor_flow_path = tmp_path / "investor_flow_latest.json"
+
+    svc.get_bundle()
+    history = svc.get_history("x5m")
+
+    assert history["window"] == "x5m"
+    assert isinstance(history["points"], list)


### PR DESCRIPTION
## Summary
- harden macro history window parsing to avoid crashes on malformed window values
- add unit tests for macro bundle/history behavior and invalid-window fallback
- document macro monitor route/env vars/api/troubleshooting in README

## Test plan
- [x] /Users/miyoungjang/Repository/quant/quant-investment3/venv/bin/python -m pytest /Users/miyoungjang/Repository/quant/quant-investment3/api/tests/test_macro_market_service.py /Users/miyoungjang/Repository/quant/quant-investment3/api/tests/test_market.py
- [x] cd /Users/miyoungjang/Repository/quant/quant-investment3/web && npm run lint

## Links
- closes #1119

🤖 Generated with [Claude Code](https://claude.com/claude-code)