### PR TITLE
feat(macro): add investor type breakdown to futures card (#1195)

### DIFF
--- a/api/schemas/market.py
+++ b/api/schemas/market.py
@@ -123,6 +123,9 @@ class MacroFuturesSnapshot(BaseModel):
     basis: Optional[float] = Field(None, description="Futures basis versus spot proxy")
     change_pct: Optional[float] = Field(None, description="Short-term futures change percent")
     updated_at: Optional[str] = Field(None, description="Last update timestamp")
+    foreign_net: Optional[int] = Field(None, description="Foreign net buy shares (proxy ETF)")
+    institution_net: Optional[int] = Field(None, description="Institutional net buy shares (proxy ETF)")
+    individual_net: Optional[int] = Field(None, description="Individual net buy shares (proxy ETF)")
 
 
 class MacroInvestorFlowSnapshot(BaseModel):

--- a/api/services/macro_market_service.py
+++ b/api/services/macro_market_service.py
@@ -305,6 +305,42 @@ class MacroMarketService:
             logger.debug("Naver stock API failed for %s: %s", code, exc)
             return None
 
+    def _fetch_naver_stock_trend(self, code: str) -> Dict[str, Any] | None:
+        """Fetch investor trend data for a stock/ETF from Naver trend API.
+
+        Returns the most recent day's entry with foreignerPureBuyQuant,
+        organPureBuyQuant, individualPureBuyQuant (share quantities).
+        """
+        try:
+            import requests
+        except ImportError:
+            return None
+        try:
+            url = f"https://m.stock.naver.com/api/stock/{code}/trend"
+            r = requests.get(url, headers={"Accept": "application/json"}, timeout=10)
+            r.raise_for_status()
+            body = r.json()
+            if isinstance(body, list) and len(body) > 0:
+                # Pick the entry with the latest bizdate (YYYYMMDD)
+                return max(body, key=lambda x: x.get("bizdate", ""))
+            return None
+        except Exception as exc:
+            logger.debug("Naver stock trend API failed for %s: %s", code, exc)
+            return None
+
+    @staticmethod
+    def _parse_naver_quantity(raw: str | int | float | None) -> int | None:
+        """Parse Naver quantity string like '+3,398' or '-282,363' to int."""
+        if raw is None:
+            return None
+        if isinstance(raw, (int, float)):
+            return int(raw)
+        try:
+            cleaned = raw.replace(",", "").replace("+", "").strip()
+            return int(cleaned)
+        except (TypeError, ValueError):
+            return None
+
     def _fetch_naver_index(self, index: str) -> Dict[str, Any] | None:
         """Fetch realtime index data from Naver Stock mobile API."""
         try:
@@ -345,12 +381,21 @@ class MacroMarketService:
                             theoretical = kpi200_value * self._KODEX_KPI200_MULTIPLIER
                             basis = round((fut_value - theoretical) / theoretical * 100, 3)
 
+                # Investor breakdown (share quantities) for the ETF
+                investor = self._fetch_naver_stock_trend(futures_code)
+                foreign_net = self._parse_naver_quantity(investor.get("foreignerPureBuyQuant")) if investor else None
+                institution_net = self._parse_naver_quantity(investor.get("organPureBuyQuant")) if investor else None
+                individual_net = self._parse_naver_quantity(investor.get("individualPureBuyQuant")) if investor else None
+
                 return {
                     "symbol": self.futures_ticker,
                     "value": fut_value,
                     "basis": basis,
                     "change_pct": change_pct,
                     "updated_at": self._to_iso(updated_at or now),
+                    "foreign_net": foreign_net,
+                    "institution_net": institution_net,
+                    "individual_net": individual_net,
                 }
         except Exception as exc:
             logger.debug("Naver futures snapshot failed, falling back: %s", exc)

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -160,6 +160,8 @@
     "flowUnit": "100M KRW",
     "fxSource": "Naver Finance",
     "futuresSource": "KODEX 200 vs KOSPI",
+    "futuresInvestorLabel": "Investor Breakdown (proxy)",
+    "sharesUnit": "shares",
     "flowSource": "Naver Stock",
     "alignmentAlignedBuy": "Aligned Buy",
     "alignmentAlignedSell": "Aligned Sell",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -160,6 +160,8 @@
     "flowUnit": "억원",
     "fxSource": "네이버 금융",
     "futuresSource": "KODEX 200 vs KOSPI",
+    "futuresInvestorLabel": "투자자별 수급 (프록시)",
+    "sharesUnit": "주",
     "flowSource": "네이버 증권",
     "alignmentAlignedBuy": "동행 매수",
     "alignmentAlignedSell": "동행 매도",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -160,6 +160,8 @@
     "flowUnit": "亿韩元",
     "fxSource": "Naver金融",
     "futuresSource": "KODEX 200 vs KOSPI",
+    "futuresInvestorLabel": "投资者分类 (代理)",
+    "sharesUnit": "股",
     "flowSource": "Naver Stock",
     "alignmentAlignedBuy": "同步买入",
     "alignmentAlignedSell": "同步卖出",

--- a/web/src/app/[locale]/macro/page.tsx
+++ b/web/src/app/[locale]/macro/page.tsx
@@ -59,6 +59,12 @@ function formatFlowBillion(value: number | null, locale: string): string {
   return prefix + formatNumber(Math.round(billion), locale, 0);
 }
 
+function formatShares(value: number | null, locale: string): string {
+  if (value == null || Number.isNaN(value)) return '-';
+  const prefix = value > 0 ? '+' : '';
+  return prefix + formatNumber(value, locale, 0);
+}
+
 const ALIGNMENT_STYLES: Record<string, { color: string; bg: string }> = {
   aligned_buy: { color: 'text-emerald-400', bg: 'bg-emerald-900/30' },
   aligned_sell: { color: 'text-red-400', bg: 'bg-red-900/30' },
@@ -162,6 +168,71 @@ function FlowGrid({
             <div key={key} className="flex items-center justify-between gap-2">
               <span className="text-xs text-[var(--foreground-muted)]">{label}</span>
               <FlowValueCell value={kosdaqValues[key]} locale={locale} />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// FuturesInvestorGrid — Investor breakdown for futures proxy ETF (shares)
+// ---------------------------------------------------------------------------
+
+function ShareValueCell({ value, locale }: { value: number | null; locale: string }) {
+  const formatted = formatShares(value, locale);
+  const color =
+    value == null ? 'text-[var(--foreground-muted)]'
+    : value > 0 ? 'text-emerald-400'
+    : value < 0 ? 'text-red-400'
+    : 'text-[var(--foreground-muted)]';
+  return <span className={`text-sm font-medium tabular-nums ${color}`}>{formatted}</span>;
+}
+
+function FuturesInvestorGrid({
+  futures,
+  locale,
+  t,
+}: {
+  futures: import('@/lib/types').MacroFuturesSnapshot | null;
+  locale: string;
+  t: (key: string) => string;
+}) {
+  const hasBasis = futures?.basis != null;
+  const hasInvestor = futures != null && (
+    futures.foreign_net != null ||
+    futures.institution_net != null ||
+    futures.individual_net != null
+  );
+
+  return (
+    <div className="space-y-2">
+      {/* Basis row — always shown */}
+      <div className="space-y-0.5">
+        <p className="text-sm text-[var(--foreground-muted)]">
+          {t('basis')}: {hasBasis ? `${futures!.basis! > 0 ? '+' : ''}${formatNumber(futures!.basis!, locale, 3)}%` : '-'}
+        </p>
+        <p className="text-[10px] text-[var(--foreground-muted)] opacity-60">{t('basisExplain')}</p>
+      </div>
+
+      {/* Investor breakdown */}
+      {hasInvestor && (
+        <div className="space-y-1.5">
+          <p className="text-[11px] font-semibold uppercase tracking-wider text-[var(--foreground-muted)] opacity-70">
+            {t('futuresInvestorLabel')}
+          </p>
+          {([
+            { key: 'foreign', label: t('foreign'), value: futures!.foreign_net },
+            { key: 'institution', label: t('institution'), value: futures!.institution_net },
+            { key: 'individual', label: t('individual'), value: futures!.individual_net },
+          ] as const).map(({ key, label, value }) => (
+            <div key={key} className="flex items-center justify-between gap-2">
+              <span className="text-xs text-[var(--foreground-muted)]">{label}</span>
+              <div className="flex items-center gap-1">
+                <ShareValueCell value={value ?? null} locale={locale} />
+                <span className="text-[10px] text-[var(--foreground-muted)]">{t('sharesUnit')}</span>
+              </div>
             </div>
           ))}
         </div>
@@ -545,9 +616,14 @@ export default function MacroPage() {
           frequencyBadge="real-time"
           frequencyLabel={t('freq_realtime')}
           tooltipText={t('explainFutures')}
-          items={[
-            { label: t('basis'), value: bundleQuery.data?.futures?.basis != null ? `${bundleQuery.data!.futures!.basis > 0 ? '+' : ''}${formatNumber(bundleQuery.data!.futures!.basis, locale, 3)}%` : '-', hint: t('basisExplain') },
-          ]}
+          items={[]}
+          customBody={
+            <FuturesInvestorGrid
+              futures={bundleQuery.data?.futures ?? null}
+              locale={locale}
+              t={t}
+            />
+          }
           ageSec={bundleQuery.data?.freshness?.futures_age_sec ?? null}
           ageLabel={formatAge(bundleQuery.data?.freshness?.futures_age_sec ?? null, t)}
           staleLabel={t('staleWarning')}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -330,6 +330,9 @@ export interface MacroFuturesSnapshot {
   basis: number | null;
   change_pct: number | null;
   updated_at: string | null;
+  foreign_net: number | null;
+  institution_net: number | null;
+  individual_net: number | null;
 }
 
 export type FlowAlignment = 'aligned_buy' | 'aligned_sell' | 'foreign_lead' | 'institution_lead' | 'unknown';


### PR DESCRIPTION
## Summary
- Add investor breakdown (foreign/institutional/individual net buy shares) to the KODEX 200 proxy futures card
- Fetch data from Naver Stock trend API (`/api/stock/{code}/trend`) — returns share quantities per investor type
- Display with color-coded +/- values using `customBody` pattern (consistent with FlowGrid)
- Backend schema + frontend types synced with `foreign_net`, `institution_net`, `individual_net` (Optional int)
- i18n keys added for en/ko/zh

## Changes
- `api/services/macro_market_service.py`: Add `_fetch_naver_stock_trend()` and `_parse_naver_quantity()`, enrich futures snapshot
- `api/schemas/market.py`: Add 3 Optional[int] fields to `MacroFuturesSnapshot`
- `web/src/lib/types.ts`: Mirror schema changes
- `web/src/app/[locale]/macro/page.tsx`: Add `FuturesInvestorGrid` component with basis + investor breakdown
- `web/messages/{en,ko,zh}.json`: Add `futuresInvestorLabel`, `sharesUnit` keys

## Test plan
- [x] ESLint clean (0 errors)
- [x] Next.js build passes
- [x] Codex code review passed (2 medium issues fixed)
- [ ] Visual verification on localhost:3001/en/macro

Closes #1195

🤖 Generated with [Claude Code](https://claude.com/claude-code)