### PR TITLE
feat(macro): structure signal reason for localized UI rendering

### DIFF
--- a/api/schemas/market.py
+++ b/api/schemas/market.py
@@ -5,7 +5,7 @@ Provides schemas for OHLCV data, quotes, and technical indicators.
 """
 
 from datetime import datetime
-from typing import List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, Field
 
@@ -134,10 +134,26 @@ class MacroInvestorFlowSnapshot(BaseModel):
     updated_at: Optional[str] = Field(None, description="Last update timestamp")
 
 
+class MacroSignalComponent(BaseModel):
+    raw: float = Field(..., description="Raw component score [-1, 1]")
+    decay: float = Field(..., description="Freshness decay factor [0, 1]")
+    weight: float = Field(..., description="Component weight in scoring")
+    contribution: float = Field(..., description="Effective contribution (raw * decay * weight)")
+
+
+class MacroReasonDetail(BaseModel):
+    version: int = Field(1, description="Schema version for forward compatibility")
+    summary: str = Field(..., description="Human-readable summary string")
+    components: Dict[str, MacroSignalComponent] = Field(
+        ..., description="Per-component scoring breakdown (fx, futures, flow)"
+    )
+
+
 class MacroSignal(BaseModel):
     macro_score: Optional[float] = Field(None, description="Composite macro score")
     regime: str = Field(..., description="Regime classification")
-    reason: Optional[str] = Field(None, description="Human-readable scoring reason")
+    reason: Optional[str] = Field(None, description="Human-readable scoring reason (backward compat)")
+    reason_detail: Optional[MacroReasonDetail] = Field(None, description="Structured scoring breakdown")
     updated_at: Optional[str] = Field(None, description="Signal timestamp")
 
 

--- a/api/services/macro_market_service.py
+++ b/api/services/macro_market_service.py
@@ -415,16 +415,19 @@ class MacroMarketService:
             else:
                 regime = "neutral"
 
-        reason = self._build_reason(fx_raw, futures_raw, flow_raw, fx_decay, futures_decay, flow_decay, regime)
+        reason_detail = self._build_reason_detail(
+            fx_raw, futures_raw, flow_raw, fx_decay, futures_decay, flow_decay, regime,
+        )
 
         return {
             "macro_score": macro_score,
             "regime": regime,
-            "reason": reason,
+            "reason": reason_detail["summary"],
+            "reason_detail": reason_detail,
             "updated_at": self._to_iso(now),
         }
 
-    def _build_reason(
+    def _build_reason_detail(
         self,
         fx_raw: float,
         futures_raw: float,
@@ -433,13 +436,32 @@ class MacroMarketService:
         futures_decay: float,
         flow_decay: float,
         regime: str,
-    ) -> str:
+    ) -> Dict[str, Any]:
+        weights = {"fx": 0.40, "futures": 0.35, "flow": 0.25}
+
+        def _component(raw: float, decay: float, weight: float) -> Dict[str, Any]:
+            return {
+                "raw": round(raw, 4),
+                "decay": round(decay, 4),
+                "weight": weight,
+                "contribution": round(raw * decay * weight, 4),
+            }
+
         parts = [
             f"fx={fx_raw:.2f} (decay={fx_decay:.2f})",
             f"futures={futures_raw:.2f} (decay={futures_decay:.2f})",
             f"flow={flow_raw:.2f} (decay={flow_decay:.2f})",
         ]
-        return f"{regime}: " + ", ".join(parts)
+
+        return {
+            "version": 1,
+            "summary": f"{regime}: " + ", ".join(parts),
+            "components": {
+                "fx": _component(fx_raw, fx_decay, weights["fx"]),
+                "futures": _component(futures_raw, futures_decay, weights["futures"]),
+                "flow": _component(flow_raw, flow_decay, weights["flow"]),
+            },
+        }
 
     # ------------------------------------------------------------------
     # Background history collector

--- a/web/src/app/[locale]/macro/page.tsx
+++ b/web/src/app/[locale]/macro/page.tsx
@@ -79,8 +79,18 @@ function formatShortTime(value: string | null, locale: string): string {
   }).format(date);
 }
 
-/** Parse reason string "neutral: fx=0.12 (decay=0.89), futures=-0.30 (decay=0.50), flow=0.00 (decay=0.00)" */
-function parseSignalContributions(reason: string | null): { fx: number | null; futures: number | null; flow: number | null } {
+function getSignalContributions(signal: { reason_detail?: { components: { fx: { raw: number }; futures: { raw: number }; flow: { raw: number } } } | null; reason?: string | null }): { fx: number | null; futures: number | null; flow: number | null } {
+  // Prefer structured reason_detail
+  const detail = signal.reason_detail;
+  if (detail?.components) {
+    return {
+      fx: detail.components.fx?.raw ?? null,
+      futures: detail.components.futures?.raw ?? null,
+      flow: detail.components.flow?.raw ?? null,
+    };
+  }
+  // Fallback: parse legacy reason string
+  const reason = signal.reason;
   if (!reason) return { fx: null, futures: null, flow: null };
   const extract = (key: string) => {
     const match = reason.match(new RegExp(`${key}=([\\-\\d.]+)`));
@@ -125,8 +135,8 @@ export default function MacroPage() {
   }, [regime]);
 
   const contributions = useMemo(
-    () => parseSignalContributions(bundleQuery.data?.signal.reason ?? null),
-    [bundleQuery.data?.signal.reason],
+    () => getSignalContributions(bundleQuery.data?.signal ?? {}),
+    [bundleQuery.data?.signal],
   );
 
   // Compute change% from first data point for each history point

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -341,10 +341,28 @@ export interface MacroInvestorFlowSnapshot {
   updated_at: string | null;
 }
 
+export interface MacroSignalComponent {
+  raw: number;
+  decay: number;
+  weight: number;
+  contribution: number;
+}
+
+export interface MacroReasonDetail {
+  version: number;
+  summary: string;
+  components: {
+    fx: MacroSignalComponent;
+    futures: MacroSignalComponent;
+    flow: MacroSignalComponent;
+  };
+}
+
 export interface MacroSignal {
   macro_score: number | null;
   regime: MacroRegime;
   reason: string | null;
+  reason_detail?: MacroReasonDetail | null;
   updated_at: string | null;
 }
 


### PR DESCRIPTION
## Summary
- Add `reason_detail` structured payload with per-component breakdown (raw, decay, weight, contribution)
- Backend: `MacroReasonDetail` + `MacroSignalComponent` Pydantic schemas
- Frontend: `getSignalContributions()` prefers `reason_detail.components`, falls back to regex parsing
- Legacy `reason` string preserved for backward compatibility
- Schema versioned (`version: 1`) for forward compatibility

Closes #1163

## Test plan
- [x] Backend import verified
- [x] `npx tsc --noEmit` passes
- [x] API returns both `reason` and `reason_detail` fields
- [x] SignalBar renders correctly from structured data
- [x] Fallback to regex parsing when `reason_detail` is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)