### PR TITLE
feat(web): indicator difference disclosure UI (#1243)

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1016,7 +1016,24 @@
     },
     "logicAndShort": "All match",
     "logicOrShort": "Any match",
-    "logicNotShort": "Invert"
+    "logicNotShort": "Invert",
+    "indicatorDisclosure": {
+      "title": "Calculation Difference",
+      "rsi_oversold": "Our RSI uses SMA smoothing, while TradingView uses Wilder's EWM method. This can cause up to ~5pt difference in RSI values.",
+      "rsi_oversoldDivergence": "Expected divergence: 2-8 points (higher on volatile stocks)",
+      "rsi_overbought": "Our RSI uses SMA smoothing, while TradingView uses Wilder's EWM method. This can cause up to ~5pt difference in RSI values.",
+      "rsi_overboughtDivergence": "Expected divergence: 2-8 points (higher on volatile stocks)",
+      "rsi_range": "Our RSI uses SMA smoothing, while TradingView uses Wilder's EWM method. This can cause up to ~5pt difference in RSI values.",
+      "rsi_rangeDivergence": "Expected divergence: 2-8 points (higher on volatile stocks)",
+      "stochrsi_signal": "Our Stochastic RSI may differ from TradingView due to underlying RSI calculation method differences.",
+      "stochrsi_signalDivergence": "Expected divergence: varies depending on RSI base calculation",
+      "bollinger_width": "Our Bollinger Bands use sample std (ddof=1), while TradingView uses population std (ddof=0). This causes ~2.6% band width difference.",
+      "bollinger_widthDivergence": "Expected divergence: ~2-3% in band width",
+      "bollinger_percent_b": "Our Bollinger Bands use sample std (ddof=1), while TradingView uses population std (ddof=0). This may slightly shift %B values.",
+      "bollinger_percent_bDivergence": "Expected divergence: ~2-3% in band width, slight %B shift",
+      "bollinger_squeeze_breakout": "Our Bollinger Bands use sample std (ddof=1), while TradingView uses population std (ddof=0). Squeeze detection threshold may trigger slightly differently.",
+      "bollinger_squeeze_breakoutDivergence": "Expected divergence: ~2-3% in band width"
+    }
   },
   "analysis": {
     "title": "Charts & Analysis",
@@ -1189,7 +1206,8 @@
     "exitPrice": "Exit Price",
     "pnl": "P&L",
     "return": "Return",
-    "totalTrades": "Total ({count} trades)"
+    "totalTrades": "Total ({count} trades)",
+    "indicatorDisclosure": "Results may differ slightly from TradingView due to RSI calculation method (SMA vs EWM, ~2-8pt) and Bollinger Band std deviation (ddof=1 vs ddof=0, ~2-3%). MACD values match exactly. Use the cross-validation tool for detailed comparison."
   },
   "conditions": {
     "recommended": "REC",
@@ -1207,19 +1225,32 @@
       "label": "Pair Correlation",
       "desc": "Rolling Pearson correlation between two tickers",
       "help": "Measures how closely two stocks move together over a rolling window. A correlation above the threshold suggests the pair moves in sync, useful for pairs trading strategies.",
-      "params": { "ticker2": "Companion ticker", "period": "Rolling window (days)", "min_correlation": "Min correlation" }
+      "params": {
+        "ticker2": "Companion ticker",
+        "period": "Rolling window (days)",
+        "min_correlation": "Min correlation"
+      }
     },
     "pair_spread_zscore": {
       "label": "Spread Z-Score",
       "desc": "Log spread z-score for mean-reversion entry",
       "help": "Calculates the z-score of the log price spread between two tickers. When the spread deviates significantly from its mean, it signals a potential mean-reversion trade opportunity.",
-      "params": { "ticker2": "Companion ticker", "period": "Lookback (days)", "zscore_entry": "Z-score threshold", "direction": "Direction" }
+      "params": {
+        "ticker2": "Companion ticker",
+        "period": "Lookback (days)",
+        "zscore_entry": "Z-score threshold",
+        "direction": "Direction"
+      }
     },
     "pair_cointegration": {
       "label": "Cointegration Test",
       "desc": "Engle-Granger cointegration test",
       "help": "Tests whether two stock prices share a long-term equilibrium relationship using the Engle-Granger method. A low p-value indicates the pair is cointegrated and suitable for pairs trading.",
-      "params": { "ticker2": "Companion ticker", "period": "Lookback (days)", "pvalue_threshold": "Max p-value" }
+      "params": {
+        "ticker2": "Companion ticker",
+        "period": "Lookback (days)",
+        "pvalue_threshold": "Max p-value"
+      }
     },
     "min_price": {
       "label": "Min Price",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -1016,7 +1016,24 @@
     },
     "logicAndShort": "모두 일치",
     "logicOrShort": "하나 이상 일치",
-    "logicNotShort": "반전"
+    "logicNotShort": "반전",
+    "indicatorDisclosure": {
+      "title": "계산 방식 차이",
+      "rsi_oversold": "저희 RSI는 SMA 스무딩을 사용하고, TradingView는 Wilder의 EWM 방식을 사용합니다. RSI 값이 최대 약 5포인트 차이날 수 있습니다.",
+      "rsi_oversoldDivergence": "예상 차이: 2-8포인트 (변동성 높은 종목일수록 큰 차이)",
+      "rsi_overbought": "저희 RSI는 SMA 스무딩을 사용하고, TradingView는 Wilder의 EWM 방식을 사용합니다. RSI 값이 최대 약 5포인트 차이날 수 있습니다.",
+      "rsi_overboughtDivergence": "예상 차이: 2-8포인트 (변동성 높은 종목일수록 큰 차이)",
+      "rsi_range": "저희 RSI는 SMA 스무딩을 사용하고, TradingView는 Wilder의 EWM 방식을 사용합니다. RSI 값이 최대 약 5포인트 차이날 수 있습니다.",
+      "rsi_rangeDivergence": "예상 차이: 2-8포인트 (변동성 높은 종목일수록 큰 차이)",
+      "stochrsi_signal": "저희 스토캐스틱 RSI는 기본 RSI 계산 방식 차이로 인해 TradingView와 다를 수 있습니다.",
+      "stochrsi_signalDivergence": "예상 차이: RSI 기본 계산에 따라 다름",
+      "bollinger_width": "저희 볼린저 밴드는 표본 표준편차(ddof=1)를 사용하고, TradingView는 모집단 표준편차(ddof=0)를 사용합니다. 밴드 폭이 약 2.6% 차이납니다.",
+      "bollinger_widthDivergence": "예상 차이: 밴드 폭 약 2-3%",
+      "bollinger_percent_b": "저희 볼린저 밴드는 표본 표준편차(ddof=1)를 사용하고, TradingView는 모집단 표준편차(ddof=0)를 사용합니다. %B 값이 약간 다를 수 있습니다.",
+      "bollinger_percent_bDivergence": "예상 차이: 밴드 폭 약 2-3%, %B 약간 차이",
+      "bollinger_squeeze_breakout": "저희 볼린저 밴드는 표본 표준편차(ddof=1)를 사용하고, TradingView는 모집단 표준편차(ddof=0)를 사용합니다. 스퀴즈 감지 시점이 약간 다를 수 있습니다.",
+      "bollinger_squeeze_breakoutDivergence": "예상 차이: 밴드 폭 약 2-3%"
+    }
   },
   "analysis": {
     "title": "차트 & 분석",
@@ -1189,7 +1206,8 @@
     "exitPrice": "청산가",
     "pnl": "손익",
     "return": "수익률",
-    "totalTrades": "합계 ({count}건)"
+    "totalTrades": "합계 ({count}건)",
+    "indicatorDisclosure": "결과가 TradingView와 약간 다를 수 있습니다. RSI 계산 방식 차이(SMA vs EWM, 약 2-8포인트)와 볼린저 밴드 표준편차 차이(ddof=1 vs ddof=0, 약 2-3%)가 있습니다. MACD는 동일합니다. 상세 비교는 교차검증 도구를 사용하세요."
   },
   "conditions": {
     "recommended": "추천",
@@ -1207,19 +1225,32 @@
       "label": "페어 상관관계",
       "desc": "두 종목 간 롤링 피어슨 상관계수",
       "help": "두 종목이 롤링 윈도우 기간 동안 얼마나 함께 움직이는지 측정합니다. 상관계수가 임계값 이상이면 두 종목이 동조하여 움직이고 있어 페어 트레이딩 전략에 적합합니다.",
-      "params": { "ticker2": "비교 종목", "period": "롤링 윈도우 (일)", "min_correlation": "최소 상관계수" }
+      "params": {
+        "ticker2": "비교 종목",
+        "period": "롤링 윈도우 (일)",
+        "min_correlation": "최소 상관계수"
+      }
     },
     "pair_spread_zscore": {
       "label": "스프레드 Z-Score",
       "desc": "로그 스프레드 Z-Score 기반 평균회귀 진입",
       "help": "두 종목 간 로그 가격 스프레드의 Z-Score를 계산합니다. 스프레드가 평균에서 크게 벗어나면 평균회귀 매매 기회를 나타냅니다.",
-      "params": { "ticker2": "비교 종목", "period": "기간 (일)", "zscore_entry": "Z-Score 진입 임계값", "direction": "방향" }
+      "params": {
+        "ticker2": "비교 종목",
+        "period": "기간 (일)",
+        "zscore_entry": "Z-Score 진입 임계값",
+        "direction": "방향"
+      }
     },
     "pair_cointegration": {
       "label": "공적분 검정",
       "desc": "Engle-Granger 공적분 검정",
       "help": "Engle-Granger 방법으로 두 주가가 장기적 균형 관계를 공유하는지 검정합니다. p-value가 낮으면 두 종목이 공적분 관계에 있어 페어 트레이딩에 적합합니다.",
-      "params": { "ticker2": "비교 종목", "period": "기간 (일)", "pvalue_threshold": "최대 p-value" }
+      "params": {
+        "ticker2": "비교 종목",
+        "period": "기간 (일)",
+        "pvalue_threshold": "최대 p-value"
+      }
     },
     "min_price": {
       "label": "최소 가격",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -1016,7 +1016,24 @@
     },
     "logicAndShort": "全部匹配",
     "logicOrShort": "任意匹配",
-    "logicNotShort": "取反"
+    "logicNotShort": "取反",
+    "indicatorDisclosure": {
+      "title": "计算差异",
+      "rsi_oversold": "我们的RSI使用SMA平滑法，而TradingView使用Wilder的EWM方法。RSI值可能相差约5个点。",
+      "rsi_oversoldDivergence": "预期差异：2-8个点（波动性越大差异越大）",
+      "rsi_overbought": "我们的RSI使用SMA平滑法，而TradingView使用Wilder的EWM方法。RSI值可能相差约5个点。",
+      "rsi_overboughtDivergence": "预期差异：2-8个点（波动性越大差异越大）",
+      "rsi_range": "我们的RSI使用SMA平滑法，而TradingView使用Wilder的EWM方法。RSI值可能相差约5个点。",
+      "rsi_rangeDivergence": "预期差异：2-8个点（波动性越大差异越大）",
+      "stochrsi_signal": "由于基础RSI计算方法不同，我们的随机RSI可能与TradingView不同。",
+      "stochrsi_signalDivergence": "预期差异：取决于RSI基础计算",
+      "bollinger_width": "我们的布林带使用样本标准差(ddof=1)，而TradingView使用总体标准差(ddof=0)。带宽相差约2.6%。",
+      "bollinger_widthDivergence": "预期差异：带宽约2-3%",
+      "bollinger_percent_b": "我们的布林带使用样本标准差(ddof=1)，而TradingView使用总体标准差(ddof=0)。%B值可能略有不同。",
+      "bollinger_percent_bDivergence": "预期差异：带宽约2-3%，%B略有偏差",
+      "bollinger_squeeze_breakout": "我们的布林带使用样本标准差(ddof=1)，而TradingView使用总体标准差(ddof=0)。挤压检测时机可能略有不同。",
+      "bollinger_squeeze_breakoutDivergence": "预期差异：带宽约2-3%"
+    }
   },
   "analysis": {
     "title": "图表与分析",
@@ -1189,7 +1206,8 @@
     "exitPrice": "平仓价",
     "pnl": "盈亏",
     "return": "收益",
-    "totalTrades": "总计（{count} 笔交易）"
+    "totalTrades": "总计（{count} 笔交易）",
+    "indicatorDisclosure": "结果可能与TradingView略有不同。RSI计算方法差异(SMA vs EWM，约2-8点)和布林带标准差差异(ddof=1 vs ddof=0，约2-3%)。MACD完全一致。使用交叉验证工具进行详细比较。"
   },
   "conditions": {
     "recommended": "推荐",
@@ -1207,19 +1225,32 @@
       "label": "配对相关性",
       "desc": "两只股票的滚动皮尔逊相关系数",
       "help": "衡量两只股票在滚动窗口期间的联动程度。相关系数超过阈值表明两只股票同步运动，适合配对交易策略。",
-      "params": { "ticker2": "配对股票", "period": "滚动窗口（天）", "min_correlation": "最低相关系数" }
+      "params": {
+        "ticker2": "配对股票",
+        "period": "滚动窗口（天）",
+        "min_correlation": "最低相关系数"
+      }
     },
     "pair_spread_zscore": {
       "label": "价差Z分数",
       "desc": "对数价差Z分数均值回归入场",
       "help": "计算两只股票对数价差的Z分数。当价差显著偏离均值时，表明存在均值回归交易机会。",
-      "params": { "ticker2": "配对股票", "period": "回溯期（天）", "zscore_entry": "Z分数阈值", "direction": "方向" }
+      "params": {
+        "ticker2": "配对股票",
+        "period": "回溯期（天）",
+        "zscore_entry": "Z分数阈值",
+        "direction": "方向"
+      }
     },
     "pair_cointegration": {
       "label": "协整检验",
       "desc": "Engle-Granger协整检验",
       "help": "使用Engle-Granger方法检验两只股票价格是否存在长期均衡关系。p值较低表明配对具有协整关系，适合配对交易。",
-      "params": { "ticker2": "配对股票", "period": "回溯期（天）", "pvalue_threshold": "最大p值" }
+      "params": {
+        "ticker2": "配对股票",
+        "period": "回溯期（天）",
+        "pvalue_threshold": "最大p值"
+      }
     },
     "min_price": {
       "label": "最低价格",

--- a/web/src/components/backtest/BacktestPanel.tsx
+++ b/web/src/components/backtest/BacktestPanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useMemo, useCallback } from 'react';
-import { X, Loader2, AlertCircle, TrendingUp, BarChart3 } from 'lucide-react';
+import { X, Loader2, AlertCircle, TrendingUp, BarChart3, Info } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useBacktestStrategies, useRunBacktest } from '@/hooks/useBacktest';
 import type {
@@ -480,6 +480,16 @@ export default function BacktestPanel({ isOpen, onClose }: BacktestPanelProps) {
 
               {/* Metrics grid */}
               <MetricsCards metrics={result.metrics} />
+
+              {/* Indicator disclosure banner */}
+              <div className="rounded-lg bg-blue-50 dark:bg-blue-500/10 border border-blue-100 dark:border-blue-500/20 p-3">
+                <div className="flex items-start gap-2">
+                  <Info className="h-3.5 w-3.5 text-[#1313ec] dark:text-blue-400 shrink-0 mt-0.5" />
+                  <p className="text-[11px] text-gray-600 dark:text-gray-300 leading-relaxed">
+                    {t('indicatorDisclosure')}
+                  </p>
+                </div>
+              </div>
 
               {/* Trade summary strip */}
               <TradeSummary

--- a/web/src/components/strategy/nodes/ConditionNode.tsx
+++ b/web/src/components/strategy/nodes/ConditionNode.tsx
@@ -3,7 +3,7 @@
 import { memo, useCallback, useState } from 'react';
 import { Handle, Position, useNodeId, useReactFlow } from '@xyflow/react';
 import type { NodeProps } from '@xyflow/react';
-import { Filter, CheckCircle2, CircleDashed, Info, Eye, ChevronDown, ChevronUp } from 'lucide-react';
+import { Filter, CheckCircle2, CircleDashed, Info, Eye, ChevronDown, ChevronUp, AlertTriangle } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { getDownstreamNodeIds, type StrategyNodeData } from '@/lib/strategy/graphSerializer';
 import type { ConditionParam } from '@/lib/strategy/conditionRegistry';
@@ -61,6 +61,7 @@ function ConditionNode({ data, selected }: NodeProps) {
 
   const [showDesc, setShowDesc] = useState(false);
   const [showInsight, setShowInsight] = useState(false);
+  const [showDisclosure, setShowDisclosure] = useState(false);
 
   // Check if condition has params configured
   const hasParams = nodeData.params && Object.keys(nodeData.params).length > 0;
@@ -393,6 +394,41 @@ function ConditionNode({ data, selected }: NodeProps) {
                     </div>
                   )}
                 </div>
+
+                {/* Indicator Disclosure — show for RSI/MACD/BB conditions */}
+                {t.has(`indicatorDisclosure.${currentMeta.key}`) && (
+                  <div className="rounded-lg bg-amber-50 dark:bg-amber-500/10 border border-amber-200 dark:border-amber-500/20">
+                    <button
+                      type="button"
+                      onClick={() => setShowDisclosure((prev) => !prev)}
+                      className="w-full flex items-center justify-between gap-1.5 p-3"
+                    >
+                      <div className="flex items-center gap-1.5">
+                        <AlertTriangle className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400" />
+                        <span className="text-xs font-semibold text-amber-600 dark:text-amber-400 uppercase">
+                          {t('indicatorDisclosure.title')}
+                        </span>
+                      </div>
+                      {showDisclosure ? (
+                        <ChevronUp className="h-3 w-3 text-amber-600 dark:text-amber-400" />
+                      ) : (
+                        <ChevronDown className="h-3 w-3 text-amber-600 dark:text-amber-400" />
+                      )}
+                    </button>
+                    {showDisclosure && (
+                      <div className="px-3 pb-3 space-y-1.5">
+                        <p className="text-[11px] text-gray-600 dark:text-gray-300 leading-relaxed">
+                          {t(`indicatorDisclosure.${currentMeta.key}`)}
+                        </p>
+                        {t.has(`indicatorDisclosure.${currentMeta.key}Divergence`) && (
+                          <p className="text-[11px] text-amber-700 dark:text-amber-300 leading-relaxed font-medium">
+                            {t(`indicatorDisclosure.${currentMeta.key}Divergence`)}
+                          </p>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                )}
               </>
             );
           })()}


### PR DESCRIPTION
## Summary
- Amber collapsible "Calculation Difference" section on RSI/BB condition nodes in QuantCanvas
- Blue info banner in backtest results explaining indicator divergence
- i18n: en/ko/zh translations for all disclosure messages
- MACD excluded (our calc matches TradingView exactly)

## Test plan
- [x] Build passes (Next.js production build)
- [x] ESLint clean
- [x] Codex code review: LGTM
- [x] i18n keys symmetric across en/ko/zh

Closes #1243

🤖 Generated with [Claude Code](https://claude.com/claude-code)