### PR TITLE
fix(macro): prevent timeline flash on tab switch

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -162,6 +162,7 @@
     "noHistory": "No history data",
     "historyAccumulating": "Data is still accumulating — try a shorter time range",
     "marketClosedHint": "Market is closed — values will update when trading resumes",
+    "dataRangeHint": "Showing {actual} of data (requested {requested}) — data is still accumulating",
     "regimeRiskOn": "Risk-On",
     "regimeRiskOff": "Risk-Off",
     "regimeNeutral": "Neutral",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -162,6 +162,7 @@
     "noHistory": "히스토리 데이터 없음",
     "historyAccumulating": "데이터가 아직 쌓이는 중입니다 — 더 짧은 시간 범위를 선택하세요",
     "marketClosedHint": "장이 닫혀 있어 동일한 값이 표시됩니다 — 거래 시간에 업데이트됩니다",
+    "dataRangeHint": "{actual} 분량의 데이터 표시 중 ({requested} 요청) — 데이터가 아직 쌓이는 중입니다",
     "regimeRiskOn": "위험 선호",
     "regimeRiskOff": "위험 회피",
     "regimeNeutral": "중립",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -162,6 +162,7 @@
     "noHistory": "暂无历史数据",
     "historyAccumulating": "数据仍在积累中 — 请尝试更短的时间范围",
     "marketClosedHint": "市场已关闭 — 交易时间恢复后数据将更新",
+    "dataRangeHint": "显示 {actual} 数据（请求 {requested}）— 数据仍在积累中",
     "regimeRiskOn": "风险偏好",
     "regimeRiskOff": "风险规避",
     "regimeNeutral": "中性",

--- a/web/src/app/[locale]/macro/page.tsx
+++ b/web/src/app/[locale]/macro/page.tsx
@@ -389,16 +389,28 @@ export default function MacroPage() {
         )}
         {(() => {
           const pts = historyQuery.data?.points ?? [];
-          if (pts.length >= 2) {
-            const fxVals = pts.map(p => p.fx_value).filter((v): v is number => v != null);
-            const isFlat = fxVals.length >= 2 && new Set(fxVals).size === 1;
-            if (isFlat) {
-              return (
-                <p className="mt-2 text-center text-xs text-[var(--foreground-muted)]">
-                  {t('marketClosedHint')}
-                </p>
-              );
-            }
+          if (pts.length < 2) return null;
+          // Show how much data we actually have vs requested
+          const windowMinutes: Record<WindowOption, number> = { '60m': 60, '6h': 360, '1d': 1440, '7d': 10080, '30d': 43200 };
+          const first = new Date(pts[0].timestamp).getTime();
+          const last = new Date(pts[pts.length - 1].timestamp).getTime();
+          const spanMin = (last - first) / 60000;
+          const requested = windowMinutes[historyWindow];
+          if (spanMin < requested * 0.8) {
+            return (
+              <p className="mt-2 text-center text-xs text-[var(--foreground-muted)]">
+                {t('dataRangeHint', { actual: spanMin < 60 ? `${Math.round(spanMin)}m` : `${(spanMin / 60).toFixed(1)}h`, requested: historyWindow === '60m' ? '1h' : historyWindow === '6h' ? '6h' : historyWindow === '1d' ? '1d' : historyWindow === '7d' ? '1w' : '1m' })}
+              </p>
+            );
+          }
+          // Check if values are flat (market closed)
+          const fxVals = pts.map(p => p.fx_value).filter((v): v is number => v != null);
+          if (fxVals.length >= 2 && new Set(fxVals).size === 1) {
+            return (
+              <p className="mt-2 text-center text-xs text-[var(--foreground-muted)]">
+                {t('marketClosedHint')}
+              </p>
+            );
           }
           return null;
         })()}

--- a/web/src/hooks/useMarket.ts
+++ b/web/src/hooks/useMarket.ts
@@ -27,6 +27,7 @@ export function useMacroHistory(window: string = '60m') {
     queryKey: queryKeys.market.macroHistory(window),
     queryFn: () => getMacroHistory(window),
     staleTime: 30 * 1000,
+    placeholderData: (prev) => prev,
   });
 }
 


### PR DESCRIPTION
## Summary
- Fix chart disappearing when switching time range tabs (placeholderData keeps previous data visible during refetch)
- Show data range hint when available data < requested range (e.g., "1.5h 분량의 데이터 표시 중 (6h 요청)")
- Keep market-closed hint for flat data periods

## Test plan
- [ ] Switch between 1H/6H/1D tabs — chart should NOT flash/disappear
- [ ] When data < requested range, hint message appears below chart
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)