### PR TITLE
fix(macro): improve SignalBar readability and FX sensitivity

### DIFF
--- a/api/services/macro_market_service.py
+++ b/api/services/macro_market_service.py
@@ -321,7 +321,7 @@ class MacroMarketService:
         now: datetime,
     ) -> Dict[str, Any]:
         # Raw component scores in [-1, +1]
-        fx_raw = self._clip((self._to_float(fx.get("change_pct")) or 0.0) / 0.5, -1.0, 1.0)
+        fx_raw = self._clip((self._to_float(fx.get("change_pct")) or 0.0) / 1.5, -1.0, 1.0)
         fut_change = self._to_float(futures.get("change_pct"))
         fut_basis = self._to_float(futures.get("basis"))  # now in % (premium/discount)
         futures_raw = self._clip((-(fut_change or 0.0) / 3.0) + (-(fut_basis or 0.0) / 1.0), -1.0, 1.0)

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -161,6 +161,7 @@
     "time": "Time",
     "noHistory": "No history data",
     "historyAccumulating": "Data is still accumulating — try a shorter time range",
+    "marketClosedHint": "Market is closed — values will update when trading resumes",
     "regimeRiskOn": "Risk-On",
     "regimeRiskOff": "Risk-Off",
     "regimeNeutral": "Neutral",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -161,6 +161,7 @@
     "time": "시간",
     "noHistory": "히스토리 데이터 없음",
     "historyAccumulating": "데이터가 아직 쌓이는 중입니다 — 더 짧은 시간 범위를 선택하세요",
+    "marketClosedHint": "장이 닫혀 있어 동일한 값이 표시됩니다 — 거래 시간에 업데이트됩니다",
     "regimeRiskOn": "위험 선호",
     "regimeRiskOff": "위험 회피",
     "regimeNeutral": "중립",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -161,6 +161,7 @@
     "time": "时间",
     "noHistory": "暂无历史数据",
     "historyAccumulating": "数据仍在积累中 — 请尝试更短的时间范围",
+    "marketClosedHint": "市场已关闭 — 交易时间恢复后数据将更新",
     "regimeRiskOn": "风险偏好",
     "regimeRiskOff": "风险规避",
     "regimeNeutral": "中性",

--- a/web/src/app/[locale]/macro/page.tsx
+++ b/web/src/app/[locale]/macro/page.tsx
@@ -387,6 +387,21 @@ export default function MacroPage() {
             </ResponsiveContainer>
           </div>
         )}
+        {(() => {
+          const pts = historyQuery.data?.points ?? [];
+          if (pts.length >= 2) {
+            const fxVals = pts.map(p => p.fx_value).filter((v): v is number => v != null);
+            const isFlat = fxVals.length >= 2 && new Set(fxVals).size === 1;
+            if (isFlat) {
+              return (
+                <p className="mt-2 text-center text-xs text-[var(--foreground-muted)]">
+                  {t('marketClosedHint')}
+                </p>
+              );
+            }
+          }
+          return null;
+        })()}
       </Card>
 
       {/* Futures OHLCV Chart */}
@@ -419,7 +434,6 @@ export default function MacroPage() {
 // ---------------------------------------------------------------------------
 
 function signalLabel(value: number, t: (key: string) => string): string {
-  // value in [-1, 1]. Negative = risk-on (buying pressure), positive = risk-off (selling pressure)
   if (value <= -0.7) return t('signalStrongBuy');
   if (value <= -0.3) return t('signalBuy');
   if (value >= 0.7) return t('signalStrongSell');
@@ -428,26 +442,22 @@ function signalLabel(value: number, t: (key: string) => string): string {
 }
 
 function SignalBar({ label, value, nullLabel, t }: { label: string; value: number | null; nullLabel: string; t: (key: string) => string }) {
-  // value is in [-1, 1] range. Positive = risk-off contribution, negative = risk-on.
   const pct = value != null ? Math.abs(value) * 100 : 0;
   const isNull = value == null;
   const isPositive = (value ?? 0) >= 0;
   const desc = !isNull ? signalLabel(value!, t) : null;
 
   return (
-    <div className="space-y-1">
+    <div className="space-y-1.5">
       <div className="flex items-center justify-between text-xs">
         <span className="text-[var(--foreground-muted)]">{label}</span>
-        <span className="font-mono text-[var(--foreground)]">
-          {isNull ? nullLabel : (
-            <span className="inline-flex items-center gap-1.5">
-              <span>{value!.toFixed(2)}</span>
-              <span className={`text-[10px] font-sans ${isPositive ? 'text-red-400' : 'text-emerald-400'}`}>{desc}</span>
-            </span>
-          )}
-        </span>
+        {isNull ? (
+          <span className="text-[var(--foreground-muted)]">{nullLabel}</span>
+        ) : (
+          <span className={`font-medium ${isPositive ? 'text-red-500' : 'text-emerald-500'}`}>{desc}</span>
+        )}
       </div>
-      <div className="relative h-2 rounded-full bg-[var(--background)] overflow-hidden">
+      <div className="relative h-2.5 rounded-full bg-[var(--background)] overflow-hidden">
         <div
           className={`absolute top-0 h-full rounded-full transition-all ${
             isNull ? 'bg-gray-300 dark:bg-gray-600' : isPositive ? 'bg-red-400' : 'bg-emerald-400'


### PR DESCRIPTION
## Summary
- Remove confusing raw score numbers (e.g., "1.00") from SignalBar — now shows only human-readable labels like "강한 매도" / "매수" with colored text
- Fix FX signal oversensitivity: divisor changed from 0.5 to 1.5, so a 0.2% FX change no longer maxes out the signal at 1.00
- Add "장이 닫혀 있어 동일한 값이 표시됩니다" hint when timeline chart shows flat values (weekends/holidays)
- Slightly increase SignalBar height for better visibility

## Test plan
- [ ] Verify SignalBar shows text labels only (no numbers) — e.g., "환율: 매도" with red text
- [ ] Verify FX signal is more moderate (not always maxed at ±1.00)
- [ ] Verify market-closed hint appears below chart on weekends
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)