### PR TITLE
feat(macro): add KODEX 200 30-day candlestick chart

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -153,6 +153,9 @@
     "fxSource": "Frankfurter (ECB)",
     "futuresSource": "KODEX 200 vs KOSPI",
     "flowSource": "Naver Finance",
+    "futuresChartTitle": "KODEX 200 · 30 Days",
+    "futuresChartLoading": "Loading futures chart...",
+    "futuresChartError": "Failed to load futures chart",
     "time": "Time",
     "noHistory": "No history data",
     "bundleUnavailable": "Macro bundle endpoint is unavailable"

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -153,6 +153,9 @@
     "fxSource": "Frankfurter (ECB)",
     "futuresSource": "KODEX 200 vs KOSPI",
     "flowSource": "네이버 금융",
+    "futuresChartTitle": "KODEX 200 · 최근 30일",
+    "futuresChartLoading": "선물 차트 로딩 중...",
+    "futuresChartError": "선물 차트를 불러올 수 없습니다",
     "time": "시간",
     "noHistory": "히스토리 데이터 없음",
     "bundleUnavailable": "매크로 번들 API를 사용할 수 없습니다"

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -153,6 +153,9 @@
     "fxSource": "Frankfurter (ECB)",
     "futuresSource": "KODEX 200 vs KOSPI",
     "flowSource": "Naver Finance",
+    "futuresChartTitle": "KODEX 200 · 近30天",
+    "futuresChartLoading": "加载期货图表...",
+    "futuresChartError": "无法加载期货图表",
     "time": "时间",
     "noHistory": "暂无历史数据",
     "bundleUnavailable": "宏观聚合接口不可用"

--- a/web/src/app/[locale]/macro/page.tsx
+++ b/web/src/app/[locale]/macro/page.tsx
@@ -3,7 +3,8 @@
 import { useLocale, useTranslations } from 'next-intl';
 import { useMemo, useState, type ReactNode } from 'react';
 import { Card } from '@/components/ui';
-import { useMacroBundle, useMacroHistory } from '@/hooks/useMarket';
+import { useMacroBundle, useMacroHistory, useOhlcv } from '@/hooks/useMarket';
+import CandleChart from '@/components/charts/CandleChart';
 import { formatPercent } from '@/lib/format';
 import {
   Activity,
@@ -93,6 +94,8 @@ export default function MacroPage() {
   const bundleQuery = useMacroBundle();
   const [historyWindow, setHistoryWindow] = useState<WindowOption>('60m');
   const historyQuery = useMacroHistory(historyWindow);
+  const futuresTicker = bundleQuery.data?.futures.symbol || '069500.KS';
+  const futuresOhlcv = useOhlcv(futuresTicker, 30);
 
   const regime = bundleQuery.data?.signal.regime ?? 'unknown';
 
@@ -145,6 +148,7 @@ export default function MacroPage() {
           onClick={() => {
             void bundleQuery.refetch();
             void historyQuery.refetch();
+            void futuresOhlcv.refetch();
           }}
           className="inline-flex items-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--background-secondary)] px-3 py-2 text-sm font-medium text-[var(--foreground)] hover:bg-[var(--background)]"
         >
@@ -341,6 +345,21 @@ export default function MacroPage() {
               </ComposedChart>
             </ResponsiveContainer>
           </div>
+        )}
+      </Card>
+
+      {/* Futures OHLCV Chart */}
+      <Card>
+        <h3 className="mb-4 text-base font-semibold text-[var(--foreground)]">{t('futuresChartTitle')}</h3>
+        {futuresOhlcv.isLoading ? (
+          <p className="text-sm text-[var(--foreground-muted)]">{t('futuresChartLoading')}</p>
+        ) : futuresOhlcv.isError || !futuresOhlcv.data?.data?.length ? (
+          <p className="inline-flex items-center gap-2 text-sm text-amber-600 dark:text-amber-400">
+            <ShieldAlert className="h-4 w-4" />
+            {t('futuresChartError')}
+          </p>
+        ) : (
+          <CandleChart data={futuresOhlcv.data.data} height={320} showVolume showMA />
         )}
       </Card>
 

--- a/web/src/hooks/useMarket.ts
+++ b/web/src/hooks/useMarket.ts
@@ -2,7 +2,7 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { queryKeys } from '@/lib/queryKeys';
-import { getMacroBundle, getMacroHistory, searchTickers } from '@/lib/api';
+import { getMacroBundle, getMacroHistory, getOhlcv, searchTickers } from '@/lib/api';
 
 export function useSearchTickers(query: string) {
   return useQuery({
@@ -27,5 +27,14 @@ export function useMacroHistory(window: string = '60m') {
     queryKey: queryKeys.market.macroHistory(window),
     queryFn: () => getMacroHistory(window),
     staleTime: 30 * 1000,
+  });
+}
+
+export function useOhlcv(ticker: string, days = 30) {
+  return useQuery({
+    queryKey: queryKeys.market.ohlcv(ticker, days),
+    queryFn: () => getOhlcv(ticker, days),
+    staleTime: 60 * 60 * 1000, // 1 hour — daily OHLCV doesn't change often
+    enabled: !!ticker,
   });
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -51,6 +51,7 @@ import type {
   SellRuleUpdate,
   SellRuleEvaluateResult,
   SellRulePreset,
+  OHLCVData,
 } from './types';
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
@@ -471,6 +472,19 @@ export async function getMacroBundle(): Promise<MacroBundle> {
  */
 export async function getMacroHistory(window: string = '60m'): Promise<MacroHistoryResponse> {
   return fetchApi<MacroHistoryResponse>(`/api/market/macro/history?window=${encodeURIComponent(window)}`);
+}
+
+/**
+ * Get OHLCV data for a ticker
+ */
+export async function getOhlcv(ticker: string, days = 30): Promise<{ ticker: string; data: OHLCVData[]; period_days: number }> {
+  const raw = await fetchApi<{ ticker: string; data: Array<{ date: string; open: number; high: number; low: number; close: number; volume: number }>; period_days: number }>(
+    `/api/market/ohlcv/${encodeURIComponent(ticker)}?days=${days}`
+  );
+  return {
+    ...raw,
+    data: raw.data.map((d) => ({ time: d.date, open: d.open, high: d.high, low: d.low, close: d.close, volume: d.volume })),
+  };
 }
 
 /**

--- a/web/src/lib/queryKeys.ts
+++ b/web/src/lib/queryKeys.ts
@@ -22,6 +22,7 @@ export const queryKeys = {
     search: (query: string) => [...queryKeys.market.all, 'search', query] as const,
     macroBundle: () => [...queryKeys.market.all, 'macro-bundle'] as const,
     macroHistory: (window: string) => [...queryKeys.market.all, 'macro-history', window] as const,
+    ohlcv: (ticker: string, days: number) => [...queryKeys.market.all, 'ohlcv', ticker, days] as const,
   },
   strategy: {
     all: ['strategy'] as const,


### PR DESCRIPTION
## Summary
- Reuses existing `/api/market/ohlcv/{ticker}` endpoint and `CandleChart` component to display KODEX 200 ETF 30-day price history on the macro monitor page
- Adds `getOhlcv()` API function, `useOhlcv()` React Query hook, and i18n keys (en/ko/zh)
- Includes chart in refresh button handler

## Test plan
- [x] `npm run build` passes
- [x] Visual verification: candlestick chart renders with volume and moving averages
- [x] No console errors, all API calls succeed (200 OK)
- [x] Codex code review passed (2 minor issues fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*Reviewed by: Claude Code*