### PR TITLE
feat(macro): clarify market mode with tab bar and dynamic subtitle (#1221)

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -115,6 +115,10 @@
   "macro": {
     "title": "Macro Monitor",
     "subtitle": "Combined view of FX, futures, and investor flow",
+    "subtitleKR": "Combined view of FX, futures, and investor flow",
+    "subtitleUS": "Combined view of VIX, rates, and S&P 500",
+    "modeTabKR": "Korea Market",
+    "modeTabUS": "US Market",
     "refresh": "Refresh",
     "regime": "Regime",
     "regime_risk_on": "Risk-On",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -115,6 +115,10 @@
   "macro": {
     "title": "매크로 모니터",
     "subtitle": "환율, 선물, 수급을 통합해서 확인합니다",
+    "subtitleKR": "환율, 선물, 수급을 통합해서 확인합니다",
+    "subtitleUS": "VIX, 금리, S&P 500을 통합해서 확인합니다",
+    "modeTabKR": "한국 시장",
+    "modeTabUS": "미국 시장",
     "refresh": "새로고침",
     "regime": "레짐",
     "regime_risk_on": "위험선호",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -115,6 +115,10 @@
   "macro": {
     "title": "宏观监控",
     "subtitle": "整合查看汇率、期货与投资者资金流",
+    "subtitleKR": "整合查看汇率、期货与投资者资金流",
+    "subtitleUS": "整合查看VIX、利率与标普500",
+    "modeTabKR": "韩国市场",
+    "modeTabUS": "美国市场",
     "refresh": "刷新",
     "regime": "状态",
     "regime_risk_on": "风险偏好",

--- a/web/src/app/[locale]/macro/page.tsx
+++ b/web/src/app/[locale]/macro/page.tsx
@@ -416,29 +416,11 @@ export default function MacroPage() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div>
-          <h1 className="text-2xl font-bold text-[var(--foreground)]">{t('title')}</h1>
-          <p className="mt-1 text-[var(--foreground-muted)]">{t('subtitle')}</p>
-        </div>
-        <div className="flex items-center gap-2">
-          {/* Market Mode Toggle */}
-          <div className="inline-flex rounded-lg border border-[var(--border)] overflow-hidden">
-            {(['kr', 'us'] as const).map((mode) => (
-              <button
-                key={mode}
-                type="button"
-                onClick={() => setMarketMode(mode)}
-                aria-pressed={marketMode === mode}
-                className={`px-3 py-2 text-sm font-medium transition-colors ${
-                  marketMode === mode
-                    ? 'bg-[var(--accent)] text-white'
-                    : 'bg-[var(--background-secondary)] text-[var(--foreground-muted)] hover:bg-[var(--background)]'
-                }`}
-              >
-                {t(mode === 'kr' ? 'modeKR' : 'modeUS')}
-              </button>
-            ))}
+      <div className="space-y-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h1 className="text-2xl font-bold text-[var(--foreground)]">{t('title')}</h1>
+            <p className="mt-1 text-[var(--foreground-muted)]">{t(isKrMode ? 'subtitleKR' : 'subtitleUS')}</p>
           </div>
           <button
             type="button"
@@ -452,6 +434,33 @@ export default function MacroPage() {
             <RefreshCw className="h-4 w-4" />
             {t('refresh')}
           </button>
+        </div>
+
+        {/* Market Mode Tabs */}
+        <div className="flex border-b border-[var(--border)]">
+          {(['kr', 'us'] as const).map((mode) => {
+            const active = marketMode === mode;
+            const flag = mode === 'kr' ? '\u{1F1F0}\u{1F1F7}' : '\u{1F1FA}\u{1F1F8}';
+            return (
+              <button
+                key={mode}
+                type="button"
+                onClick={() => setMarketMode(mode)}
+                aria-pressed={active}
+                className={`relative flex items-center gap-2 px-5 py-3 text-sm font-semibold transition-colors ${
+                  active
+                    ? 'text-[var(--accent)]'
+                    : 'text-[var(--foreground-muted)] hover:text-[var(--foreground)]'
+                }`}
+              >
+                <span className="text-base">{flag}</span>
+                {t(mode === 'kr' ? 'modeTabKR' : 'modeTabUS')}
+                {active && (
+                  <span className="absolute inset-x-0 bottom-0 h-0.5 bg-[var(--accent)]" />
+                )}
+              </button>
+            );
+          })}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Replace small KR/US toggle buttons with full-width tab bar (🇰🇷 한국 시장 / 🇺🇸 미국 시장)
- Selected tab shows accent underline bar
- Subtitle dynamically changes per mode (KR: FX/futures/flow, US: VIX/rates/S&P 500)
- Refresh button stays at title right (unchanged)

Closes #1221

## Test plan
- [x] Build clean
- [x] Playwright visual verification — KR and US tabs render correctly with flags
- [x] Subtitle changes on tab switch
- [x] Codex review passed (emoji escape false positive dismissed — verified in screenshot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Reviewed-by: Codex