### PR TITLE
fix(analysis): news section empty/incomplete in popup mode

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -3230,6 +3230,8 @@
     "loadPrompt": "Load news articles with sentiment analysis",
     "loadButton": "Load News",
     "noArticles": "No news articles available",
+    "loadError": "Failed to load news. Please try again.",
+    "retry": "Retry",
     "showMore": "Show {count} more",
     "showLess": "Show less"
   },

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -3230,6 +3230,8 @@
     "loadPrompt": "감성 분석이 포함된 뉴스 기사를 불러옵니다",
     "loadButton": "뉴스 불러오기",
     "noArticles": "뉴스 기사가 없습니다",
+    "loadError": "뉴스를 불러오지 못했습니다. 다시 시도해 주세요.",
+    "retry": "다시 시도",
     "showMore": "{count}개 더 보기",
     "showLess": "접기"
   },

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -3230,6 +3230,8 @@
     "loadPrompt": "加载带情感分析的新闻文章",
     "loadButton": "加载新闻",
     "noArticles": "暂无新闻文章",
+    "loadError": "加载新闻失败，请重试。",
+    "retry": "重试",
     "showMore": "显示更多 {count} 条",
     "showLess": "收起"
   },

--- a/web/src/app/[locale]/analysis/[ticker]/page.tsx
+++ b/web/src/app/[locale]/analysis/[ticker]/page.tsx
@@ -131,6 +131,7 @@ export default function TickerAnalysisPage() {
   // News (opt-in)
   const [newsLoading, setNewsLoading] = useState(false);
   const [newsLoaded, setNewsLoaded] = useState(false);
+  const [newsError, setNewsError] = useState<string | null>(null);
 
   // Strategy Context
   const [screeningResult, setScreeningResult] = useState<ScreeningResult | null>(null);
@@ -214,6 +215,8 @@ export default function TickerAnalysisPage() {
 
   const handlePeriodChange = (period: PeriodOption) => {
     setSelectedPeriod(period);
+    setNewsError(null);
+    setNewsLoaded(false);
   };
 
   const handleAIAnalysis = async () => {
@@ -231,12 +234,13 @@ export default function TickerAnalysisPage() {
 
   const handleLoadNews = async () => {
     setNewsLoading(true);
+    setNewsError(null);
     try {
       const data = await getTickerAnalysis(ticker.toUpperCase(), selectedPeriod, true);
       setTickerData(data);
       setNewsLoaded(true);
-    } catch {
-      // News load failure is non-critical
+    } catch (err) {
+      setNewsError(err instanceof Error ? err.message : 'error');
     } finally {
       setNewsLoading(false);
     }
@@ -337,7 +341,7 @@ export default function TickerAnalysisPage() {
     strategy: false,
     ai: false,
     companyInfo: false,
-    news: false,
+    news: true,
   });
   const [showAdvancedSections, setShowAdvancedSections] = useState(!isPopup);
 
@@ -727,6 +731,8 @@ export default function TickerAnalysisPage() {
                     sentimentSummary={tickerData.news?.sentiment_summary}
                     onLoadNews={!newsLoaded ? handleLoadNews : undefined}
                     isLoading={newsLoading}
+                    error={newsError}
+                    onRetry={handleLoadNews}
                   />
                 </CollapsibleSection>
 

--- a/web/src/components/analysis/NewsCard.tsx
+++ b/web/src/components/analysis/NewsCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { Newspaper, ExternalLink } from 'lucide-react';
+import { Newspaper, ExternalLink, AlertTriangle, RefreshCw } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { Button } from '@/components/ui';
 import type { NewsArticle } from '@/lib/types';
@@ -11,6 +11,8 @@ interface NewsCardProps {
   sentimentSummary?: string;
   onLoadNews?: () => void;
   isLoading?: boolean;
+  error?: string | null;
+  onRetry?: () => void;
   className?: string;
 }
 
@@ -46,6 +48,8 @@ export default function NewsCard({
   sentimentSummary,
   onLoadNews,
   isLoading = false,
+  error = null,
+  onRetry,
   className = '',
 }: NewsCardProps) {
   const t = useTranslations('news');
@@ -72,7 +76,22 @@ export default function NewsCard({
         )}
       </div>
 
-      {!hasArticles && onLoadNews && (
+      {error && !hasArticles && (
+        <div className="flex flex-col items-center py-6 gap-3">
+          <div className="flex items-center gap-2 text-amber-600 dark:text-amber-400">
+            <AlertTriangle className="h-4 w-4" />
+            <p className="text-sm">{t('loadError')}</p>
+          </div>
+          {onRetry && (
+            <Button variant="outline" size="sm" onClick={onRetry} isLoading={isLoading}>
+              <RefreshCw className="h-3.5 w-3.5 mr-1" />
+              {t('retry')}
+            </Button>
+          )}
+        </div>
+      )}
+
+      {!error && !hasArticles && onLoadNews && (
         <div className="flex flex-col items-center py-6 gap-3">
           <p className="text-sm text-[var(--foreground-muted)]">{t('loadPrompt')}</p>
           <Button
@@ -86,7 +105,7 @@ export default function NewsCard({
         </div>
       )}
 
-      {!hasArticles && !onLoadNews && (
+      {!error && !hasArticles && !onLoadNews && (
         <p className="text-sm text-[var(--foreground-muted)] text-center py-4">{t('noArticles')}</p>
       )}
 


### PR DESCRIPTION
## Summary
- Surface news load errors with retry button (was silently swallowed)
- Pre-expand news section in popup mode (3 clicks → 2 to see news)
- Reset news error/loaded state on period change to prevent stale display
- Guard error UI to only show when no articles exist

Closes #1132

## Test plan
- [x] `npm run build` passes
- [x] Popup mode: "고급 정보 보기" → News section already expanded with "뉴스 불러오기"
- [x] Non-popup mode: behavior unchanged, News section visible inline
- [x] Codex review passed (2 issues fixed: stale error state, hardcoded fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*Reviewed by: Claude Code*