### PR TITLE
feat(macro): redesign signal bars with center-diverging layout

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -177,6 +177,8 @@
     "signalNeutral": "Neutral",
     "signalSell": "Sell",
     "signalStrongSell": "Strong Sell",
+    "signalLegendBuy": "← Buy Favorable",
+    "signalLegendSell": "Sell Favorable →",
     "bundleUnavailable": "Macro bundle endpoint is unavailable",
     "entryAssessment": "Market Entry Assessment",
     "entry_buy_favorable": "Buy Favorable",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -177,6 +177,8 @@
     "signalNeutral": "중립",
     "signalSell": "매도",
     "signalStrongSell": "강한 매도",
+    "signalLegendBuy": "← 매수 유리",
+    "signalLegendSell": "매도 유리 →",
     "bundleUnavailable": "매크로 번들 API를 사용할 수 없습니다",
     "entryAssessment": "시장 진입 판단",
     "entry_buy_favorable": "매수 적기",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -177,6 +177,8 @@
     "signalNeutral": "中性",
     "signalSell": "卖出",
     "signalStrongSell": "强烈卖出",
+    "signalLegendBuy": "← 买入有利",
+    "signalLegendSell": "卖出有利 →",
     "bundleUnavailable": "宏观聚合接口不可用",
     "entryAssessment": "市场进入评估",
     "entry_buy_favorable": "买入时机",

--- a/web/src/app/[locale]/macro/page.tsx
+++ b/web/src/app/[locale]/macro/page.tsx
@@ -213,11 +213,17 @@ export default function MacroPage() {
           </p>
         </div>
 
-        {/* Signal Contribution Bars */}
-        <div className="mt-4 grid gap-3 md:grid-cols-3">
-          <SignalBar label={t('fxSignal')} value={contributions.fx} nullLabel={t('flowUnavailable')} t={t} />
-          <SignalBar label={t('futuresSignal')} value={contributions.futures} nullLabel={t('flowUnavailable')} t={t} />
-          <SignalBar label={t('flowSignal')} value={contributions.flow} nullLabel={t('flowUnavailable')} t={t} />
+        {/* Signal Contribution Bars — center-diverging */}
+        <div className="mt-4 space-y-1">
+          <div className="flex items-center justify-between text-[10px] text-[var(--foreground-muted)] opacity-60 px-0.5">
+            <span>{t('signalLegendBuy')}</span>
+            <span>{t('signalLegendSell')}</span>
+          </div>
+          <div className="grid gap-3 md:grid-cols-3">
+            <SignalBar label={t('fxSignal')} value={contributions.fx} nullLabel={t('flowUnavailable')} t={t} />
+            <SignalBar label={t('futuresSignal')} value={contributions.futures} nullLabel={t('flowUnavailable')} t={t} />
+            <SignalBar label={t('flowSignal')} value={contributions.flow} nullLabel={t('flowUnavailable')} t={t} />
+          </div>
         </div>
       </div>
 
@@ -488,9 +494,9 @@ function signalLabel(value: number, t: (key: string) => string): string {
 }
 
 function SignalBar({ label, value, nullLabel, t }: { label: string; value: number | null; nullLabel: string; t: (key: string) => string }) {
-  const pct = value != null ? Math.abs(value) * 100 : 0;
+  const pct = value != null ? Math.min(Math.abs(value) * 50, 50) : 0; // half-width max 50%
   const isNull = value == null;
-  const isPositive = (value ?? 0) >= 0;
+  const isBuy = (value ?? 0) < 0; // negative = buy favorable
   const desc = !isNull ? signalLabel(value!, t) : null;
 
   return (
@@ -500,16 +506,31 @@ function SignalBar({ label, value, nullLabel, t }: { label: string; value: numbe
         {isNull ? (
           <span className="text-[var(--foreground-muted)]">{nullLabel}</span>
         ) : (
-          <span className={`font-medium ${isPositive ? 'text-red-500' : 'text-emerald-500'}`}>{desc}</span>
+          <span className={`font-medium ${isBuy ? 'text-emerald-500' : 'text-red-500'}`}>{desc}</span>
         )}
       </div>
+      {/* Center-anchored diverging bar: green ← center → red */}
       <div className="relative h-2.5 rounded-full bg-[var(--background)] overflow-hidden">
-        <div
-          className={`absolute top-0 h-full rounded-full transition-all ${
-            isNull ? 'bg-gray-300 dark:bg-gray-600' : isPositive ? 'bg-red-400' : 'bg-emerald-400'
-          }`}
-          style={{ width: `${Math.min(pct, 100)}%`, left: 0 }}
-        />
+        {/* Center line */}
+        <div className="absolute left-1/2 top-0 h-full w-px bg-[var(--foreground-muted)] opacity-30" />
+        {!isNull && pct > 0 && (
+          <div
+            className={`absolute top-0 h-full rounded-full transition-all ${
+              isBuy ? 'bg-emerald-400' : 'bg-red-400'
+            }`}
+            style={
+              isBuy
+                ? { right: '50%', width: `${pct}%` }
+                : { left: '50%', width: `${pct}%` }
+            }
+          />
+        )}
+        {isNull && (
+          <div
+            className="absolute top-0 h-full rounded-full bg-gray-300 dark:bg-gray-600"
+            style={{ left: '50%', width: '2%', transform: 'translateX(-50%)' }}
+          />
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Replace left-to-right signal bars with center-anchored diverging bars
- Green bars extend LEFT from center for buy-favorable signals
- Red bars extend RIGHT from center for sell-favorable signals
- Add "← 매수 유리 | 매도 유리 →" legend for clarity

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] Desktop screenshot verified (1280×800)
- [x] Mobile screenshot verified (375×812)
- [x] No console errors
- [x] i18n keys added for ko/en/zh

🤖 Generated with [Claude Code](https://claude.com/claude-code)