### PR TITLE
feat(engine): connect QuantCanvas strategy graph to backtesting engine (#1241)

### DIFF
--- a/api/routers/backtest.py
+++ b/api/routers/backtest.py
@@ -11,6 +11,8 @@ from fastapi import APIRouter, HTTPException
 from api.schemas.backtest import (
     BacktestRequest,
     BacktestResponse,
+    GraphBacktestRequest,
+    GraphBacktestResponse,
     OptimizeRequest,
     OptimizeResponse,
     StrategiesListResponse,
@@ -19,6 +21,7 @@ from api.services.backtest_service import (
     get_strategies,
     optimize_backtest,
     run_backtest,
+    run_graph_backtest,
 )
 
 logger = logging.getLogger(__name__)
@@ -55,6 +58,26 @@ def run(request: BacktestRequest) -> BacktestResponse:
     except Exception as e:
         logger.exception("Backtest execution failed")
         raise HTTPException(status_code=500, detail=f"Backtest failed: {str(e)}")
+
+
+@router.post(
+    "/run-graph",
+    response_model=GraphBacktestResponse,
+    summary="Run a backtest from a strategy graph",
+    description="Run a backtest using a QuantCanvas strategy graph. "
+    "Converts graph conditions into a backtesting strategy and executes it. "
+    "Unsupported conditions (fundamental, pairs) are skipped with warnings.",
+)
+def run_graph(request: GraphBacktestRequest) -> GraphBacktestResponse:
+    """Run a backtest from a QuantCanvas strategy graph."""
+    try:
+        result = run_graph_backtest(request)
+        return result
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.exception("Graph backtest execution failed")
+        raise HTTPException(status_code=500, detail=f"Graph backtest failed: {str(e)}")
 
 
 @router.post(

--- a/api/schemas/backtest.py
+++ b/api/schemas/backtest.py
@@ -8,6 +8,8 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
+from api.schemas.strategy import StrategyGraph
+
 
 class StrategyParamInfo(BaseModel):
     """Schema for a single strategy parameter."""
@@ -173,3 +175,55 @@ class OptimizeResponse(BaseModel):
     best_metrics: BacktestMetrics
     trades: List[TradeRecord] = Field(default_factory=list)
     equity_curve: List[EquityPoint] = Field(default_factory=list)
+
+
+class GraphBacktestRequest(BaseModel):
+    """Request to run a backtest using a QuantCanvas strategy graph."""
+
+    graph: StrategyGraph = Field(description="Strategy graph from QuantCanvas")
+    ticker: str = Field(description="Ticker symbol (e.g., 'AAPL', '005930.KS')")
+    period: str = Field(default="1y", description="Data period (e.g., '1y', '6mo')")
+    start: Optional[str] = Field(default=None, description="Start date (YYYY-MM-DD)")
+    end: Optional[str] = Field(default=None, description="End date (YYYY-MM-DD)")
+    cash: float = Field(default=10_000_000, description="Initial cash amount")
+    commission: float = Field(default=0.001, description="Commission rate")
+    take_profit: Optional[float] = Field(
+        default=None,
+        ge=0.001,
+        le=1.0,
+        description="Fixed take-profit ratio (e.g. 0.05 = 5%)",
+    )
+    stop_loss: Optional[float] = Field(
+        default=None,
+        ge=0.001,
+        le=1.0,
+        description="Fixed stop-loss ratio (e.g. 0.03 = 3%)",
+    )
+    include_trades: bool = Field(default=True)
+    include_equity_curve: bool = Field(default=True)
+    max_trades: int = Field(default=500, ge=1, le=5000)
+    max_equity_points: int = Field(default=1000, ge=10, le=5000)
+
+
+class GraphBacktestResponse(BaseModel):
+    """Response from a graph-based backtest run."""
+
+    ticker: str
+    strategy: str = Field(default="graph", description="Always 'graph' for graph-based backtests")
+    period: str
+    cash: float
+    metrics: BacktestMetrics
+    trades: List[TradeRecord] = Field(default_factory=list)
+    equity_curve: List[EquityPoint] = Field(default_factory=list)
+    compiled_conditions: List[str] = Field(
+        default_factory=list,
+        description="Condition types that were compiled into the strategy",
+    )
+    skipped_conditions: List[str] = Field(
+        default_factory=list,
+        description="Condition types that were skipped (unsupported for backtesting)",
+    )
+    warnings: List[str] = Field(
+        default_factory=list,
+        description="Warnings about graph interpretation",
+    )

--- a/api/services/backtest_service.py
+++ b/api/services/backtest_service.py
@@ -19,6 +19,8 @@ from api.schemas.backtest import (
     BacktestRequest,
     BacktestResponse,
     EquityPoint,
+    GraphBacktestRequest,
+    GraphBacktestResponse,
     OptimizeRequest,
     OptimizeResponse,
     StrategyInfo,
@@ -373,4 +375,70 @@ def optimize_backtest(request: OptimizeRequest) -> OptimizeResponse:
         best_metrics=metrics,
         trades=trades,
         equity_curve=equity_curve,
+    )
+
+
+def run_graph_backtest(request: GraphBacktestRequest) -> GraphBacktestResponse:
+    """Run a backtest using a QuantCanvas strategy graph.
+
+    Converts graph conditions into a compiled strategy and runs it through
+    the BacktestEngine.
+
+    Args:
+        request: GraphBacktestRequest with graph, ticker, period, etc.
+
+    Returns:
+        GraphBacktestResponse with metrics, trades, equity curve, and warnings.
+
+    Raises:
+        ValueError: If no backtestable conditions are found.
+    """
+    from api.services.strategy_builder import build_strategy_from_graph
+
+    # Build strategy from graph
+    build_result = build_strategy_from_graph(
+        graph=request.graph,
+        take_profit=request.take_profit,
+        stop_loss=request.stop_loss,
+    )
+
+    engine = BacktestEngine(commission=request.commission)
+
+    # Run backtest
+    result = engine.run(
+        strategy=build_result.strategy_cls,
+        ticker=request.ticker,
+        period=request.period,
+        start=request.start,
+        end=request.end,
+        cash=request.cash,
+    )
+
+    # Calculate metrics
+    perf = calculate_metrics(result)
+    metrics = _metrics_to_schema(perf)
+
+    # Extract trades and equity curve
+    trades = (
+        _extract_trades(result, max_trades=request.max_trades)
+        if request.include_trades
+        else []
+    )
+    equity_curve = (
+        _extract_equity_curve(result, max_points=request.max_equity_points)
+        if request.include_equity_curve
+        else []
+    )
+
+    return GraphBacktestResponse(
+        ticker=request.ticker,
+        strategy="graph",
+        period=request.period,
+        cash=request.cash,
+        metrics=metrics,
+        trades=trades,
+        equity_curve=equity_curve,
+        compiled_conditions=build_result.compiled_conditions,
+        skipped_conditions=build_result.skipped_conditions,
+        warnings=build_result.warnings,
     )

--- a/api/services/strategy_builder.py
+++ b/api/services/strategy_builder.py
@@ -1,0 +1,204 @@
+"""
+Strategy Builder Service.
+
+Converts a QuantCanvas strategy graph (DAG) into a backtestable Strategy.
+Uses the GraphBacktestStrategy with compiled signal functions.
+
+Architecture:
+    StrategyGraph (JSON) -> walk DAG from output node -> compile conditions -> inject into Strategy -> run backtest
+
+The builder respects graph topology by walking edges backward from the output
+node, rather than flat-scanning all nodes. This ensures only reachable
+conditions are included and the correct logic operator is used.
+"""
+
+import logging
+from collections import defaultdict, deque
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Set, Type
+
+from backtesting import Strategy
+
+from api.schemas.strategy import StrategyGraph, StrategyNode
+from engine.strategies.graph_strategy import (
+    GraphBacktestStrategy,
+    SignalSpec,
+    SUPPORTED_CONDITION_TYPES,
+    compile_condition,
+)
+
+logger = logging.getLogger(__name__)
+
+# Logic operators supported for backtesting
+_SUPPORTED_LOGIC_OPS = {"and", "or"}
+
+
+@dataclass
+class BuildResult:
+    """Result of building a Strategy from a graph."""
+
+    strategy_cls: Type[Strategy]
+    warnings: List[str] = field(default_factory=list)
+    skipped_conditions: List[str] = field(default_factory=list)
+    compiled_conditions: List[str] = field(default_factory=list)
+
+
+def _walk_reachable(
+    node_id: str,
+    reverse_adj: Dict[str, List[str]],
+    node_map: Dict[str, StrategyNode],
+    visited: Set[str],
+) -> List[str]:
+    """Walk backward from a node and return all reachable node IDs (BFS)."""
+    queue = deque([node_id])
+    order: List[str] = []
+    while queue:
+        nid = queue.popleft()
+        if nid in visited:
+            continue
+        visited.add(nid)
+        order.append(nid)
+        # Follow reverse edges
+        for parent_id in reverse_adj.get(nid, []):
+            if parent_id not in visited:
+                queue.append(parent_id)
+        # Follow child_node_ids (logic nodes reference children directly)
+        node = node_map.get(nid)
+        if node and node.data.child_node_ids:
+            for child_id in node.data.child_node_ids:
+                if child_id not in visited:
+                    queue.append(child_id)
+    return order
+
+
+def build_strategy_from_graph(
+    graph: StrategyGraph,
+    take_profit: Optional[float] = None,
+    stop_loss: Optional[float] = None,
+) -> BuildResult:
+    """Build a backtestable Strategy class from a QuantCanvas graph.
+
+    Walks the DAG backward from the output node to discover reachable
+    condition and logic nodes. Only connected nodes are compiled.
+
+    Args:
+        graph: The strategy graph with nodes and edges.
+        take_profit: Optional fixed take-profit ratio (e.g. 0.05 = 5%).
+        stop_loss: Optional fixed stop-loss ratio (e.g. 0.03 = 3%).
+
+    Returns:
+        BuildResult with the Strategy class, warnings, and metadata.
+
+    Raises:
+        ValueError: If no backtestable conditions are found in the graph.
+    """
+    warnings: List[str] = []
+    skipped: List[str] = []
+    compiled: List[str] = []
+
+    # Build node lookup and adjacency
+    node_map: Dict[str, StrategyNode] = {n.id: n for n in graph.nodes}
+    reverse_adj: Dict[str, List[str]] = defaultdict(list)
+    for edge in graph.edges:
+        reverse_adj[edge.target].append(edge.source)
+
+    # Find output node(s) — walk backward from each
+    output_nodes = [n for n in graph.nodes if n.data.node_type == "output"]
+    if not output_nodes:
+        # Fallback: treat all nodes as reachable (backward compat)
+        reachable_ids = set(node_map.keys())
+        warnings.append("No output node found; using all nodes as reachable.")
+    else:
+        visited: Set[str] = set()
+        for out_node in output_nodes:
+            _walk_reachable(out_node.id, reverse_adj, node_map, visited)
+        reachable_ids = visited
+
+    # Collect condition nodes and logic operator from reachable nodes
+    condition_nodes: List[StrategyNode] = []
+    root_logic_operator = "and"  # default
+    seen_condition_ids: Set[str] = set()
+
+    for nid in reachable_ids:
+        node = node_map.get(nid)
+        if node is None:
+            continue
+
+        if node.data.node_type == "condition":
+            if nid not in seen_condition_ids:
+                seen_condition_ids.add(nid)
+                condition_nodes.append(node)
+
+        elif node.data.node_type == "logic":
+            op = node.data.logic_operator
+            if op:
+                if op in _SUPPORTED_LOGIC_OPS:
+                    root_logic_operator = op
+                elif op == "not":
+                    warnings.append(
+                        f"Logic operator 'not' (node '{nid}') is not supported for "
+                        f"backtesting. Falling back to 'and'."
+                    )
+                else:
+                    warnings.append(
+                        f"Unknown logic operator '{op}' (node '{nid}'). "
+                        f"Falling back to 'and'."
+                    )
+
+        elif node.data.node_type in ("universe", "sector"):
+            warnings.append(
+                f"Node '{nid}' ({node.data.node_type}) is ignored in backtesting "
+                f"(single-ticker mode)."
+            )
+
+    # Compile conditions into signals
+    signal_specs: List[SignalSpec] = []
+
+    for cond_node in condition_nodes:
+        ct = cond_node.data.condition_type
+        if ct is None:
+            warnings.append(f"Condition node '{cond_node.id}' has no condition_type, skipped.")
+            continue
+
+        if ct not in SUPPORTED_CONDITION_TYPES:
+            skipped.append(ct)
+            warnings.append(
+                f"Condition '{ct}' is not supported for backtesting and was skipped. "
+                f"Supported: {', '.join(sorted(SUPPORTED_CONDITION_TYPES))}"
+            )
+            continue
+
+        spec = compile_condition(ct, cond_node.data.params)
+        if spec is None:
+            skipped.append(ct)
+            continue
+
+        signal_specs.append(spec)
+        compiled.append(ct)
+
+    if not signal_specs:
+        raise ValueError(
+            "No backtestable conditions found in the graph. "
+            f"Skipped conditions: {skipped}. "
+            f"Supported types: {', '.join(sorted(SUPPORTED_CONDITION_TYPES))}"
+        )
+
+    # Create a new subclass with injected attributes
+    # (Backtesting.py requires class-level attributes for parameter binding)
+    strategy_cls = type(
+        "CompiledGraphStrategy",
+        (GraphBacktestStrategy,),
+        {
+            "_signal_specs": signal_specs,
+            "_logic_operator": root_logic_operator,
+            "_take_profit": take_profit,
+            "_stop_loss": stop_loss,
+        },
+    )
+
+    return BuildResult(
+        strategy_cls=strategy_cls,
+        warnings=warnings,
+        skipped_conditions=skipped,
+        compiled_conditions=compiled,
+    )

--- a/engine/strategies/__init__.py
+++ b/engine/strategies/__init__.py
@@ -2,5 +2,6 @@
 Trading strategies for backtesting
 """
 from .ma_cross import SmaCross, EmaCross, MaTouchStrategy
+from .graph_strategy import GraphBacktestStrategy
 
-__all__ = ['SmaCross', 'EmaCross', 'MaTouchStrategy']
+__all__ = ['SmaCross', 'EmaCross', 'MaTouchStrategy', 'GraphBacktestStrategy']

--- a/engine/strategies/graph_strategy.py
+++ b/engine/strategies/graph_strategy.py
@@ -1,0 +1,509 @@
+"""
+Graph-based backtesting strategy.
+
+Converts QuantCanvas condition graphs into a Backtesting.py Strategy.
+Uses a single GraphBacktestStrategy with compiled signal functions.
+
+Each compiled condition stores indicators in strategy._ind[key] to avoid
+attribute name collisions when the same condition type is used multiple times.
+
+Supported condition types (1st release):
+  - MA: ma_touch, above_ma, below_ma, ma_cross_up, ma_cross_down
+  - RSI: rsi_oversold, rsi_overbought, rsi_range
+  - MACD: macd_cross_up, macd_cross_down
+  - BB: bb_lower_touch, bb_upper_touch
+  - Volume: min_volume, volume_above_avg
+
+Unsupported conditions (fundamental, pairs, etc.) are skipped with warnings.
+"""
+
+import uuid
+from typing import Any, Callable, Dict, List, Optional
+
+import numpy as np
+import pandas as pd
+from backtesting import Strategy
+from backtesting.lib import crossover
+
+
+# ---------------------------------------------------------------------------
+# Indicator helper functions (used with Strategy.I())
+# ---------------------------------------------------------------------------
+
+def SMA(values: pd.Series, n: int) -> pd.Series:
+    return values.rolling(n).mean()
+
+
+def EMA(values: pd.Series, n: int) -> pd.Series:
+    return values.ewm(span=n, adjust=False).mean()
+
+
+def RSI(values: pd.Series, period: int = 14) -> pd.Series:
+    """RSI using Wilder's smoothing (industry standard)."""
+    delta = values.diff()
+    gain = delta.where(delta > 0, 0)
+    loss = -delta.where(delta < 0, 0)
+    avg_gain = gain.ewm(alpha=1 / period, adjust=False).mean()
+    avg_loss = loss.ewm(alpha=1 / period, adjust=False).mean()
+    rs = avg_gain / avg_loss
+    return 100 - (100 / (1 + rs))
+
+
+def MACD_LINE(values: pd.Series, fast: int = 12, slow: int = 26) -> pd.Series:
+    return EMA(values, fast) - EMA(values, slow)
+
+
+def MACD_SIGNAL(values: pd.Series, fast: int = 12, slow: int = 26, signal: int = 9) -> pd.Series:
+    macd = MACD_LINE(values, fast, slow)
+    return EMA(macd, signal)
+
+
+def BB_UPPER(values: pd.Series, period: int = 20, std_dev: float = 2.0) -> pd.Series:
+    sma = values.rolling(period).mean()
+    std = values.rolling(period).std()
+    return sma + std_dev * std
+
+
+def BB_LOWER(values: pd.Series, period: int = 20, std_dev: float = 2.0) -> pd.Series:
+    sma = values.rolling(period).mean()
+    std = values.rolling(period).std()
+    return sma - std_dev * std
+
+
+def VOLUME_SMA(volume: pd.Series, period: int = 20) -> pd.Series:
+    return volume.rolling(period).mean()
+
+
+# ---------------------------------------------------------------------------
+# Signal compilers: condition_type + params -> (init_fn, entry_fn, exit_fn)
+# Each compiler receives a unique `key` to store indicators without collision.
+# ---------------------------------------------------------------------------
+
+class SignalSpec:
+    """Compiled signal specification for a single condition."""
+
+    def __init__(
+        self,
+        condition_type: str,
+        init_fn: Callable,
+        entry_fn: Callable,
+        exit_fn: Optional[Callable] = None,
+    ):
+        self.condition_type = condition_type
+        self.init_fn = init_fn
+        self.entry_fn = entry_fn
+        self.exit_fn = exit_fn
+
+
+def _unique_key() -> str:
+    return uuid.uuid4().hex[:8]
+
+
+def _safe_int(value: Any, default: int, min_val: int = 1, max_val: int = 1000) -> int:
+    """Safely parse an integer parameter with bounds."""
+    try:
+        v = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(min_val, min(v, max_val))
+
+
+def _safe_float(value: Any, default: float, min_val: float = 0.0, max_val: float = 1e6) -> float:
+    """Safely parse a float parameter with bounds."""
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return default
+    if np.isnan(v) or np.isinf(v):
+        return default
+    return max(min_val, min(v, max_val))
+
+
+def compile_condition(condition_type: str, params: Dict[str, Any]) -> Optional[SignalSpec]:
+    """Compile a condition_type + params into a SignalSpec.
+
+    Returns None if the condition is not supported for backtesting.
+    Parameters are validated and clamped to safe ranges.
+    """
+    compiler = CONDITION_COMPILERS.get(condition_type)
+    if compiler is None:
+        return None
+    return compiler(params)
+
+
+# --- MA conditions ---
+
+def _compile_ma_cross_up(params: Dict[str, Any]) -> SignalSpec:
+    short_p = _safe_int(params.get("short_period", 20), 20, min_val=2)
+    long_p = _safe_int(params.get("long_period", 60), 60, min_val=2)
+    if short_p >= long_p:
+        short_p, long_p = min(short_p, long_p), max(short_p, long_p) + 1
+    k = _unique_key()
+
+    def init_fn(strategy):
+        close = pd.Series(strategy.data.Close)
+        strategy._ind[f"short_{k}"] = strategy.I(SMA, close, short_p, name=f"SMA_{short_p}_{k}")
+        strategy._ind[f"long_{k}"] = strategy.I(SMA, close, long_p, name=f"SMA_{long_p}_{k}")
+
+    def entry_fn(strategy) -> bool:
+        return crossover(strategy._ind[f"short_{k}"], strategy._ind[f"long_{k}"])
+
+    def exit_fn(strategy) -> bool:
+        return crossover(strategy._ind[f"long_{k}"], strategy._ind[f"short_{k}"])
+
+    return SignalSpec("ma_cross_up", init_fn, entry_fn, exit_fn)
+
+
+def _compile_ma_cross_down(params: Dict[str, Any]) -> SignalSpec:
+    short_p = _safe_int(params.get("short_period", 20), 20, min_val=2)
+    long_p = _safe_int(params.get("long_period", 60), 60, min_val=2)
+    if short_p >= long_p:
+        short_p, long_p = min(short_p, long_p), max(short_p, long_p) + 1
+    k = _unique_key()
+
+    def init_fn(strategy):
+        close = pd.Series(strategy.data.Close)
+        strategy._ind[f"short_{k}"] = strategy.I(SMA, close, short_p, name=f"SMA_d_{short_p}_{k}")
+        strategy._ind[f"long_{k}"] = strategy.I(SMA, close, long_p, name=f"SMA_d_{long_p}_{k}")
+
+    def entry_fn(strategy) -> bool:
+        return crossover(strategy._ind[f"long_{k}"], strategy._ind[f"short_{k}"])
+
+    def exit_fn(strategy) -> bool:
+        return crossover(strategy._ind[f"short_{k}"], strategy._ind[f"long_{k}"])
+
+    return SignalSpec("ma_cross_down", init_fn, entry_fn, exit_fn)
+
+
+def _compile_above_ma(params: Dict[str, Any]) -> SignalSpec:
+    period = _safe_int(params.get("period", 20), 20, min_val=2)
+    k = _unique_key()
+
+    def init_fn(strategy):
+        close = pd.Series(strategy.data.Close)
+        strategy._ind[k] = strategy.I(SMA, close, period, name=f"MA_{period}_{k}")
+
+    def entry_fn(strategy) -> bool:
+        return strategy.data.Close[-1] > strategy._ind[k][-1]
+
+    def exit_fn(strategy) -> bool:
+        return strategy.data.Close[-1] < strategy._ind[k][-1]
+
+    return SignalSpec("above_ma", init_fn, entry_fn, exit_fn)
+
+
+def _compile_below_ma(params: Dict[str, Any]) -> SignalSpec:
+    period = _safe_int(params.get("period", 20), 20, min_val=2)
+    k = _unique_key()
+
+    def init_fn(strategy):
+        close = pd.Series(strategy.data.Close)
+        strategy._ind[k] = strategy.I(SMA, close, period, name=f"MA_below_{period}_{k}")
+
+    def entry_fn(strategy) -> bool:
+        return strategy.data.Close[-1] < strategy._ind[k][-1]
+
+    def exit_fn(strategy) -> bool:
+        return strategy.data.Close[-1] > strategy._ind[k][-1]
+
+    return SignalSpec("below_ma", init_fn, entry_fn, exit_fn)
+
+
+def _compile_ma_touch(params: Dict[str, Any]) -> SignalSpec:
+    period = _safe_int(params.get("period", 20), 20, min_val=2)
+    threshold = _safe_float(params.get("threshold", 0.02), 0.02, min_val=0.001, max_val=0.5)
+    k = _unique_key()
+
+    def init_fn(strategy):
+        close = pd.Series(strategy.data.Close)
+        strategy._ind[k] = strategy.I(SMA, close, period, name=f"MA_touch_{period}_{k}")
+
+    def entry_fn(strategy) -> bool:
+        price = strategy.data.Close[-1]
+        ma = strategy._ind[k][-1]
+        if np.isnan(ma) or ma == 0:
+            return False
+        if len(strategy.data.Close) < 2:
+            return False
+        prev_price = strategy.data.Close[-2]
+        prev_ma = strategy._ind[k][-2]
+        if np.isnan(prev_ma):
+            return False
+        return prev_price < prev_ma and abs(price - ma) / ma < threshold
+
+    return SignalSpec("ma_touch", init_fn, entry_fn, None)
+
+
+# --- RSI conditions ---
+
+def _compile_rsi_oversold(params: Dict[str, Any]) -> SignalSpec:
+    threshold = _safe_float(params.get("threshold", 30), 30, min_val=1, max_val=99)
+    period = _safe_int(params.get("period", 14), 14, min_val=2)
+    k = _unique_key()
+
+    def init_fn(strategy):
+        close = pd.Series(strategy.data.Close)
+        strategy._ind[k] = strategy.I(RSI, close, period, name=f"RSI_{period}_{k}")
+
+    def entry_fn(strategy) -> bool:
+        v = strategy._ind[k][-1]
+        return not np.isnan(v) and v <= threshold
+
+    def exit_fn(strategy) -> bool:
+        v = strategy._ind[k][-1]
+        return not np.isnan(v) and v >= 70
+
+    return SignalSpec("rsi_oversold", init_fn, entry_fn, exit_fn)
+
+
+def _compile_rsi_overbought(params: Dict[str, Any]) -> SignalSpec:
+    threshold = _safe_float(params.get("threshold", 70), 70, min_val=1, max_val=99)
+    period = _safe_int(params.get("period", 14), 14, min_val=2)
+    k = _unique_key()
+
+    def init_fn(strategy):
+        close = pd.Series(strategy.data.Close)
+        strategy._ind[k] = strategy.I(RSI, close, period, name=f"RSI_ob_{period}_{k}")
+
+    def entry_fn(strategy) -> bool:
+        return False  # Overbought is exit-only for long strategies
+
+    def exit_fn(strategy) -> bool:
+        v = strategy._ind[k][-1]
+        return not np.isnan(v) and v >= threshold
+
+    return SignalSpec("rsi_overbought", init_fn, entry_fn, exit_fn)
+
+
+def _compile_rsi_range(params: Dict[str, Any]) -> SignalSpec:
+    lower = _safe_float(params.get("lower", 30), 30, min_val=0, max_val=100)
+    upper = _safe_float(params.get("upper", 70), 70, min_val=0, max_val=100)
+    if lower > upper:
+        lower, upper = upper, lower
+    period = _safe_int(params.get("period", 14), 14, min_val=2)
+    k = _unique_key()
+
+    def init_fn(strategy):
+        close = pd.Series(strategy.data.Close)
+        strategy._ind[k] = strategy.I(RSI, close, period, name=f"RSI_range_{period}_{k}")
+
+    def entry_fn(strategy) -> bool:
+        v = strategy._ind[k][-1]
+        return not np.isnan(v) and lower <= v <= upper
+
+    return SignalSpec("rsi_range", init_fn, entry_fn, None)
+
+
+# --- MACD conditions ---
+
+def _compile_macd_cross_up(params: Dict[str, Any]) -> SignalSpec:
+    fast = _safe_int(params.get("fast_period", 12), 12, min_val=2)
+    slow = _safe_int(params.get("slow_period", 26), 26, min_val=2)
+    signal = _safe_int(params.get("signal_period", 9), 9, min_val=2)
+    k = _unique_key()
+
+    def init_fn(strategy):
+        close = pd.Series(strategy.data.Close)
+        strategy._ind[f"ml_{k}"] = strategy.I(MACD_LINE, close, fast, slow, name=f"MACD_{k}")
+        strategy._ind[f"ms_{k}"] = strategy.I(MACD_SIGNAL, close, fast, slow, signal, name=f"MACD_Sig_{k}")
+
+    def entry_fn(strategy) -> bool:
+        return crossover(strategy._ind[f"ml_{k}"], strategy._ind[f"ms_{k}"])
+
+    def exit_fn(strategy) -> bool:
+        return crossover(strategy._ind[f"ms_{k}"], strategy._ind[f"ml_{k}"])
+
+    return SignalSpec("macd_cross_up", init_fn, entry_fn, exit_fn)
+
+
+def _compile_macd_cross_down(params: Dict[str, Any]) -> SignalSpec:
+    fast = _safe_int(params.get("fast_period", 12), 12, min_val=2)
+    slow = _safe_int(params.get("slow_period", 26), 26, min_val=2)
+    signal = _safe_int(params.get("signal_period", 9), 9, min_val=2)
+    k = _unique_key()
+
+    def init_fn(strategy):
+        close = pd.Series(strategy.data.Close)
+        strategy._ind[f"ml_{k}"] = strategy.I(MACD_LINE, close, fast, slow, name=f"MACD_d_{k}")
+        strategy._ind[f"ms_{k}"] = strategy.I(MACD_SIGNAL, close, fast, slow, signal, name=f"MACD_Sig_d_{k}")
+
+    def entry_fn(strategy) -> bool:
+        return crossover(strategy._ind[f"ms_{k}"], strategy._ind[f"ml_{k}"])
+
+    def exit_fn(strategy) -> bool:
+        return crossover(strategy._ind[f"ml_{k}"], strategy._ind[f"ms_{k}"])
+
+    return SignalSpec("macd_cross_down", init_fn, entry_fn, exit_fn)
+
+
+# --- BB conditions ---
+
+def _compile_bb_lower_touch(params: Dict[str, Any]) -> SignalSpec:
+    period = _safe_int(params.get("period", 20), 20, min_val=2)
+    std_dev = _safe_float(params.get("std_dev", 2.0), 2.0, min_val=0.1, max_val=5.0)
+    k = _unique_key()
+
+    def init_fn(strategy):
+        close = pd.Series(strategy.data.Close)
+        strategy._ind[f"bbl_{k}"] = strategy.I(BB_LOWER, close, period, std_dev, name=f"BB_Lower_{k}")
+        strategy._ind[f"bbu_{k}"] = strategy.I(BB_UPPER, close, period, std_dev, name=f"BB_Upper_{k}")
+
+    def entry_fn(strategy) -> bool:
+        return strategy.data.Close[-1] <= strategy._ind[f"bbl_{k}"][-1]
+
+    def exit_fn(strategy) -> bool:
+        return strategy.data.Close[-1] >= strategy._ind[f"bbu_{k}"][-1]
+
+    return SignalSpec("bb_lower_touch", init_fn, entry_fn, exit_fn)
+
+
+def _compile_bb_upper_touch(params: Dict[str, Any]) -> SignalSpec:
+    period = _safe_int(params.get("period", 20), 20, min_val=2)
+    std_dev = _safe_float(params.get("std_dev", 2.0), 2.0, min_val=0.1, max_val=5.0)
+    k = _unique_key()
+
+    def init_fn(strategy):
+        close = pd.Series(strategy.data.Close)
+        strategy._ind[f"bbu_{k}"] = strategy.I(BB_UPPER, close, period, std_dev, name=f"BB_Upper_t_{k}")
+
+    def entry_fn(strategy) -> bool:
+        return False  # Upper touch is exit-only for long strategies
+
+    def exit_fn(strategy) -> bool:
+        return strategy.data.Close[-1] >= strategy._ind[f"bbu_{k}"][-1]
+
+    return SignalSpec("bb_upper_touch", init_fn, entry_fn, exit_fn)
+
+
+# --- Volume conditions ---
+
+def _compile_min_volume(params: Dict[str, Any]) -> SignalSpec:
+    min_vol = _safe_int(params.get("min_volume", 100000), 100000, min_val=0, max_val=10**9)
+
+    def init_fn(strategy):
+        pass
+
+    def entry_fn(strategy) -> bool:
+        return strategy.data.Volume[-1] >= min_vol
+
+    return SignalSpec("min_volume", init_fn, entry_fn, None)
+
+
+def _compile_volume_above_avg(params: Dict[str, Any]) -> SignalSpec:
+    period = _safe_int(params.get("period", 20), 20, min_val=2)
+    multiplier = _safe_float(params.get("multiplier", 1.5), 1.5, min_val=0.1, max_val=100.0)
+    k = _unique_key()
+
+    def init_fn(strategy):
+        vol = pd.Series(strategy.data.Volume, dtype=float)
+        strategy._ind[k] = strategy.I(VOLUME_SMA, vol, period, name=f"Vol_SMA_{period}_{k}")
+
+    def entry_fn(strategy) -> bool:
+        avg = strategy._ind[k][-1]
+        if np.isnan(avg) or avg == 0:
+            return False
+        return strategy.data.Volume[-1] >= avg * multiplier
+
+    return SignalSpec("volume_above_avg", init_fn, entry_fn, None)
+
+
+# ---------------------------------------------------------------------------
+# Condition compiler registry
+# ---------------------------------------------------------------------------
+
+CONDITION_COMPILERS: Dict[str, Callable] = {
+    "ma_cross_up": _compile_ma_cross_up,
+    "ma_cross_down": _compile_ma_cross_down,
+    "above_ma": _compile_above_ma,
+    "below_ma": _compile_below_ma,
+    "ma_touch": _compile_ma_touch,
+    "rsi_oversold": _compile_rsi_oversold,
+    "rsi_overbought": _compile_rsi_overbought,
+    "rsi_range": _compile_rsi_range,
+    "macd_cross_up": _compile_macd_cross_up,
+    "macd_cross_down": _compile_macd_cross_down,
+    "bb_lower_touch": _compile_bb_lower_touch,
+    "bb_upper_touch": _compile_bb_upper_touch,
+    "min_volume": _compile_min_volume,
+    "volume_above_avg": _compile_volume_above_avg,
+}
+
+SUPPORTED_CONDITION_TYPES = set(CONDITION_COMPILERS.keys())
+
+
+# ---------------------------------------------------------------------------
+# GraphBacktestStrategy — single fixed Strategy class with injected signals
+# ---------------------------------------------------------------------------
+
+class GraphBacktestStrategy(Strategy):
+    """Backtesting strategy compiled from a QuantCanvas condition graph.
+
+    Class attributes are injected before running:
+      - _signal_specs: List[SignalSpec]
+      - _logic_operator: str — 'and' or 'or'
+      - _take_profit: Optional[float]
+      - _stop_loss: Optional[float]
+    """
+
+    _signal_specs: List[SignalSpec] = []
+    _logic_operator: str = "and"
+    _take_profit: Optional[float] = None
+    _stop_loss: Optional[float] = None
+
+    def init(self):
+        self._ind: Dict[str, Any] = {}
+        for spec in self._signal_specs:
+            spec.init_fn(self)
+        self._entry_price = None
+
+    def next(self):
+        if len(self.data.Close) < 2:
+            return
+
+        # Compute entry signals
+        entry_signals = []
+        for spec in self._signal_specs:
+            try:
+                entry_signals.append(spec.entry_fn(self))
+            except (IndexError, ValueError):
+                entry_signals.append(False)
+
+        if not entry_signals:
+            return
+
+        if self._logic_operator == "or":
+            should_enter = any(entry_signals)
+        else:  # "and"
+            should_enter = all(entry_signals)
+
+        if not self.position:
+            if should_enter:
+                self.buy()
+                self._entry_price = self.data.Close[-1]
+        else:
+            # Check TP/SL first
+            if self._entry_price is not None:
+                price = self.data.Close[-1]
+                pnl = (price - self._entry_price) / self._entry_price
+
+                if self._take_profit is not None and pnl >= self._take_profit:
+                    self.position.close()
+                    self._entry_price = None
+                    return
+                if self._stop_loss is not None and pnl <= -self._stop_loss:
+                    self.position.close()
+                    self._entry_price = None
+                    return
+
+            # Check exit signals (any exit triggers close)
+            exit_signals = []
+            for spec in self._signal_specs:
+                if spec.exit_fn is not None:
+                    try:
+                        exit_signals.append(spec.exit_fn(self))
+                    except (IndexError, ValueError):
+                        exit_signals.append(False)
+
+            if exit_signals and any(exit_signals):
+                self.position.close()
+                self._entry_price = None

--- a/tests/test_graph_backtest.py
+++ b/tests/test_graph_backtest.py
@@ -1,0 +1,307 @@
+"""
+Tests for graph-based backtesting (QuantCanvas -> Backtesting.py bridge).
+
+Verifies that strategy graphs can be compiled and executed through
+the BacktestEngine.
+"""
+
+import sys
+import os
+
+import pytest
+import pandas as pd
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from api.schemas.strategy import StrategyGraph, StrategyNode, StrategyNodeData, StrategyEdge
+from api.services.strategy_builder import build_strategy_from_graph, BuildResult
+from engine.backtesting_engine import BacktestEngine
+from engine.strategies.graph_strategy import (
+    SUPPORTED_CONDITION_TYPES,
+    compile_condition,
+)
+
+
+# --- Fixtures ---
+
+@pytest.fixture(scope="module")
+def sample_ohlcv() -> pd.DataFrame:
+    """Generate synthetic OHLCV data for testing."""
+    import numpy as np
+    np.random.seed(42)
+    n = 300
+    dates = pd.bdate_range(start="2024-01-01", periods=n)
+    close = 100 + np.cumsum(np.random.randn(n) * 0.5)
+    close = pd.Series(close, index=dates).clip(lower=1)
+    df = pd.DataFrame({
+        "Open": close * (1 + np.random.randn(n) * 0.005),
+        "High": close * (1 + abs(np.random.randn(n) * 0.01)),
+        "Low": close * (1 - abs(np.random.randn(n) * 0.01)),
+        "Close": close,
+        "Volume": np.random.randint(100000, 1000000, size=n),
+    }, index=dates)
+    return df
+
+
+def _make_graph(condition_nodes, logic_operator="and") -> StrategyGraph:
+    """Helper to create a simple graph with universe -> logic -> output."""
+    nodes = [
+        StrategyNode(id="u1", data=StrategyNodeData(node_type="universe", universe="SP500")),
+    ]
+    child_ids = []
+
+    for i, (ct, params) in enumerate(condition_nodes):
+        cid = f"c{i}"
+        nodes.append(StrategyNode(
+            id=cid,
+            data=StrategyNodeData(
+                node_type="condition",
+                condition_type=ct,
+                params=params,
+            ),
+        ))
+        child_ids.append(cid)
+
+    nodes.append(StrategyNode(
+        id="g1",
+        data=StrategyNodeData(
+            node_type="logic",
+            logic_operator=logic_operator,
+            child_node_ids=child_ids,
+        ),
+    ))
+    nodes.append(StrategyNode(id="o1", data=StrategyNodeData(node_type="output")))
+
+    edges = [
+        StrategyEdge(id="e1", source="u1", target="g1"),
+        StrategyEdge(id="e2", source="g1", target="o1"),
+    ]
+
+    return StrategyGraph(nodes=nodes, edges=edges)
+
+
+# --- Tests: compile_condition ---
+
+class TestCompileCondition:
+    def test_supported_types(self):
+        """All supported types should compile without error."""
+        test_cases = [
+            ("ma_cross_up", {"short_period": 10, "long_period": 20}),
+            ("ma_cross_down", {"short_period": 10, "long_period": 20}),
+            ("above_ma", {"period": 20}),
+            ("below_ma", {"period": 20}),
+            ("ma_touch", {"period": 20, "threshold": 0.02}),
+            ("rsi_oversold", {"threshold": 30, "period": 14}),
+            ("rsi_overbought", {"threshold": 70, "period": 14}),
+            ("rsi_range", {"lower": 30, "upper": 70, "period": 14}),
+            ("macd_cross_up", {}),
+            ("macd_cross_down", {}),
+            ("bb_lower_touch", {"period": 20}),
+            ("bb_upper_touch", {"period": 20}),
+            ("min_volume", {"min_volume": 100000}),
+            ("volume_above_avg", {"period": 20, "multiplier": 1.5}),
+        ]
+        for ct, params in test_cases:
+            spec = compile_condition(ct, params)
+            assert spec is not None, f"compile_condition returned None for '{ct}'"
+            assert spec.condition_type == ct
+
+    def test_unsupported_returns_none(self):
+        assert compile_condition("pe_ratio", {}) is None
+        assert compile_condition("pairs_correlation", {}) is None
+        assert compile_condition("nonexistent", {}) is None
+
+    def test_supported_count(self):
+        assert len(SUPPORTED_CONDITION_TYPES) == 14
+
+
+# --- Tests: build_strategy_from_graph ---
+
+class TestBuildStrategyFromGraph:
+    def test_simple_ma_cross(self):
+        graph = _make_graph([("ma_cross_up", {"short_period": 10, "long_period": 20})])
+        result = build_strategy_from_graph(graph)
+        assert result.strategy_cls is not None
+        assert "ma_cross_up" in result.compiled_conditions
+        assert len(result.skipped_conditions) == 0
+
+    def test_multi_condition_and(self):
+        graph = _make_graph([
+            ("rsi_oversold", {"threshold": 30}),
+            ("macd_cross_up", {}),
+        ], logic_operator="and")
+        result = build_strategy_from_graph(graph)
+        assert len(result.compiled_conditions) == 2
+        assert "rsi_oversold" in result.compiled_conditions
+        assert "macd_cross_up" in result.compiled_conditions
+
+    def test_multi_condition_or(self):
+        graph = _make_graph([
+            ("rsi_oversold", {"threshold": 30}),
+            ("bb_lower_touch", {"period": 20}),
+        ], logic_operator="or")
+        result = build_strategy_from_graph(graph)
+        assert len(result.compiled_conditions) == 2
+
+    def test_unsupported_skipped_with_warning(self):
+        graph = _make_graph([
+            ("ma_cross_up", {"short_period": 10, "long_period": 20}),
+            ("pe_ratio", {"max_pe": 15}),
+        ])
+        result = build_strategy_from_graph(graph)
+        assert "ma_cross_up" in result.compiled_conditions
+        assert "pe_ratio" in result.skipped_conditions
+        assert any("pe_ratio" in w for w in result.warnings)
+
+    def test_all_unsupported_raises(self):
+        graph = _make_graph([("pe_ratio", {"max_pe": 15})])
+        with pytest.raises(ValueError, match="No backtestable conditions"):
+            build_strategy_from_graph(graph)
+
+    def test_universe_warning(self):
+        graph = _make_graph([("ma_cross_up", {"short_period": 10, "long_period": 20})])
+        result = build_strategy_from_graph(graph)
+        assert any("universe" in w.lower() or "ignored" in w.lower() for w in result.warnings)
+
+    def test_tp_sl_injected(self):
+        graph = _make_graph([("ma_cross_up", {"short_period": 10, "long_period": 20})])
+        result = build_strategy_from_graph(graph, take_profit=0.05, stop_loss=0.03)
+        assert result.strategy_cls._take_profit == 0.05
+        assert result.strategy_cls._stop_loss == 0.03
+
+    def test_not_operator_warns(self):
+        """'not' logic operator should produce a warning and fallback to 'and'."""
+        graph = _make_graph(
+            [("ma_cross_up", {"short_period": 10, "long_period": 20})],
+            logic_operator="not",
+        )
+        result = build_strategy_from_graph(graph)
+        assert result.strategy_cls._logic_operator == "and"
+        assert any("not" in w.lower() for w in result.warnings)
+
+    def test_invalid_params_use_defaults(self):
+        """Invalid parameter values should fall back to defaults, not crash."""
+        spec = compile_condition("ma_cross_up", {"short_period": "bad", "long_period": None})
+        assert spec is not None
+        assert spec.condition_type == "ma_cross_up"
+
+    def test_disconnected_node_ignored(self):
+        """A condition node not reachable from output should be ignored."""
+        nodes = [
+            StrategyNode(id="u1", data=StrategyNodeData(node_type="universe", universe="SP500")),
+            StrategyNode(id="c1", data=StrategyNodeData(
+                node_type="condition", condition_type="ma_cross_up",
+                params={"short_period": 10, "long_period": 20},
+            )),
+            StrategyNode(id="c_orphan", data=StrategyNodeData(
+                node_type="condition", condition_type="rsi_oversold",
+                params={"threshold": 30},
+            )),
+            StrategyNode(id="g1", data=StrategyNodeData(
+                node_type="logic", logic_operator="and", child_node_ids=["c1"],
+            )),
+            StrategyNode(id="o1", data=StrategyNodeData(node_type="output")),
+        ]
+        edges = [
+            StrategyEdge(id="e1", source="u1", target="g1"),
+            StrategyEdge(id="e2", source="g1", target="o1"),
+        ]
+        graph = StrategyGraph(nodes=nodes, edges=edges)
+        result = build_strategy_from_graph(graph)
+        assert "ma_cross_up" in result.compiled_conditions
+        assert "rsi_oversold" not in result.compiled_conditions
+
+
+# --- Tests: end-to-end backtest execution ---
+
+class TestGraphBacktestExecution:
+    def test_ma_cross_runs(self, sample_ohlcv):
+        """MA crossover graph should execute a full backtest."""
+        graph = _make_graph([("ma_cross_up", {"short_period": 10, "long_period": 30})])
+        result = build_strategy_from_graph(graph)
+
+        engine = BacktestEngine(commission=0.001)
+        bt_result = engine.run(
+            strategy=result.strategy_cls,
+            ticker="TEST",
+            data=sample_ohlcv,
+            cash=10_000_000,
+        )
+        assert bt_result is not None
+        assert bt_result.num_trades >= 0
+
+    def test_rsi_oversold_runs(self, sample_ohlcv):
+        """RSI oversold graph should execute without error."""
+        graph = _make_graph([("rsi_oversold", {"threshold": 35, "period": 14})])
+        result = build_strategy_from_graph(graph)
+
+        engine = BacktestEngine(commission=0.001)
+        bt_result = engine.run(
+            strategy=result.strategy_cls,
+            ticker="TEST",
+            data=sample_ohlcv,
+            cash=10_000_000,
+        )
+        assert bt_result is not None
+
+    def test_multi_condition_and_runs(self, sample_ohlcv):
+        """AND combination of conditions should work."""
+        graph = _make_graph([
+            ("rsi_oversold", {"threshold": 40}),
+            ("volume_above_avg", {"period": 20, "multiplier": 1.0}),
+        ], logic_operator="and")
+        result = build_strategy_from_graph(graph)
+
+        engine = BacktestEngine(commission=0.001)
+        bt_result = engine.run(
+            strategy=result.strategy_cls,
+            ticker="TEST",
+            data=sample_ohlcv,
+            cash=10_000_000,
+        )
+        assert bt_result is not None
+
+    def test_tp_sl_works(self, sample_ohlcv):
+        """TP/SL should be respected."""
+        graph = _make_graph([("ma_cross_up", {"short_period": 5, "long_period": 20})])
+        result = build_strategy_from_graph(graph, take_profit=0.02, stop_loss=0.01)
+
+        engine = BacktestEngine(commission=0.001)
+        bt_result = engine.run(
+            strategy=result.strategy_cls,
+            ticker="TEST",
+            data=sample_ohlcv,
+            cash=10_000_000,
+        )
+        assert bt_result is not None
+        # With tight TP/SL, we should get more trades than without
+        assert bt_result.num_trades >= 0
+
+    def test_bb_strategy_runs(self, sample_ohlcv):
+        """Bollinger Band strategy should execute."""
+        graph = _make_graph([("bb_lower_touch", {"period": 20, "std_dev": 2.0})])
+        result = build_strategy_from_graph(graph)
+
+        engine = BacktestEngine(commission=0.001)
+        bt_result = engine.run(
+            strategy=result.strategy_cls,
+            ticker="TEST",
+            data=sample_ohlcv,
+            cash=10_000_000,
+        )
+        assert bt_result is not None
+
+    def test_macd_cross_runs(self, sample_ohlcv):
+        """MACD crossover should execute."""
+        graph = _make_graph([("macd_cross_up", {})])
+        result = build_strategy_from_graph(graph)
+
+        engine = BacktestEngine(commission=0.001)
+        bt_result = engine.run(
+            strategy=result.strategy_cls,
+            ticker="TEST",
+            data=sample_ohlcv,
+            cash=10_000_000,
+        )
+        assert bt_result is not None
+        assert bt_result.num_trades >= 0


### PR DESCRIPTION
## Summary
- Bridge QuantCanvas visual strategy graphs to Backtesting.py engine
- 14 condition compilers (MA cross/touch/above/below, RSI oversold/overbought/range, MACD cross, BB touch, Volume filters)
- DAG-aware graph traversal from output node with UUID-keyed indicator storage
- Safe parameter validation with `_safe_int`/`_safe_float` helpers
- `POST /api/backtest/run-graph` endpoint with full metrics, trades, and equity curve response

## Test plan
- [x] 19 tests pass (compile_condition, build_strategy_from_graph, end-to-end backtest execution)
- [x] Tests cover: supported/unsupported conditions, AND/OR/NOT logic, TP/SL, disconnected nodes, invalid params
- [x] Codex code review: LGTM (2 rounds)

Closes #1241

🤖 Generated with [Claude Code](https://claude.com/claude-code)