### PR TITLE
feat(macro): show change % on cards + wider timeline ranges (#1145)

### DIFF
--- a/api/services/macro_market_service.py
+++ b/api/services/macro_market_service.py
@@ -39,7 +39,7 @@ class MacroMarketService:
             os.getenv("MACRO_INVESTOR_FLOW_PATH", "data/market/investor_flow_latest.json")
         )
 
-        self._history: Deque[Dict[str, Any]] = deque(maxlen=1000)
+        self._history: Deque[Dict[str, Any]] = deque(maxlen=50_000)
         self._last_fx_value: Optional[float] = None
 
         # Session-start FX baseline for daily change calculation
@@ -79,18 +79,24 @@ class MacroMarketService:
         delta = self._parse_window(window)
         min_ts = now - delta
 
-        points = [
-            {
+        # Reverse scan: deque is chronological, so iterate from newest.
+        # Stop early once we pass the time boundary.
+        points = []
+        for p in reversed(self._history):
+            dt = self._safe_datetime(p.get("timestamp"))
+            if not dt:
+                continue
+            if dt < min_ts:
+                break
+            points.append({
                 "timestamp": p["timestamp"],
                 "fx_value": p.get("fx_value"),
                 "futures_value": p.get("futures_value"),
                 "foreign_net": p.get("foreign_net"),
                 "macro_score": p.get("macro_score"),
                 "regime": p.get("regime", "unknown"),
-            }
-            for p in self._history
-            if self._safe_datetime(p.get("timestamp")) and self._safe_datetime(p.get("timestamp")) >= min_ts
-        ]
+            })
+        points.reverse()  # restore chronological order
 
         return {"window": window, "points": points}
 

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -136,6 +136,8 @@
     "window1h": "1H",
     "window6h": "6H",
     "window1d": "1D",
+    "window1w": "1W",
+    "window1m": "1M",
     "futures": "Futures",
     "basis": "Basis",
     "investorFlow": "Investor Flow",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -136,6 +136,8 @@
     "window1h": "1시간",
     "window6h": "6시간",
     "window1d": "1일",
+    "window1w": "1주",
+    "window1m": "1개월",
     "futures": "선물",
     "basis": "베이시스",
     "investorFlow": "수급",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -136,6 +136,8 @@
     "window1h": "1小时",
     "window6h": "6小时",
     "window1d": "1天",
+    "window1w": "1周",
+    "window1m": "1月",
     "futures": "期货",
     "basis": "基差",
     "investorFlow": "资金流向",

--- a/web/src/app/[locale]/macro/page.tsx
+++ b/web/src/app/[locale]/macro/page.tsx
@@ -92,7 +92,7 @@ const REGIME_COLORS: Record<MacroRegime, string> = {
   unknown: 'rgba(156, 163, 175, 0.04)',
 };
 
-type WindowOption = '60m' | '6h' | '1d';
+type WindowOption = '60m' | '6h' | '1d' | '7d' | '30d';
 
 // ---------------------------------------------------------------------------
 // Main Page
@@ -207,10 +207,9 @@ export default function MacroPage() {
           icon={<DollarSign className="h-4 w-4" />}
           value={formatNumber(bundleQuery.data?.fx.value ?? null, locale, 2)}
           unit={t('fxUnit')}
+          changePct={bundleQuery.data?.fx.change_pct ?? null}
           source={t('fxSource')}
-          items={[
-            { label: t('changePct'), value: formatPercent(bundleQuery.data?.fx.change_pct ?? null) },
-          ]}
+          items={[]}
           ageSec={bundleQuery.data?.freshness.fx_age_sec ?? null}
           ageLabel={t('ageSec', { age: bundleQuery.data?.freshness.fx_age_sec ?? '-' })}
           staleLabel={t('staleWarning')}
@@ -221,10 +220,10 @@ export default function MacroPage() {
           icon={<CandlestickChart className="h-4 w-4" />}
           value={formatNumber(bundleQuery.data?.futures.value ?? null, locale, 0)}
           unit={t('futuresUnit')}
+          changePct={bundleQuery.data?.futures.change_pct ?? null}
           source={t('futuresSource')}
           items={[
             { label: t('basis'), value: bundleQuery.data?.futures.basis != null ? `${bundleQuery.data.futures.basis > 0 ? '+' : ''}${formatNumber(bundleQuery.data.futures.basis, locale, 3)}%` : '-' },
-            { label: t('changePct'), value: formatPercent(bundleQuery.data?.futures.change_pct ?? null) },
           ]}
           ageSec={bundleQuery.data?.freshness.futures_age_sec ?? null}
           ageLabel={t('ageSec', { age: bundleQuery.data?.freshness.futures_age_sec ?? '-' })}
@@ -264,20 +263,23 @@ export default function MacroPage() {
             </div>
           </div>
           <div className="inline-flex shrink-0 rounded-lg border border-[var(--border)] overflow-hidden">
-            {(['60m', '6h', '1d'] as WindowOption[]).map((w) => (
-              <button
-                key={w}
-                type="button"
-                onClick={() => setHistoryWindow(w)}
-                className={`px-3 py-1.5 text-xs font-medium transition-colors ${
-                  historyWindow === w
-                    ? 'bg-[var(--accent)] text-white'
-                    : 'bg-[var(--background-secondary)] text-[var(--foreground-muted)] hover:bg-[var(--background)]'
-                }`}
-              >
-                {t(`window${w === '60m' ? '1h' : w === '6h' ? '6h' : '1d'}`)}
-              </button>
-            ))}
+            {(['60m', '6h', '1d', '7d', '30d'] as WindowOption[]).map((w) => {
+              const labelMap: Record<WindowOption, string> = { '60m': '1h', '6h': '6h', '1d': '1d', '7d': '1w', '30d': '1m' };
+              return (
+                <button
+                  key={w}
+                  type="button"
+                  onClick={() => setHistoryWindow(w)}
+                  className={`px-3 py-1.5 text-xs font-medium transition-colors ${
+                    historyWindow === w
+                      ? 'bg-[var(--accent)] text-white'
+                      : 'bg-[var(--background-secondary)] text-[var(--foreground-muted)] hover:bg-[var(--background)]'
+                  }`}
+                >
+                  {t(`window${labelMap[w]}`)}
+                </button>
+              );
+            })}
           </div>
         </div>
 
@@ -466,6 +468,7 @@ function MetricCard({
   icon,
   value,
   unit,
+  changePct,
   source,
   items,
   ageSec,
@@ -477,6 +480,7 @@ function MetricCard({
   icon: ReactNode;
   value: string;
   unit: string;
+  changePct?: number | null;
   source: string;
   items: { label: string; value: string }[];
   ageSec: number | null;
@@ -501,12 +505,19 @@ function MetricCard({
             </span>
           )}
         </div>
-        <p className="text-xl font-semibold text-[var(--foreground)]">
-          {value}
-          {/\d/.test(value) && (
-            <span className="ml-1 text-sm font-normal text-[var(--foreground-muted)]">{unit}</span>
+        <div className="flex items-baseline gap-2">
+          <p className="text-xl font-semibold text-[var(--foreground)]">
+            {value}
+            {/\d/.test(value) && (
+              <span className="ml-1 text-sm font-normal text-[var(--foreground-muted)]">{unit}</span>
+            )}
+          </p>
+          {changePct != null && (
+            <span className={`text-sm font-medium ${changePct > 0 ? 'text-red-500' : changePct < 0 ? 'text-emerald-500' : 'text-[var(--foreground-muted)]'}`}>
+              {changePct > 0 ? '+' : ''}{changePct.toFixed(2)}%
+            </span>
           )}
-        </p>
+        </div>
         {items.map((item) => (
           <p key={item.label} className="text-sm text-[var(--foreground-muted)]">
             {item.label}: {item.value}


### PR DESCRIPTION
## Summary
- Add prominent change_pct display on FX and futures MetricCards (red for positive, green for negative)
- Add 1W and 1M timeline range options alongside existing 1H/6H/1D
- Increase history deque from 1000 to 50000 entries for wider range support
- Optimize `get_history()` with reverse scan + early termination (Codex review feedback)
- Add `window1w`/`window1m` i18n keys (en/ko/zh)

Closes #1145

## Test plan
- [ ] Verify FX card shows change % (e.g., +0.20%) next to the rate value
- [ ] Verify futures card shows change % next to the price
- [ ] Verify flow card does NOT show change % (not applicable)
- [ ] Verify 1W and 1M buttons appear in timeline range selector
- [ ] `npx tsc --noEmit` passes
- [ ] Python syntax check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)