### PR TITLE
feat(macro): add units and data source labels

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -147,6 +147,12 @@
     "historyUnavailable": "Macro history is unavailable",
     "staleWarning": "Stale",
     "changePct": "Change",
+    "fxUnit": "₩/USD",
+    "futuresUnit": "pt",
+    "flowUnit": "KRW",
+    "fxSource": "Frankfurter (ECB)",
+    "futuresSource": "KODEX 200 vs KOSPI",
+    "flowSource": "Naver Finance",
     "time": "Time",
     "noHistory": "No history data",
     "bundleUnavailable": "Macro bundle endpoint is unavailable"

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -147,6 +147,12 @@
     "historyUnavailable": "매크로 히스토리를 불러올 수 없습니다",
     "staleWarning": "지연",
     "changePct": "등락",
+    "fxUnit": "₩/USD",
+    "futuresUnit": "pt",
+    "flowUnit": "억원",
+    "fxSource": "Frankfurter (ECB)",
+    "futuresSource": "KODEX 200 vs KOSPI",
+    "flowSource": "네이버 금융",
     "time": "시간",
     "noHistory": "히스토리 데이터 없음",
     "bundleUnavailable": "매크로 번들 API를 사용할 수 없습니다"

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -147,6 +147,12 @@
     "historyUnavailable": "宏观历史数据不可用",
     "staleWarning": "延迟",
     "changePct": "涨跌",
+    "fxUnit": "₩/USD",
+    "futuresUnit": "pt",
+    "flowUnit": "韩元",
+    "fxSource": "Frankfurter (ECB)",
+    "futuresSource": "KODEX 200 vs KOSPI",
+    "flowSource": "Naver Finance",
     "time": "时间",
     "noHistory": "暂无历史数据",
     "bundleUnavailable": "宏观聚合接口不可用"

--- a/web/src/app/[locale]/macro/page.tsx
+++ b/web/src/app/[locale]/macro/page.tsx
@@ -188,6 +188,8 @@ export default function MacroPage() {
           title="USD/KRW"
           icon={<DollarSign className="h-4 w-4" />}
           value={formatNumber(bundleQuery.data?.fx.value ?? null, locale, 2)}
+          unit={t('fxUnit')}
+          source={t('fxSource')}
           items={[
             { label: t('changePct'), value: formatPercent(bundleQuery.data?.fx.change_pct ?? null) },
           ]}
@@ -199,6 +201,8 @@ export default function MacroPage() {
           title={t('futures')}
           icon={<CandlestickChart className="h-4 w-4" />}
           value={formatNumber(bundleQuery.data?.futures.value ?? null, locale, 0)}
+          unit={t('futuresUnit')}
+          source={t('futuresSource')}
           items={[
             { label: t('basis'), value: formatNumber(bundleQuery.data?.futures.basis ?? null, locale, 2) },
             { label: t('changePct'), value: formatPercent(bundleQuery.data?.futures.change_pct ?? null) },
@@ -215,6 +219,8 @@ export default function MacroPage() {
               ? formatNumber(bundleQuery.data.flow.foreign_net, locale, 0)
               : t('flowUnavailable')
           }
+          unit={t('flowUnit')}
+          source={t('flowSource')}
           items={[
             { label: t('institution'), value: formatNumber(bundleQuery.data?.flow.institution_net ?? null, locale, 0) },
             { label: t('individual'), value: formatNumber(bundleQuery.data?.flow.individual_net ?? null, locale, 0) },
@@ -386,6 +392,8 @@ function MetricCard({
   title,
   icon,
   value,
+  unit,
+  source,
   items,
   ageSec,
   ageLabel,
@@ -394,6 +402,8 @@ function MetricCard({
   title: string;
   icon: ReactNode;
   value: string;
+  unit: string;
+  source: string;
   items: { label: string; value: string }[];
   ageSec: number | null;
   ageLabel: string;
@@ -416,15 +426,23 @@ function MetricCard({
             </span>
           )}
         </div>
-        <p className="text-xl font-semibold text-[var(--foreground)]">{value}</p>
+        <p className="text-xl font-semibold text-[var(--foreground)]">
+          {value}
+          {/\d/.test(value) && (
+            <span className="ml-1 text-sm font-normal text-[var(--foreground-muted)]">{unit}</span>
+          )}
+        </p>
         {items.map((item) => (
           <p key={item.label} className="text-sm text-[var(--foreground-muted)]">
             {item.label}: {item.value}
           </p>
         ))}
-        <p className={`text-xs ${isStale ? 'text-amber-600 dark:text-amber-400' : 'text-[var(--foreground-muted)]'}`}>
-          {ageLabel}
-        </p>
+        <div className="flex items-center justify-between">
+          <p className={`text-xs ${isStale ? 'text-amber-600 dark:text-amber-400' : 'text-[var(--foreground-muted)]'}`}>
+            {ageLabel}
+          </p>
+          <p className="text-[10px] text-[var(--foreground-muted)] opacity-60">{source}</p>
+        </div>
       </div>
     </Card>
   );


### PR DESCRIPTION
## Summary
- Add **unit suffix** (₩/USD, pt, 억원) next to numeric values in metric cards
- Add **data source attribution** in bottom-right corner of each card:
  - USD/KRW → `Frankfurter (ECB)`
  - 선물 → `KODEX 200 vs KOSPI`
  - 수급 → `네이버 금융` / `Naver Finance`
- Units hidden when value is non-numeric (e.g. "미수집")
- i18n: 6 keys added across en/ko/zh (`fxUnit`, `futuresUnit`, `flowUnit`, `fxSource`, `futuresSource`, `flowSource`)

## Test plan
- [x] `npm run build` passes
- [x] Visual verification on localhost:3002/ko/macro
- [x] Unit not shown for text values ("미수집")
- [x] Sources render in correct locale

🤖 Generated with [Claude Code](https://claude.com/claude-code)