### PR TITLE
fix(macro): normalize MetricCard height and footer alignment

### DIFF
--- a/web/src/app/[locale]/macro/page.tsx
+++ b/web/src/app/[locale]/macro/page.tsx
@@ -1065,8 +1065,8 @@ function MetricCard({
   const isStale = stale ?? (decay != null ? decay < 0.1 : (ageSec != null && ageSec > 600));
 
   return (
-    <Card>
-      <div className="space-y-2">
+    <Card className="h-full">
+      <div className="flex h-full flex-col gap-2">
         <div className="flex items-center justify-between">
           <div className="inline-flex items-center gap-1 text-sm text-[var(--foreground-muted)]">
             {icon}
@@ -1106,7 +1106,7 @@ function MetricCard({
         {interpretationText && (
           <p className="text-xs italic text-[var(--foreground-muted)]">{interpretationText}</p>
         )}
-        <div className="flex items-center justify-between">
+        <div className="mt-auto flex items-center justify-between pt-2 border-t border-[var(--border)]">
           <p className={`text-xs ${isStale ? 'text-amber-600 dark:text-amber-400' : 'text-[var(--foreground-muted)]'}`}>
             {ageLabel}
           </p>

--- a/web/src/components/ui/Card.tsx
+++ b/web/src/components/ui/Card.tsx
@@ -50,7 +50,7 @@ export default function Card({
           </h3>
         </div>
       )}
-      <div className={paddingStyles[padding]}>{children}</div>
+      <div className={`${paddingStyles[padding]} h-full`}>{children}</div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add `h-full` + `flex flex-col` layout to MetricCard for uniform card heights across grid rows
- Bottom-align footer (source/timestamp) with `mt-auto` and add `border-t` separator
- Fix Card component's inner padding wrapper to pass through `h-full` for proper flex chain

Closes #1171

## Test plan
- [x] ESLint clean
- [x] Next.js build passes
- [ ] Visual check: all macro cards in same row have equal height
- [ ] Visual check: footer is always at bottom with separator line

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Reviewed-by: Codex