### PR TITLE
fix(macro): improve timeline empty state for accumulating data

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -158,6 +158,7 @@
     "futuresChartError": "Failed to load futures chart",
     "time": "Time",
     "noHistory": "No history data",
+    "historyAccumulating": "Data is still accumulating — try a shorter time range",
     "bundleUnavailable": "Macro bundle endpoint is unavailable",
     "entryAssessment": "Market Entry Assessment",
     "entry_buy_favorable": "Buy Favorable",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -158,6 +158,7 @@
     "futuresChartError": "선물 차트를 불러올 수 없습니다",
     "time": "시간",
     "noHistory": "히스토리 데이터 없음",
+    "historyAccumulating": "데이터가 아직 쌓이는 중입니다 — 더 짧은 시간 범위를 선택하세요",
     "bundleUnavailable": "매크로 번들 API를 사용할 수 없습니다",
     "entryAssessment": "시장 진입 판단",
     "entry_buy_favorable": "매수 적기",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -158,6 +158,7 @@
     "futuresChartError": "无法加载期货图表",
     "time": "时间",
     "noHistory": "暂无历史数据",
+    "historyAccumulating": "数据仍在积累中 — 请尝试更短的时间范围",
     "bundleUnavailable": "宏观聚合接口不可用",
     "entryAssessment": "市场进入评估",
     "entry_buy_favorable": "买入时机",

--- a/web/src/app/[locale]/macro/page.tsx
+++ b/web/src/app/[locale]/macro/page.tsx
@@ -285,8 +285,11 @@ export default function MacroPage() {
             </p>
           </div>
         ) : (!historyQuery.data?.points || historyQuery.data.points.length === 0) ? (
-          <div className="flex h-72 items-center justify-center">
+          <div className="flex h-72 flex-col items-center justify-center gap-2">
             <p className="text-sm text-[var(--foreground-muted)]">{t('noHistory')}</p>
+            {historyWindow !== '60m' && (
+              <p className="text-xs text-[var(--foreground-muted)]">{t('historyAccumulating')}</p>
+            )}
           </div>
         ) : (
           <div className="h-72">


### PR DESCRIPTION
## Summary
- When timeline has no data for 6h/1d range, show guidance: "Data is still accumulating — try a shorter time range"
- This is expected behavior: history collector runs every 60s, so 6h of data takes 6 hours to accumulate
- i18n keys added for en/ko/zh

Closes #1137

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] Select 6h/1d when server just started → shows accumulating message
- [ ] Select 1h → shows available data points
- [ ] All 3 buttons remain visible after switching

🤖 Generated with [Claude Code](https://claude.com/claude-code)