### PR TITLE
fix(web): update API base URL default from 8000 to 8001

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -1,2 +1,2 @@
-# API server URL (default: http://localhost:8000)
-NEXT_PUBLIC_API_URL=http://localhost:8000
+# API server URL (default: http://localhost:8001)
+NEXT_PUBLIC_API_URL=http://localhost:8001

--- a/web/src/app/[locale]/page.tsx
+++ b/web/src/app/[locale]/page.tsx
@@ -29,7 +29,7 @@ export default function Home() {
   useEffect(() => {
     const checkConnection = async () => {
       try {
-        const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+        const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001';
         const response = await fetch(`${apiUrl}/health`, {
           method: 'GET',
           signal: AbortSignal.timeout(5000),
@@ -56,7 +56,7 @@ export default function Home() {
     checkConnection();
   }, []);
 
-  const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001';
 
   return (
     <div className="space-y-6">

--- a/web/src/app/[locale]/portfolio/page.tsx
+++ b/web/src/app/[locale]/portfolio/page.tsx
@@ -293,7 +293,7 @@ export default function PortfolioPage() {
     (tickers: string[]): string | null => {
       try {
         const configured = process.env.NEXT_PUBLIC_PORTFOLIO_WS_URL;
-        const baseUrl = configured ?? process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8000';
+        const baseUrl = configured ?? process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8001';
         const wsUrl = new URL(baseUrl);
         if (!configured) {
           wsUrl.protocol = wsUrl.protocol === 'https:' ? 'wss:' : 'ws:';

--- a/web/src/components/portfolio/OrderDesk.tsx
+++ b/web/src/components/portfolio/OrderDesk.tsx
@@ -120,7 +120,7 @@ export default function OrderDesk({ prefill }: OrderDeskProps) {
     let unmounted = false;
 
     const configured = process.env.NEXT_PUBLIC_KIWOOM_ORDERS_WS_URL;
-    const baseUrl = configured ?? process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8000';
+    const baseUrl = configured ?? process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8001';
     let wsUrl: string | null = null;
 
     try {

--- a/web/src/components/screening/ConditionMonitorPanel.tsx
+++ b/web/src/components/screening/ConditionMonitorPanel.tsx
@@ -167,7 +167,7 @@ export default function ConditionMonitorPanel() {
     if (!isMonitoring || !selectedCondition) return;
 
     const configured = process.env.NEXT_PUBLIC_KIWOOM_CONDITION_WS_URL;
-    const baseUrl = configured ?? process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8000';
+    const baseUrl = configured ?? process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8001';
     let wsUrl: string | null = null;
 
     try {

--- a/web/src/components/strategy/ChatPanel.tsx
+++ b/web/src/components/strategy/ChatPanel.tsx
@@ -8,7 +8,7 @@ import MessageActions from './chat/MessageActions';
 import SectionedMessage from './chat/SectionedMessage';
 import { normalizeChunk, finalizeStreamText } from './chat/streamTextFormatter';
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001';
 
 interface StructuredSuggestion {
   condition_type: string;

--- a/web/src/components/strategy/chat/MessageActions.tsx
+++ b/web/src/components/strategy/chat/MessageActions.tsx
@@ -3,7 +3,7 @@
 import { memo, useState, useCallback } from 'react';
 import { Copy, Check, ClipboardCheck, Loader2 } from 'lucide-react';
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001';
 
 interface StructuredSuggestion {
   condition_type: string;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -54,7 +54,7 @@ import type {
   OHLCVData,
 } from './types';
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001';
 
 export async function fetchApi<T>(endpoint: string, options?: RequestInit): Promise<T> {
   const response = await fetch(`${API_BASE_URL}${endpoint}`, {


### PR DESCRIPTION
## Summary
- Updated all 8 hardcoded `localhost:8000` fallback URLs to `localhost:8001` across frontend codebase
- Updated `.env.example` to document correct default port

This is part of the #1184 frontend stability epic. The other items in the epic were analyzed and found to be already working correctly:

| Item | Status | Notes |
|------|--------|-------|
| SSR bailout | No action needed | Dev-only behavior from AgentationProvider, no prod impact |
| API base URL | **Fixed** | 8 files updated from 8000 → 8001 |
| Locale redirect | No action needed | next-intl correctly detects browser language |
| Macro UX | Already done | Resolved via #1171 and #1172 |
| Popup news action | No action needed | Loading/success/error feedback already implemented |

Closes #1184

## Test plan
- [x] Next.js build passes
- [x] No remaining `localhost:8000` references in `web/src/`
- [x] Codex direction review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Reviewed-by: Codex