### PR TITLE
feat(macro): add VIX bar chart overlay to timeline chart (#1206)

### DIFF
--- a/api/database.py
+++ b/api/database.py
@@ -67,6 +67,7 @@ def init_db() -> None:
     _migrate_json_data()
     _migrate_portfolio_json()
     _migrate_saved_screening_to_execution_history()
+    _migrate_macro_history_vix()
 
 
 def _get_column_names(conn, table_name: str):
@@ -389,3 +390,17 @@ def _migrate_saved_screening_to_execution_history() -> None:
         logger.error("Saved screening migration failed: %s", e)
     finally:
         db.close()
+
+
+def _migrate_macro_history_vix() -> None:
+    """Add vix column to macro_history table if missing."""
+    try:
+        with engine.begin() as conn:
+            existing_columns = _get_column_names(conn, "macro_history")
+            if existing_columns is None:
+                return
+            if "vix" not in existing_columns:
+                conn.execute(text("ALTER TABLE macro_history ADD COLUMN vix FLOAT"))
+                logger.info("Added macro_history.vix column")
+    except Exception as e:
+        logger.warning("macro_history vix migration skipped: %s", e)

--- a/api/models/macro_history.py
+++ b/api/models/macro_history.py
@@ -22,4 +22,5 @@ class MacroHistory(Base):
     foreign_net = Column(Float, nullable=True)
     macro_score = Column(Float, nullable=True)
     regime = Column(String(32), nullable=True, default="unknown")
+    vix = Column(Float, nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)

--- a/api/schemas/market.py
+++ b/api/schemas/market.py
@@ -284,6 +284,7 @@ class MacroHistoryPoint(BaseModel):
     foreign_net: Optional[float] = Field(None, description="Foreign net flow")
     macro_score: Optional[float] = Field(None, description="Macro score")
     regime: str = Field(..., description="Regime at timestamp")
+    vix: Optional[float] = Field(None, description="VIX index value at timestamp")
 
 
 class MacroHistoryResponse(BaseModel):

--- a/api/services/macro_market_service.py
+++ b/api/services/macro_market_service.py
@@ -175,6 +175,7 @@ class MacroMarketService:
                     "foreign_net": p.get("foreign_net"),
                     "macro_score": p.get("macro_score"),
                     "regime": p.get("regime", "unknown"),
+                    "vix": p.get("vix"),
                 })
         points.reverse()  # restore chronological order
 
@@ -788,6 +789,16 @@ class MacroMarketService:
         futures = bundle.get("futures", {})
         flow = bundle.get("flow", {})
 
+        # Fetch VIX from volatility service (lazy import to avoid circular deps)
+        vix_value: float | None = None
+        try:
+            from api.services.volatility_service import get_volatility_service
+            vol = get_volatility_service().get_snapshot()
+            if vol:
+                vix_value = self._to_float(vol.get("vix"))
+        except Exception as exc:
+            logger.debug("VIX fetch for history point failed: %s", exc)
+
         point = {
             "timestamp": self._to_iso(now),
             "fx_value": self._to_float(fx.get("value")),
@@ -795,6 +806,7 @@ class MacroMarketService:
             "foreign_net": self._to_float(flow.get("foreign_net")),
             "macro_score": self._to_float(signal.get("macro_score")),
             "regime": signal.get("regime", "unknown"),
+            "vix": vix_value,
         }
         should_flush = False
         with self._lock:
@@ -834,6 +846,7 @@ class MacroMarketService:
                         "foreign_net": row.foreign_net,
                         "macro_score": row.macro_score,
                         "regime": row.regime or "unknown",
+                        "vix": getattr(row, "vix", None),
                     })
                 if rows:
                     logger.info("Loaded %d macro history rows from DB", len(rows))
@@ -1058,6 +1071,7 @@ class MacroMarketService:
                         foreign_net=point.get("foreign_net"),
                         macro_score=point.get("macro_score"),
                         regime=point.get("regime"),
+                        vix=point.get("vix"),
                     ))
                 db.commit()
             finally:
@@ -1091,6 +1105,7 @@ class MacroMarketService:
                         "foreign_net": r.foreign_net,
                         "macro_score": r.macro_score,
                         "regime": r.regime or "unknown",
+                        "vix": getattr(r, "vix", None),
                     }
                     for r in rows
                 ]

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -202,6 +202,7 @@
     "regimeRiskOff": "Risk-Off",
     "regimeNeutral": "Neutral",
     "fxVolatility": "FX Volatility",
+    "vixBar": "VIX",
     "signalStrongBuy": "Strong Buy",
     "signalBuy": "Buy",
     "signalNeutral": "Neutral",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -202,6 +202,7 @@
     "regimeRiskOff": "위험 회피",
     "regimeNeutral": "중립",
     "fxVolatility": "FX 변동성",
+    "vixBar": "VIX",
     "signalStrongBuy": "강한 매수",
     "signalBuy": "매수",
     "signalNeutral": "중립",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -202,6 +202,7 @@
     "regimeRiskOff": "风险规避",
     "regimeNeutral": "中性",
     "fxVolatility": "汇率波动性",
+    "vixBar": "VIX",
     "signalStrongBuy": "强烈买入",
     "signalBuy": "买入",
     "signalNeutral": "中性",

--- a/web/src/app/[locale]/macro/page.tsx
+++ b/web/src/app/[locale]/macro/page.tsx
@@ -1058,6 +1058,7 @@ export default function MacroPage() {
                   tickFormatter={(v: number) => `${(v * 100).toFixed(0)}%`}
                   width={50}
                 />
+                <YAxis yAxisId="vix" orientation="right" hide domain={[0, 'auto']} />
                 <Tooltip
                   contentStyle={{
                     backgroundColor: 'var(--background-secondary)',
@@ -1074,6 +1075,7 @@ export default function MacroPage() {
                     if (name === t('macroScore')) return [formatPercent(v), name];
                     if (name === t('fxChangePct')) return [`${v > 0 ? '+' : ''}${v.toFixed(3)}%`, name];
                     if (name === t('fxVolatility')) return [`${(v * 100).toFixed(3)}%`, name];
+                    if (name === t('vixBar')) return [v.toFixed(2), name];
                     return [String(value), name];
                   }}
                 />
@@ -1082,6 +1084,13 @@ export default function MacroPage() {
                   align="right"
                   iconType="line"
                   wrapperStyle={{ fontSize: 11, paddingBottom: 4 }}
+                />
+                <Bar
+                  yAxisId="vix"
+                  dataKey="vix"
+                  name={t('vixBar')}
+                  fill="rgba(239,68,68,0.18)"
+                  barSize={8}
                 />
                 <Bar
                   yAxisId="score"

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -486,6 +486,7 @@ export interface MacroHistoryPoint {
   foreign_net: number | null;
   macro_score: number | null;
   regime: MacroRegime;
+  vix: number | null;
 }
 
 export interface MacroHistoryResponse {


### PR DESCRIPTION
## Summary
- Add VIX values to macro history snapshots (both in-memory deque and DB persistence)
- Display VIX as semi-transparent red bar chart overlay on the timeline
- Auto-migration adds `vix` column to existing `macro_history` table
- VIX fetched from volatility service at each history collector tick via lazy import

## Changes
- `api/models/macro_history.py`: Add `vix` Float column
- `api/schemas/market.py`: Add `vix` to `MacroHistoryPoint`
- `api/services/macro_market_service.py`: Record VIX in `_append_history`, include in all history read paths (memory + DB)
- `api/database.py`: Add `_migrate_macro_history_vix()` migration
- `web/src/lib/types.ts`: Add `vix` to `MacroHistoryPoint`
- `web/src/app/[locale]/macro/page.tsx`: Add hidden VIX Y-axis + Bar component
- `web/messages/{en,ko,zh}.json`: Add `vixBar` key

## Test plan
- [x] Next.js build passes
- [x] Codex code review passed (1 high fix: memory path missing vix, 1 medium fix: debug logging)
- [ ] Visual verification on localhost:3001/ko/macro

Closes #1206

🤖 Generated with [Claude Code](https://claude.com/claude-code)