### PR TITLE
feat(macro): server-side TTL cache for bundle aggregation

### DIFF
--- a/api/routers/market.py
+++ b/api/routers/market.py
@@ -145,8 +145,10 @@ def get_technical_indicators(ticker: str) -> TechnicalIndicators:
     summary="Get Macro Bundle",
     description="Get aggregated macro snapshot for FX, futures, investor flow, and regime score.",
 )
-def get_macro_bundle() -> MacroBundleResponse:
-    result = _macro_service.get_bundle()
+def get_macro_bundle(
+    force: bool = Query(False, description="Bypass server cache and force fresh data collection"),
+) -> MacroBundleResponse:
+    result = _macro_service.get_bundle(force_refresh=force)
     return MacroBundleResponse(**result)
 
 

--- a/api/schemas/market.py
+++ b/api/schemas/market.py
@@ -161,6 +161,8 @@ class MacroBundleResponse(BaseModel):
     signal: MacroSignal
     freshness: MacroFreshness
     interpretation: Optional[MacroInterpretation] = None
+    cache_hit: Optional[bool] = Field(None, description="Whether this response was served from cache")
+    generated_at: Optional[str] = Field(None, description="When this bundle was originally generated")
 
 
 class MacroHistoryPoint(BaseModel):

--- a/api/services/macro_market_service.py
+++ b/api/services/macro_market_service.py
@@ -58,10 +58,26 @@ class MacroMarketService:
         self._session_start_fx: Optional[float] = None
         self._session_start_date: Optional[date] = None
 
+        # Bundle TTL cache (separate lock to avoid contention with history)
+        self._BUNDLE_TTL_SEC = 5.0
+        self._cache_lock = threading.Lock()
+        self._cached_bundle: Optional[Dict[str, Any]] = None
+        self._cached_at: float = 0.0  # monotonic timestamp
+
         # Load recent history from DB on startup
         self._load_history_from_db()
 
-    def get_bundle(self) -> Dict[str, Any]:
+    def get_bundle(self, force_refresh: bool = False) -> Dict[str, Any]:
+        # Check TTL cache (lock-free read for fast path)
+        if not force_refresh:
+            with self._cache_lock:
+                if self._cached_bundle is not None:
+                    elapsed = time.monotonic() - self._cached_at
+                    if elapsed < self._BUNDLE_TTL_SEC:
+                        # Return shallow copy with cache_hit flag
+                        hit = {**self._cached_bundle, "cache_hit": True}
+                        return hit
+
         now = datetime.now(timezone.utc)
 
         fx = self._get_fx_snapshot(now)
@@ -78,6 +94,7 @@ class MacroMarketService:
 
         interpretation = self._build_interpretation(fx, futures, flow)
 
+        generated_at = self._to_iso(now)
         bundle = {
             "fx": fx,
             "futures": futures,
@@ -85,8 +102,16 @@ class MacroMarketService:
             "signal": signal,
             "freshness": freshness,
             "interpretation": interpretation,
+            "cache_hit": False,
+            "generated_at": generated_at,
         }
         self._append_history(bundle, now)
+
+        # Update cache
+        with self._cache_lock:
+            self._cached_bundle = bundle.copy()
+            self._cached_at = time.monotonic()
+
         return bundle
 
     def get_history(self, window: str = "60m") -> Dict[str, Any]:
@@ -429,7 +454,7 @@ class MacroMarketService:
         logger.info("Macro history collector started (interval=%ds)", interval_sec)
         while True:
             try:
-                self.get_bundle()
+                self.get_bundle(force_refresh=True)
                 # Flush any buffered points to DB each tick
                 self._flush_to_db()
             except Exception as exc:

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -370,6 +370,8 @@ export interface MacroBundle {
   signal: MacroSignal;
   freshness: MacroFreshness;
   interpretation?: MacroInterpretation | null;
+  cache_hit?: boolean | null;
+  generated_at?: string | null;
 }
 
 export interface MacroHistoryPoint {


### PR DESCRIPTION
## Summary
- Add 5-second monotonic TTL cache on `get_bundle()` to reduce upstream API fan-out
- Separate `_cache_lock` from history `_lock` to avoid contention
- Background history collector bypasses cache with `force_refresh=True`
- Router accepts `?force=true` for manual cache bypass
- Response includes `cache_hit` and `generated_at` for observability

Closes #1161

## Test plan
- [x] Backend import verified
- [x] `npx tsc --noEmit` passes
- [x] Repeated rapid requests return `cache_hit: true`
- [x] `?force=true` always returns fresh data
- [x] History collector still appends points every 60s

🤖 Generated with [Claude Code](https://claude.com/claude-code)