### PR TITLE
fix(macro): sync history auto-refresh with bundle polling

### DIFF
--- a/web/src/hooks/useMarket.ts
+++ b/web/src/hooks/useMarket.ts
@@ -4,6 +4,8 @@ import { useQuery } from '@tanstack/react-query';
 import { queryKeys } from '@/lib/queryKeys';
 import { getMacroBundle, getMacroHistory, getOhlcv, searchTickers } from '@/lib/api';
 
+const MACRO_POLL_MS = 30 * 1000; // shared polling cadence for macro queries
+
 export function useSearchTickers(query: string) {
   return useQuery({
     queryKey: queryKeys.market.search(query),
@@ -17,7 +19,7 @@ export function useMacroBundle() {
   return useQuery({
     queryKey: queryKeys.market.macroBundle(),
     queryFn: () => getMacroBundle(),
-    refetchInterval: 30 * 1000,
+    refetchInterval: MACRO_POLL_MS,
     staleTime: 10 * 1000,
   });
 }
@@ -26,7 +28,8 @@ export function useMacroHistory(window: string = '60m') {
   return useQuery({
     queryKey: queryKeys.market.macroHistory(window),
     queryFn: () => getMacroHistory(window),
-    staleTime: 30 * 1000,
+    refetchInterval: MACRO_POLL_MS,
+    staleTime: MACRO_POLL_MS,
     placeholderData: (prev) => prev,
   });
 }


### PR DESCRIPTION
## Summary
- Add `refetchInterval` to `useMacroHistory` so history updates automatically every 30s
- Extract `MACRO_POLL_MS` constant shared between bundle and history hooks
- Background tabs skip polling via React Query defaults (`refetchIntervalInBackground: false`)

Closes #1156

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] History chart updates automatically without manual refresh
- [x] Manual refresh button still forces both queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)