### PR TITLE
feat(macro): decay-based signal display & off-hours half-life (#1175)

### DIFF
--- a/api/schemas/market.py
+++ b/api/schemas/market.py
@@ -139,6 +139,7 @@ class MacroSignalComponent(BaseModel):
     decay: float = Field(..., description="Freshness decay factor [0, 1]")
     weight: float = Field(..., description="Component weight in scoring")
     contribution: float = Field(..., description="Effective contribution (raw * decay * weight)")
+    half_life_sec: Optional[int] = Field(None, description="Half-life used for decay calculation (seconds)")
 
 
 class MacroReasonDetail(BaseModel):
@@ -179,6 +180,7 @@ class MacroBundleResponse(BaseModel):
     interpretation: Optional[MacroInterpretation] = None
     cache_hit: Optional[bool] = Field(None, description="Whether this response was served from cache")
     generated_at: Optional[str] = Field(None, description="When this bundle was originally generated")
+    is_market_hours: Optional[bool] = Field(None, description="Whether KRX is currently in market hours")
 
 
 class MacroHistoryPoint(BaseModel):

--- a/api/services/macro_market_service.py
+++ b/api/services/macro_market_service.py
@@ -34,6 +34,14 @@ class MacroMarketService:
     # Batch DB writes every N ticks to reduce I/O
     _DB_FLUSH_INTERVAL = 10
 
+    # Off-hours half-life multiplier (장외 시간에 반감기 확장)
+    _OFF_HOURS_MULTIPLIER = 24
+
+    # Default half-lives (seconds) — used during market hours
+    _HALF_LIFE_FX = 600
+    _HALF_LIFE_FUTURES = 600
+    _HALF_LIFE_FLOW = 900
+
     def __init__(
         self,
         market_service: MarketService,
@@ -109,6 +117,7 @@ class MacroMarketService:
             "interpretation": interpretation,
             "cache_hit": False,
             "generated_at": generated_at,
+            "is_market_hours": self._is_krx_market_hours(),
         }
         self._append_history(bundle, now)
 
@@ -159,6 +168,20 @@ class MacroMarketService:
         points.reverse()  # restore chronological order
 
         return {"window": window, "points": points}
+
+    def _is_krx_market_hours(self) -> bool:
+        """Check if current KST time is within KRX market hours (Mon-Fri 09:00-15:40)."""
+        from datetime import timezone as tz, timedelta as td
+
+        now_kst = datetime.now(tz.utc).astimezone(tz(td(hours=9)))
+        if now_kst.weekday() > 4:
+            return False
+        hour, minute = now_kst.hour, now_kst.minute
+        if hour < 9:
+            return False
+        if hour > 15 or (hour == 15 and minute > 40):
+            return False
+        return True
 
     def _get_fx_snapshot(self, now: datetime) -> Dict[str, Any]:
         # Primary: Naver FX (realtime during KRW market hours)
@@ -389,10 +412,16 @@ class MacroMarketService:
         foreign_net = self._to_float(flow.get("foreign_net"))
         flow_raw = self._clip((-(foreign_net or 0.0)) / 1_000_000_000.0, -1.0, 1.0)
 
-        # Freshness decay (half-life in seconds)
-        fx_decay = self._stale_decay(freshness.get("fx_age_sec"), half_life_sec=600)
-        futures_decay = self._stale_decay(freshness.get("futures_age_sec"), half_life_sec=600)
-        flow_decay = self._stale_decay(freshness.get("flow_age_sec"), half_life_sec=900)
+        # Freshness decay (half-life in seconds, extended off-hours)
+        is_market = self._is_krx_market_hours()
+        mult = 1 if is_market else self._OFF_HOURS_MULTIPLIER
+        fx_hl = self._HALF_LIFE_FX * mult
+        futures_hl = self._HALF_LIFE_FUTURES * mult
+        flow_hl = self._HALF_LIFE_FLOW * mult
+
+        fx_decay = self._stale_decay(freshness.get("fx_age_sec"), half_life_sec=fx_hl)
+        futures_decay = self._stale_decay(freshness.get("futures_age_sec"), half_life_sec=futures_hl)
+        flow_decay = self._stale_decay(freshness.get("flow_age_sec"), half_life_sec=flow_hl)
 
         weighted = [
             (0.40, fx_raw, fx_decay, fx.get("value") is not None),
@@ -421,7 +450,10 @@ class MacroMarketService:
                 regime = "neutral"
 
         reason_detail = self._build_reason_detail(
-            fx_raw, futures_raw, flow_raw, fx_decay, futures_decay, flow_decay, regime,
+            fx_raw, futures_raw, flow_raw,
+            fx_decay, futures_decay, flow_decay,
+            regime,
+            fx_hl, futures_hl, flow_hl,
         )
 
         return {
@@ -441,15 +473,19 @@ class MacroMarketService:
         futures_decay: float,
         flow_decay: float,
         regime: str,
+        fx_hl: int = 600,
+        futures_hl: int = 600,
+        flow_hl: int = 900,
     ) -> Dict[str, Any]:
         weights = {"fx": 0.40, "futures": 0.35, "flow": 0.25}
 
-        def _component(raw: float, decay: float, weight: float) -> Dict[str, Any]:
+        def _component(raw: float, decay: float, weight: float, half_life_sec: int) -> Dict[str, Any]:
             return {
                 "raw": round(raw, 4),
                 "decay": round(decay, 4),
                 "weight": weight,
                 "contribution": round(raw * decay * weight, 4),
+                "half_life_sec": half_life_sec,
             }
 
         parts = [
@@ -462,9 +498,9 @@ class MacroMarketService:
             "version": 1,
             "summary": f"{regime}: " + ", ".join(parts),
             "components": {
-                "fx": _component(fx_raw, fx_decay, weights["fx"]),
-                "futures": _component(futures_raw, futures_decay, weights["futures"]),
-                "flow": _component(flow_raw, flow_decay, weights["flow"]),
+                "fx": _component(fx_raw, fx_decay, weights["fx"], fx_hl),
+                "futures": _component(futures_raw, futures_decay, weights["futures"], futures_hl),
+                "flow": _component(flow_raw, flow_decay, weights["flow"], flow_hl),
             },
         }
 

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -202,7 +202,13 @@
     "interp_flow_foreign_strong_sell": "Foreigners selling heavily → strong selling pressure",
     "interp_flow_foreign_sell": "Foreigners selling → selling dominant",
     "interp_flow_neutral": "Balanced flow among foreign, institutional, and retail",
-    "interp_flow_unavailable": "Weekend/off-hours — flow data not collected"
+    "interp_flow_unavailable": "Weekend/off-hours — flow data not collected",
+    "signalStale": "Stale",
+    "signalFading": "Fading",
+    "afterHoursNotice": "After hours — extended decay",
+    "marketOpen": "Market open",
+    "marketClosed": "Market closed",
+    "signalStrength": "({pct}%)"
   },
   "screening": {
     "title": "Stock Screening",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -202,7 +202,13 @@
     "interp_flow_foreign_strong_sell": "외국인이 대규모로 팔고 있음 → 강한 매도세",
     "interp_flow_foreign_sell": "외국인이 팔고 있음 → 매도 우위",
     "interp_flow_neutral": "외국인·기관·개인 수급 균형",
-    "interp_flow_unavailable": "주말/장외 시간이라 수급 데이터 미수집"
+    "interp_flow_unavailable": "주말/장외 시간이라 수급 데이터 미수집",
+    "signalStale": "만료",
+    "signalFading": "약화",
+    "afterHoursNotice": "장마감 — 확장 반감기",
+    "marketOpen": "장중",
+    "marketClosed": "장마감",
+    "signalStrength": "({pct}%)"
   },
   "screening": {
     "title": "종목 스크리닝",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -202,7 +202,13 @@
     "interp_flow_foreign_strong_sell": "外资大规模卖出中 → 强劲卖盘",
     "interp_flow_foreign_sell": "外资卖出中 → 卖盘占优",
     "interp_flow_neutral": "外资·机构·散户资金流向均衡",
-    "interp_flow_unavailable": "周末/非交易时间，资金流数据未采集"
+    "interp_flow_unavailable": "周末/非交易时间，资金流数据未采集",
+    "signalStale": "过期",
+    "signalFading": "衰减",
+    "afterHoursNotice": "盘后 — 扩展衰减",
+    "marketOpen": "盘中",
+    "marketClosed": "休市",
+    "signalStrength": "({pct}%)"
   },
   "screening": {
     "title": "股票筛选",

--- a/web/src/app/[locale]/macro/page.tsx
+++ b/web/src/app/[locale]/macro/page.tsx
@@ -78,29 +78,40 @@ function formatShortTime(value: string | null, locale: string): string {
   }).format(date);
 }
 
-function getSignalContributions(signal: { reason_detail?: { components: { fx: { raw: number }; futures: { raw: number }; flow: { raw: number } } } | null; reason?: string | null }): { fx: number | null; futures: number | null; flow: number | null } {
-  // Prefer structured reason_detail
+interface SignalContrib {
+  raw: number | null;
+  decay: number | null;
+  effective: number | null; // raw * decay
+}
+
+function getSignalContributions(signal: { reason_detail?: { components: { fx: { raw: number; decay: number }; futures: { raw: number; decay: number }; flow: { raw: number; decay: number } } } | null; reason?: string | null }): { fx: SignalContrib; futures: SignalContrib; flow: SignalContrib } {
   const detail = signal.reason_detail;
   if (detail?.components) {
+    const nil: SignalContrib = { raw: null, decay: null, effective: null };
+    const toContrib = (c?: { raw?: number; decay?: number } | null): SignalContrib => {
+      if (!c) return nil;
+      const raw = c.raw ?? null;
+      const decay = c.decay ?? null;
+      return { raw, decay, effective: (raw != null && decay != null) ? raw * decay : null };
+    };
     return {
-      fx: detail.components.fx?.raw ?? null,
-      futures: detail.components.futures?.raw ?? null,
-      flow: detail.components.flow?.raw ?? null,
+      fx: toContrib(detail.components?.fx),
+      futures: toContrib(detail.components?.futures),
+      flow: toContrib(detail.components?.flow),
     };
   }
-  // Fallback: parse legacy reason string
+  // Fallback: parse legacy reason string -- decay unknown, treat as full strength
   const reason = signal.reason;
-  if (!reason) return { fx: null, futures: null, flow: null };
-  const extract = (key: string) => {
+  if (!reason) return { fx: { raw: null, decay: null, effective: null }, futures: { raw: null, decay: null, effective: null }, flow: { raw: null, decay: null, effective: null } };
+  const extract = (key: string): SignalContrib => {
     const match = reason.match(new RegExp(`${key}=([\\-\\d.]+)`));
-    if (!match) return null;
+    if (!match) return { raw: null, decay: null, effective: null };
     const val = parseFloat(match[1]);
-    return Number.isNaN(val) ? null : val;
+    if (Number.isNaN(val)) return { raw: null, decay: null, effective: null };
+    return { raw: val, decay: null, effective: val }; // legacy: no decay info, treat raw as effective
   };
   return { fx: extract('fx'), futures: extract('futures'), flow: extract('flow') };
 }
-
-const STALE_THRESHOLD_SEC = 600; // half-life
 
 const REGIME_COLORS: Record<MacroRegime, string> = {
   risk_on: 'rgba(16, 185, 129, 0.08)',
@@ -255,10 +266,17 @@ export default function MacroPage() {
                 <span>{t('signalLegendBuy')}</span>
                 <span>{t('signalLegendSell')}</span>
               </div>
+              {bundleQuery.data?.is_market_hours === false && (
+                <div className="flex justify-center">
+                  <span className="inline-flex items-center gap-1 rounded-full bg-slate-600/50 px-2.5 py-0.5 text-[10px] font-medium text-slate-300">
+                    {t('afterHoursNotice')}
+                  </span>
+                </div>
+              )}
               <div className="grid gap-3 md:grid-cols-3">
-                <SignalBar label={t('fxSignal')} value={contributions.fx} nullLabel={t('flowUnavailable')} t={t} />
-                <SignalBar label={t('futuresSignal')} value={contributions.futures} nullLabel={t('flowUnavailable')} t={t} />
-                <SignalBar label={t('flowSignal')} value={contributions.flow} nullLabel={t('flowUnavailable')} t={t} />
+                <SignalBar label={t('fxSignal')} contribution={contributions.fx} nullLabel={t('flowUnavailable')} t={t} />
+                <SignalBar label={t('futuresSignal')} contribution={contributions.futures} nullLabel={t('flowUnavailable')} t={t} />
+                <SignalBar label={t('flowSignal')} contribution={contributions.flow} nullLabel={t('flowUnavailable')} t={t} />
               </div>
             </div>
           </div>
@@ -279,6 +297,7 @@ export default function MacroPage() {
           ageLabel={formatAge(bundleQuery.data?.freshness.fx_age_sec ?? null, t)}
           staleLabel={t('staleWarning')}
           interpretationText={interpretation ? t(`interp_fx_${interpretation.fx_interpretation}`) : undefined}
+          decay={bundleQuery.data?.signal.reason_detail?.components?.fx?.decay}
         />
         <MetricCard
           title={t('futures')}
@@ -294,6 +313,7 @@ export default function MacroPage() {
           ageLabel={formatAge(bundleQuery.data?.freshness.futures_age_sec ?? null, t)}
           staleLabel={t('staleWarning')}
           interpretationText={interpretation ? t(`interp_futures_${interpretation.futures_interpretation}`) : undefined}
+          decay={bundleQuery.data?.signal.reason_detail?.components?.futures?.decay}
         />
         <MetricCard
           title={t('investorFlow')}
@@ -314,6 +334,7 @@ export default function MacroPage() {
           ageLabel={formatAge(bundleQuery.data?.freshness.flow_age_sec ?? null, t)}
           staleLabel={t('staleWarning')}
           interpretationText={interpretation ? t(`interp_flow_${interpretation.flow_interpretation}`) : undefined}
+          decay={bundleQuery.data?.signal.reason_detail?.components?.flow?.decay}
         />
       </div>
 
@@ -596,29 +617,60 @@ function signalLabel(value: number, t: (key: string) => string): string {
   return t('signalNeutral');
 }
 
-function SignalBar({ label, value, nullLabel, t }: { label: string; value: number | null; nullLabel: string; t: (key: string) => string }) {
-  const pct = value != null ? Math.min(Math.abs(value) * 50, 50) : 0;
-  const isNull = value == null;
-  const isBuy = (value ?? 0) < 0;
-  const desc = !isNull ? signalLabel(value!, t) : null;
+function SignalBar({ label, contribution, nullLabel, t }: { label: string; contribution: SignalContrib; nullLabel: string; t: (key: string, values?: Record<string, string | number>) => string }) {
+  const { raw, decay, effective } = contribution;
+  const isNull = effective == null && raw == null;
+  const displayValue = effective ?? raw;
+  const pct = displayValue != null ? Math.min(Math.abs(displayValue) * 50, 50) : 0;
+  const isBuy = (displayValue ?? 0) < 0;
+  const desc = displayValue != null ? signalLabel(displayValue, t) : null;
+
+  // Decay-based 3-tier visualization
+  const isStale = decay != null && decay < 0.1;
+  const isFading = decay != null && decay >= 0.1 && decay < 0.5;
+  // Strength percentage (based on effective vs raw)
+  const strengthPct = (raw != null && raw !== 0 && effective != null)
+    ? Math.round(Math.abs(effective / raw) * 100)
+    : null;
+
+  // Color classes based on decay state
+  const barColor = isStale
+    ? 'bg-slate-500'
+    : isFading
+      ? (isBuy ? 'bg-emerald-400/60' : 'bg-red-400/60')
+      : (isBuy ? 'bg-emerald-400' : 'bg-red-400');
+  const labelColor = isStale
+    ? 'text-slate-400'
+    : isFading
+      ? (isBuy ? 'text-emerald-400/70' : 'text-red-400/70')
+      : (isBuy ? 'text-emerald-400' : 'text-red-400');
 
   return (
-    <div className="space-y-1.5">
+    <div className={`space-y-1.5 ${isStale ? 'opacity-30' : ''}`}>
       <div className="flex items-center justify-between text-xs">
         <span className="text-slate-400">{label}</span>
         {isNull ? (
           <span className="text-slate-500">{nullLabel}</span>
         ) : (
-          <span className={`font-medium ${isBuy ? 'text-emerald-400' : 'text-red-400'}`}>{desc}</span>
+          <span className="flex items-center gap-1">
+            <span className={`font-medium ${labelColor}`}>{desc}</span>
+            {strengthPct != null && strengthPct < 100 && (
+              <span className="text-slate-500 text-[10px]">({strengthPct}%)</span>
+            )}
+            {isStale && (
+              <span className="rounded bg-slate-600 px-1 py-0.5 text-[9px] font-medium text-slate-300">{t('signalStale')}</span>
+            )}
+            {isFading && !isStale && (
+              <span className="rounded bg-amber-800/40 px-1 py-0.5 text-[9px] font-medium text-amber-400">{t('signalFading')}</span>
+            )}
+          </span>
         )}
       </div>
       <div className="relative h-2.5 rounded-full bg-slate-700 overflow-hidden">
         <div className="absolute left-1/2 top-0 h-full w-px bg-slate-500 opacity-40" />
         {!isNull && pct > 0 && (
           <div
-            className={`absolute top-0 h-full rounded-full transition-all ${
-              isBuy ? 'bg-emerald-400' : 'bg-red-400'
-            }`}
+            className={`absolute top-0 h-full rounded-full transition-all ${barColor}`}
             style={
               isBuy
                 ? { right: '50%', width: `${pct}%` }
@@ -653,6 +705,7 @@ function MetricCard({
   ageLabel,
   staleLabel,
   interpretationText,
+  decay,
 }: {
   title: string;
   icon: ReactNode;
@@ -665,8 +718,9 @@ function MetricCard({
   ageLabel: string;
   staleLabel: string;
   interpretationText?: string;
+  decay?: number | null;
 }) {
-  const isStale = ageSec != null && ageSec > STALE_THRESHOLD_SEC;
+  const isStale = decay != null ? decay < 0.1 : (ageSec != null && ageSec > 600);
 
   return (
     <Card>

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -346,6 +346,7 @@ export interface MacroSignalComponent {
   decay: number;
   weight: number;
   contribution: number;
+  half_life_sec?: number | null;
 }
 
 export interface MacroReasonDetail {
@@ -390,6 +391,7 @@ export interface MacroBundle {
   interpretation?: MacroInterpretation | null;
   cache_hit?: boolean | null;
   generated_at?: string | null;
+  is_market_hours?: boolean | null;
 }
 
 export interface MacroHistoryPoint {


### PR DESCRIPTION
## Summary
- **Backend**: Add KRX market hours detection with 24x off-hours half-life multiplier (FX/Futures: 600→14400s, Flow: 900→21600s). Expose `half_life_sec` per component and `is_market_hours` in bundle response.
- **Frontend**: SignalBar now uses effective (raw×decay) value instead of raw. 3-tier decay visualization: fresh (≥0.5), fading (0.1-0.5), stale (<0.1). After-hours notice badge. MetricCard stale detection via decay.
- **i18n**: Add signalStale/signalFading/afterHoursNotice/marketOpen/marketClosed/signalStrength for en/ko/zh

## Test plan
- [x] Backend: Python import OK, API response verified with correct half_life_sec and is_market_hours
- [x] Frontend: `npm run build` passes
- [x] Playwright: Visual verification of all 3 decay tiers + after-hours badge
- [x] Codex code review: LGTM

Closes #1175

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*Reviewed by: Claude Code*