### PR TITLE
fix(macro): add yfinance fallback for bond rates and fix VKOSPI pykrx crash

### DIFF
--- a/api/services/bond_rate_service.py
+++ b/api/services/bond_rate_service.py
@@ -22,6 +22,10 @@ class BondRateService:
         us_2y = self.fred.get_series("DGS2")
         us_spread_2_10 = self.fred.get_series("T10Y2Y")
 
+        # Calculate spread from individual yields when T10Y2Y is unavailable
+        if us_spread_2_10 is None and us_10y is not None and us_2y is not None:
+            us_spread_2_10 = round(us_10y - us_2y, 4)
+
         kr_10y = self.ecos.get_stat_value("817Y002", "010210000")
         kr_3y = self.ecos.get_stat_value("817Y002", "010200000")
 

--- a/api/services/ecos_service.py
+++ b/api/services/ecos_service.py
@@ -22,6 +22,8 @@ class EcosService:
 
     def __init__(self) -> None:
         self._api_key = os.getenv("ECOS_API_KEY")
+        if not self._api_key:
+            logger.warning("ECOS_API_KEY not set — KR bond rates will be unavailable")
         self._lock = threading.RLock()
         self._cache: Dict[str, Optional[float]] = {}
         self._cache_time: Dict[str, float] = {}

--- a/api/services/fred_service.py
+++ b/api/services/fred_service.py
@@ -12,15 +12,26 @@ import requests
 
 logger = logging.getLogger(__name__)
 
+# yfinance ticker mapping for FRED series fallback
+_YFINANCE_FALLBACK: Dict[str, str] = {
+    "DGS10": "^TNX",   # CBOE 10-Year Treasury Yield Index
+    "DGS2": "2YY=F",   # 2-Year T-Note Yield Futures
+}
+
 
 class FredService:
-    """Fetches latest FRED series value with in-memory TTL cache."""
+    """Fetches latest FRED series value with in-memory TTL cache.
+
+    When FRED_API_KEY is not set, falls back to yfinance for supported series.
+    """
 
     CACHE_TTL_SECONDS = 3600
     API_TIMEOUT_SECONDS = 10
 
     def __init__(self) -> None:
         self._api_key = os.getenv("FRED_API_KEY")
+        if not self._api_key:
+            logger.warning("FRED_API_KEY not set — will use yfinance fallback for US rates")
         self._lock = threading.RLock()
         self._cache: Dict[str, Optional[float]] = {}
         self._cache_time: Dict[str, float] = {}
@@ -32,9 +43,6 @@ class FredService:
 
     def get_series_with_date(self, series_id: str) -> Tuple[Optional[float], Optional[str]]:
         """Return (value, observation_date) for the latest valid FRED observation."""
-        if not self._api_key:
-            return None, None
-
         series = (series_id or "").strip().upper()
         if not series:
             return None, None
@@ -45,7 +53,11 @@ class FredService:
             if cache_key in self._cache and (now - self._cache_time.get(cache_key, 0.0)) < self.CACHE_TTL_SECONDS:
                 return self._cache[cache_key], self._cache.get(f"{series}:obs_date")
 
-        value, obs_date = self._fetch_latest(series)
+        if self._api_key:
+            value, obs_date = self._fetch_latest(series)
+        else:
+            value, obs_date = self._fetch_yfinance_fallback(series)
+
         with self._lock:
             self._cache[cache_key] = value
             self._cache[f"{series}:obs_date"] = obs_date
@@ -73,6 +85,56 @@ class FredService:
             return None, None
         except Exception:
             logger.warning("Failed to fetch FRED series: %s", series_id, exc_info=True)
+            return None, None
+
+    @staticmethod
+    def _fetch_yfinance_fallback(series_id: str) -> Tuple[Optional[float], Optional[str]]:
+        """Fetch US rates from yfinance when FRED API key is unavailable.
+
+        Includes a sanity check: yield values must be in [0, 20]% range
+        to guard against data-unit mismatches between sources.
+        """
+        ticker_symbol = _YFINANCE_FALLBACK.get(series_id)
+        if ticker_symbol is None:
+            return None, None
+
+        try:
+            import yfinance as yf  # noqa: PLC0415
+
+            ticker = yf.Ticker(ticker_symbol)
+            hist = ticker.history(period="5d")
+            if hist is None or hist.empty:
+                return None, None
+
+            close_col = "Close" if "Close" in hist.columns else None
+            if close_col is None:
+                return None, None
+
+            closes = hist[close_col].dropna()
+            if closes.empty:
+                return None, None
+
+            value = round(float(closes.iloc[-1]), 4)
+
+            # Sanity check: treasury yields should be in 0-20% range
+            if not (0.0 <= value <= 20.0):
+                logger.warning(
+                    "yfinance fallback value %.4f for %s (%s) out of sane range [0, 20] — discarded",
+                    value,
+                    series_id,
+                    ticker_symbol,
+                )
+                return None, None
+
+            obs_date = closes.index[-1].strftime("%Y-%m-%d")
+            return value, obs_date
+        except Exception:
+            logger.warning(
+                "yfinance fallback failed for FRED series %s (ticker %s)",
+                series_id,
+                ticker_symbol,
+                exc_info=True,
+            )
             return None, None
 
 

--- a/api/services/volatility_service.py
+++ b/api/services/volatility_service.py
@@ -96,6 +96,20 @@ class VolatilityService:
             logger.warning("Failed to fetch VIX snapshot", exc_info=True)
             return None, None, None
 
+    @staticmethod
+    def _safe_get_index_ohlcv(stock_mod: Any, fromdate: str, todate: str, ticker: str) -> Any:
+        """Call pykrx get_index_ohlcv_by_date with name_display=False fallback.
+
+        pykrx >=1.2.4 may crash with KeyError('지수명') when IndexTicker
+        returns an empty DataFrame.  Passing name_display=False avoids the
+        broken name-lookup path.  If the kwarg is unsupported (older versions),
+        fall back to the original call.
+        """
+        try:
+            return stock_mod.get_index_ohlcv_by_date(fromdate, todate, ticker, name_display=False)
+        except TypeError:
+            return stock_mod.get_index_ohlcv_by_date(fromdate, todate, ticker)
+
     def _fetch_vkospi(self) -> Tuple[Optional[float], Optional[float], Optional[str]]:
         try:
             from pykrx import stock
@@ -112,30 +126,18 @@ class VolatilityService:
         ticker = "1205"
 
         try:
-            df_today = stock.get_index_ohlcv_by_date(
-                today.strftime("%Y%m%d"),
-                today.strftime("%Y%m%d"),
-                ticker,
-            )
+            df_today = self._safe_get_index_ohlcv(stock, today.strftime("%Y%m%d"), today.strftime("%Y%m%d"), ticker)
 
             df_range = None
             if df_today is None or getattr(df_today, "empty", True):
-                df_range = stock.get_index_ohlcv_by_date(
-                    start_5d.strftime("%Y%m%d"),
-                    today.strftime("%Y%m%d"),
-                    ticker,
-                )
+                df_range = self._safe_get_index_ohlcv(stock, start_5d.strftime("%Y%m%d"), today.strftime("%Y%m%d"), ticker)
                 if df_range is None or getattr(df_range, "empty", True):
                     return None, None, None
                 base_df = df_range
             else:
                 base_df = df_today
                 # Change% needs at least previous close; fetch short range for robustness.
-                df_range = stock.get_index_ohlcv_by_date(
-                    start_5d.strftime("%Y%m%d"),
-                    today.strftime("%Y%m%d"),
-                    ticker,
-                )
+                df_range = self._safe_get_index_ohlcv(stock, start_5d.strftime("%Y%m%d"), today.strftime("%Y%m%d"), ticker)
 
             closes = self._extract_close_series(base_df)
             if not closes:

--- a/api/tests/test_bond_rate_service.py
+++ b/api/tests/test_bond_rate_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pandas as pd
 import pytest
 
 from api.services.bond_rate_service import BondRateService
@@ -11,12 +12,21 @@ from api.services.ecos_service import EcosService
 from api.services.fred_service import FredService
 
 
-def test_fred_service_returns_none_without_api_key():
+def test_fred_service_uses_yfinance_fallback_without_api_key():
     with patch.dict("os.environ", {}, clear=True):
         svc = FredService()
-        with patch("api.services.fred_service.requests.get") as mock_get:
-            assert svc.get_series("DGS10") is None
+        with (
+            patch("api.services.fred_service.requests.get") as mock_get,
+            patch.object(
+                FredService,
+                "_fetch_yfinance_fallback",
+                return_value=(4.21, "2026-03-11"),
+            ) as mock_yf,
+        ):
+            value = svc.get_series("DGS10")
             mock_get.assert_not_called()
+            mock_yf.assert_called_once_with("DGS10")
+            assert value == 4.21
 
 
 def test_fred_service_returns_latest_value_from_response():
@@ -157,4 +167,48 @@ def test_bond_rate_service_inverted_flag_false_when_spread_positive():
     service = BondRateService(fred=fred, ecos=ecos)
     snapshot = service.get_snapshot()
 
+    assert snapshot["inverted"] is False
+
+
+def test_fred_yfinance_fallback_returns_close_value():
+    """_fetch_yfinance_fallback should return close price from yfinance history."""
+    hist = pd.DataFrame(
+        {"Close": [4.15, 4.21]},
+        index=pd.to_datetime(["2026-03-10", "2026-03-11"]),
+    )
+    fake_ticker = MagicMock()
+    fake_ticker.history.return_value = hist
+
+    fake_yf = MagicMock()
+    fake_yf.Ticker.return_value = fake_ticker
+
+    with patch.dict("sys.modules", {"yfinance": fake_yf}):
+        value, obs_date = FredService._fetch_yfinance_fallback("DGS10")
+
+    assert value == 4.21
+    assert obs_date == "2026-03-11"
+
+
+def test_fred_yfinance_fallback_returns_none_for_unknown_series():
+    """Unknown series should return None without attempting yfinance fetch."""
+    value, obs_date = FredService._fetch_yfinance_fallback("UNKNOWN_SERIES")
+    assert value is None
+    assert obs_date is None
+
+
+def test_bond_rate_service_calculates_spread_when_t10y2y_unavailable():
+    """When T10Y2Y is None but both 10Y and 2Y are available, spread is calculated."""
+    fred = MagicMock()
+    fred.get_series_with_date.return_value = (4.10, "2026-03-10")
+    fred.get_series.side_effect = lambda s: {
+        "DGS2": 3.90,
+        "T10Y2Y": None,
+    }.get(s)
+    ecos = MagicMock()
+    ecos.get_stat_value.return_value = None
+
+    service = BondRateService(fred=fred, ecos=ecos)
+    snapshot = service.get_snapshot()
+
+    assert snapshot["us_spread_2_10"] == pytest.approx(0.20)
     assert snapshot["inverted"] is False

--- a/api/tests/test_volatility_service.py
+++ b/api/tests/test_volatility_service.py
@@ -39,7 +39,7 @@ def test_fetch_vkospi_snapshot_with_primary_and_range_change():
         index=pd.to_datetime(["2026-03-10", "2026-03-11"]),
     )
 
-    def fake_get_index_ohlcv_by_date(fromdate, todate, ticker):
+    def fake_get_index_ohlcv_by_date(fromdate, todate, ticker, **kwargs):
         if fromdate == todate:
             return today_df
         return range_df


### PR DESCRIPTION
## Summary
- Add yfinance fallback (`^TNX`, `2YY=F`) for US bond rates when `FRED_API_KEY` is not set, with sanity check (0-20% range)
- Calculate `T10Y2Y` spread from individual yields when direct FRED series unavailable
- Fix pykrx VKOSPI crash (`KeyError: '지수명'`) by bypassing broken `IndexTicker` name lookup via `name_display=False`
- Add warning logs when `FRED_API_KEY` / `ECOS_API_KEY` are missing

## Test plan
- [x] 18 unit tests pass (12 existing + 3 new + 3 updated)
- [ ] Verify bond rates display on `/ko/macro` with `FRED_API_KEY` unset (yfinance fallback)
- [ ] Verify bond rates display with `FRED_API_KEY` set (FRED primary)
- [ ] Verify VKOSPI displays on `/ko/macro` during KRX market hours

Closes #1192

🤖 Generated with [Claude Code](https://claude.com/claude-code)