### PR TITLE
fix(macro): adapt timeline chart X-axis format to selected time window

### DIFF
--- a/web/src/app/[locale]/macro/page.tsx
+++ b/web/src/app/[locale]/macro/page.tsx
@@ -100,14 +100,18 @@ function formatDateTime(value: string | null, locale: string): string {
   }).format(date);
 }
 
-function formatShortTime(value: string | null, locale: string): string {
+function formatShortTime(value: string | null, locale: string, window?: string): string {
   if (!value) return '';
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return '';
-  return new Intl.DateTimeFormat(locale === 'ko' ? 'ko-KR' : locale === 'zh' ? 'zh-CN' : 'en-US', {
-    hour: '2-digit',
-    minute: '2-digit',
-  }).format(date);
+  const loc = locale === 'ko' ? 'ko-KR' : locale === 'zh' ? 'zh-CN' : 'en-US';
+  if (window === '30d') {
+    return new Intl.DateTimeFormat(loc, { month: '2-digit', day: '2-digit' }).format(date);
+  }
+  if (window === '7d') {
+    return new Intl.DateTimeFormat(loc, { month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' }).format(date);
+  }
+  return new Intl.DateTimeFormat(loc, { hour: '2-digit', minute: '2-digit' }).format(date);
 }
 
 interface SignalContrib {
@@ -750,7 +754,7 @@ export default function MacroPage() {
                 ))}
                 <XAxis
                   dataKey="timestamp"
-                  tickFormatter={(v: string) => formatShortTime(v, locale)}
+                  tickFormatter={(v: string) => formatShortTime(v, locale, historyWindow)}
                   tick={{ fontSize: 11, fill: 'var(--foreground-muted)' }}
                   stroke="var(--border)"
                 />


### PR DESCRIPTION
## Summary
- Timeline chart X-axis now adapts label format to the selected time window
- **1시간/6시간/1일**: time only (`오후 03:57`)
- **1주**: date + time (`03. 12. 오전 06:38`)
- **1개월**: date only (`03. 12.`)

Previously all windows showed time-only format, making 1w/1m views unreadable.

Closes #1214

## Test plan
- [x] TypeScript type check passes
- [x] 1시간 view: X-axis shows time only
- [x] 1주 view: X-axis shows date + time
- [x] 1개월 view: X-axis shows date only
- [x] Codex review: LGTM

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*Reviewed by: Codex MCP*