### PR TITLE
feat(api): add strategy status lifecycle

### DIFF
--- a/api/database.py
+++ b/api/database.py
@@ -64,6 +64,8 @@ def init_db() -> None:
     _migrate_buy_rule_template_id()
     _migrate_sell_rule_preset_id()
 
+    _migrate_strategy_status()
+
     _migrate_json_data()
     _migrate_portfolio_json()
     _migrate_saved_screening_to_execution_history()
@@ -166,6 +168,22 @@ def _migrate_sell_rule_preset_id() -> None:
                 logger.info("Added sell_rules.preset_id column")
     except Exception as e:
         logger.warning("sell_rules preset_id migration skipped: %s", e)
+
+
+def _migrate_strategy_status() -> None:
+    """Add status column to strategies table if missing."""
+    try:
+        with engine.begin() as conn:
+            existing_columns = _get_column_names(conn, "strategies")
+            if existing_columns is None:
+                return
+            if "status" not in existing_columns:
+                conn.execute(
+                    text("ALTER TABLE strategies ADD COLUMN status VARCHAR(16) NOT NULL DEFAULT 'draft'")
+                )
+                logger.info("Added strategies.status column")
+    except Exception as e:
+        logger.warning("strategies status migration skipped: %s", e)
 
 
 def _migrate_json_data() -> None:

--- a/api/models/strategy.py
+++ b/api/models/strategy.py
@@ -10,6 +10,9 @@ from sqlalchemy.dialects.postgresql import JSONB
 from api.database import Base
 
 
+VALID_STATUSES = {"draft", "backtested", "validated", "production", "retired"}
+
+
 class Strategy(Base):
     __tablename__ = "strategies"
 
@@ -17,5 +20,6 @@ class Strategy(Base):
     name = Column(String(255), nullable=False)
     description = Column(Text, nullable=True)
     graph = Column(JSON().with_variant(JSONB, "postgresql"), nullable=False)
+    status = Column(String(16), nullable=False, default="draft")
     created_at = Column(DateTime, default=datetime.utcnow)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)

--- a/api/routers/strategy.py
+++ b/api/routers/strategy.py
@@ -28,6 +28,7 @@ from api.schemas.strategy import (
     StrategyExecuteResponse,
     StrategyProgressEvent,
     StrategySaveRequest,
+    StrategyStatusUpdateRequest,
     StrategyUpdateRequest,
 )
 from api.schemas.screening import (
@@ -146,6 +147,35 @@ async def update_saved_strategy(
         raise HTTPException(
             status_code=500,
             detail=f"Failed to update strategy: {str(e)}",
+        )
+
+
+@router.patch(
+    "/saved/{strategy_id}/status",
+    response_model=SavedStrategyResponse,
+    summary="Update strategy status",
+    description="Update the lifecycle status of a saved strategy (draft → backtested → validated → production → retired).",
+)
+async def update_strategy_status(
+    strategy_id: str,
+    data: StrategyStatusUpdateRequest,
+) -> SavedStrategyResponse:
+    """Update strategy lifecycle status."""
+    service = get_strategy_save_service()
+    try:
+        strategy = service.update_status(strategy_id, data.status)
+        if strategy is None:
+            raise HTTPException(status_code=404, detail=f"Strategy not found: {strategy_id}")
+        return strategy
+    except HTTPException:
+        raise
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error(f"Failed to update strategy status {strategy_id}: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=500,
+            detail="Failed to update strategy status. Check server logs.",
         )
 
 

--- a/api/schemas/strategy.py
+++ b/api/schemas/strategy.py
@@ -5,8 +5,9 @@ Pydantic models for the visual strategy builder graph serialization and executio
 """
 
 from typing import Any, Dict, List, Literal, Optional
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
+from api.models.strategy import VALID_STATUSES
 from api.schemas.screening import normalize_universe_values
 
 
@@ -353,12 +354,27 @@ class ConditionsListResponse(BaseModel):
     categories: List[str]
 
 
+VALID_STRATEGY_STATUSES = VALID_STATUSES
+
+
+def _validate_strategy_status(v: str) -> str:
+    if v not in VALID_STRATEGY_STATUSES:
+        raise ValueError(f"Invalid status '{v}'. Valid: {', '.join(sorted(VALID_STRATEGY_STATUSES))}")
+    return v
+
+
 class StrategySaveRequest(BaseModel):
     """Request to save a strategy graph."""
 
     name: str = Field(..., description="Strategy name")
     description: Optional[str] = Field(None, description="Strategy description")
     graph: StrategyGraph
+    status: str = Field(default="draft", description="Strategy lifecycle status")
+
+    @field_validator("status")
+    @classmethod
+    def validate_status(cls, v: str) -> str:
+        return _validate_strategy_status(v)
 
 
 class StrategyUpdateRequest(BaseModel):
@@ -367,6 +383,25 @@ class StrategyUpdateRequest(BaseModel):
     name: Optional[str] = Field(None, description="Strategy name")
     description: Optional[str] = Field(None, description="Strategy description")
     graph: Optional[StrategyGraph] = None
+    status: Optional[str] = Field(None, description="Strategy lifecycle status")
+
+    @field_validator("status")
+    @classmethod
+    def validate_status(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None:
+            return _validate_strategy_status(v)
+        return v
+
+
+class StrategyStatusUpdateRequest(BaseModel):
+    """Request to update only the strategy status."""
+
+    status: str = Field(..., description="New status: draft, backtested, validated, production, retired")
+
+    @field_validator("status")
+    @classmethod
+    def validate_status(cls, v: str) -> str:
+        return _validate_strategy_status(v)
 
 
 class SavedStrategyResponse(BaseModel):
@@ -376,6 +411,7 @@ class SavedStrategyResponse(BaseModel):
     name: str
     description: Optional[str] = None
     graph: StrategyGraph
+    status: str = "draft"
     created_at: str
     updated_at: str
 

--- a/api/services/strategy_save_service.py
+++ b/api/services/strategy_save_service.py
@@ -11,12 +11,22 @@ from datetime import datetime
 from typing import List, Optional
 
 from api.database import SessionLocal
-from api.models.strategy import Strategy
+from api.models.strategy import Strategy, VALID_STATUSES
 from api.schemas.strategy import (
     SavedStrategyResponse,
     StrategySaveRequest,
     StrategyUpdateRequest,
 )
+
+# Allowed transitions: any status can move forward or revert to draft.
+# retired is a terminal state that can only go back to draft.
+_ALLOWED_TRANSITIONS = {
+    "draft": {"backtested", "validated", "production", "retired"},
+    "backtested": {"draft", "validated", "production", "retired"},
+    "validated": {"draft", "production", "retired"},
+    "production": {"draft", "retired"},
+    "retired": {"draft"},
+}
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +37,7 @@ def _row_to_response(row: Strategy) -> SavedStrategyResponse:
         name=row.name,
         description=row.description,
         graph=row.graph,
+        status=row.status or "draft",
         created_at=row.created_at.isoformat() if row.created_at else "",
         updated_at=row.updated_at.isoformat() if row.updated_at else "",
     )
@@ -90,6 +101,7 @@ class StrategySaveService:
             name=data.name,
             description=data.description,
             graph=data.graph.model_dump(),
+            status=data.status if hasattr(data, "status") else "draft",
             created_at=now,
             updated_at=now,
         )
@@ -132,12 +144,45 @@ class StrategySaveService:
                 row.description = data.description
             if data.graph is not None:
                 row.graph = data.graph.model_dump()
+            if hasattr(data, "status") and data.status is not None:
+                row.status = data.status
 
             row.updated_at = datetime.utcnow()
 
             db.commit()
             db.refresh(row)
             logger.info("Updated strategy: %s", strategy_id)
+            return _row_to_response(row)
+        except Exception:
+            db.rollback()
+            raise
+        finally:
+            db.close()
+
+    def update_status(self, strategy_id: str, status: str) -> Optional[SavedStrategyResponse]:
+        """Update only the status of a saved strategy.
+
+        Raises:
+            ValueError: If the transition is not allowed.
+        """
+        db = SessionLocal()
+        try:
+            row = db.get(Strategy, strategy_id)
+            if row is None:
+                return None
+            current = row.status or "draft"
+            if status != current:
+                allowed = _ALLOWED_TRANSITIONS.get(current, set())
+                if status not in allowed:
+                    raise ValueError(
+                        f"Invalid transition: '{current}' → '{status}'. "
+                        f"Allowed from '{current}': {', '.join(sorted(allowed))}"
+                    )
+            row.status = status
+            row.updated_at = datetime.utcnow()
+            db.commit()
+            db.refresh(row)
+            logger.info("Updated strategy %s status to %s", strategy_id, status)
             return _row_to_response(row)
         except Exception:
             db.rollback()

--- a/tests/test_strategy_status.py
+++ b/tests/test_strategy_status.py
@@ -1,0 +1,263 @@
+"""
+Tests for strategy status lifecycle feature.
+
+Verifies:
+  - Status column default, CRUD with status, status-only PATCH
+  - Status validation (valid/invalid values)
+  - Migration function for existing databases
+"""
+
+import sys
+import os
+import uuid
+from datetime import datetime
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from api.models.strategy import Strategy, VALID_STATUSES
+from api.schemas.strategy import (
+    SavedStrategyResponse,
+    StrategySaveRequest,
+    StrategyStatusUpdateRequest,
+    StrategyUpdateRequest,
+    StrategyGraph,
+    StrategyNode,
+    StrategyNodeData,
+    StrategyEdge,
+    VALID_STRATEGY_STATUSES,
+)
+from api.services.strategy_save_service import StrategySaveService
+
+
+# --- Fixtures ---
+
+def _make_graph() -> StrategyGraph:
+    return StrategyGraph(
+        nodes=[
+            StrategyNode(
+                id="u1",
+                data=StrategyNodeData(node_type="universe", universe="SP500", universes=["SP500"]),
+            ),
+            StrategyNode(
+                id="o1",
+                data=StrategyNodeData(node_type="output"),
+            ),
+        ],
+        edges=[
+            StrategyEdge(id="e1", source="u1", target="o1"),
+        ],
+    )
+
+
+@pytest.fixture(autouse=True)
+def _use_in_memory_db(monkeypatch):
+    """Override database to use in-memory SQLite for tests."""
+    from api import database
+    from api.services import strategy_save_service
+
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+
+    test_engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    TestSession = sessionmaker(bind=test_engine)
+
+    monkeypatch.setattr(database, "engine", test_engine)
+    monkeypatch.setattr(database, "SessionLocal", TestSession)
+    monkeypatch.setattr(strategy_save_service, "SessionLocal", TestSession)
+
+    database.Base.metadata.create_all(bind=test_engine)
+
+    # Reset singleton so each test gets a fresh service
+    monkeypatch.setattr(strategy_save_service, "_strategy_save_service", None)
+
+    yield
+    database.Base.metadata.drop_all(bind=test_engine)
+
+
+@pytest.fixture
+def service() -> StrategySaveService:
+    return StrategySaveService()
+
+
+# --- Tests: Model ---
+
+class TestStrategyModel:
+    def test_valid_statuses_set(self):
+        assert VALID_STATUSES == {"draft", "backtested", "validated", "production", "retired"}
+
+    def test_default_status_column_exists(self):
+        """Strategy model has a status column with default 'draft'."""
+        col = Strategy.__table__.columns["status"]
+        assert col.default.arg == "draft"
+        assert not col.nullable
+
+
+# --- Tests: Schema validation ---
+
+class TestSchemaValidation:
+    def test_status_update_valid(self):
+        req = StrategyStatusUpdateRequest(status="backtested")
+        assert req.status == "backtested"
+
+    def test_status_update_all_valid_values(self):
+        for status in VALID_STRATEGY_STATUSES:
+            req = StrategyStatusUpdateRequest(status=status)
+            assert req.status == status
+
+    def test_status_update_invalid(self):
+        with pytest.raises(ValueError, match="Invalid status"):
+            StrategyStatusUpdateRequest(status="invalid_status")
+
+    def test_save_request_default_status(self):
+        req = StrategySaveRequest(name="test", graph=_make_graph())
+        assert req.status == "draft"
+
+    def test_save_request_custom_status(self):
+        req = StrategySaveRequest(name="test", graph=_make_graph(), status="backtested")
+        assert req.status == "backtested"
+
+    def test_update_request_status_optional(self):
+        req = StrategyUpdateRequest(name="updated")
+        assert req.status is None
+
+    def test_update_request_with_status(self):
+        req = StrategyUpdateRequest(status="validated")
+        assert req.status == "validated"
+
+    def test_save_request_invalid_status(self):
+        with pytest.raises(ValueError, match="Invalid status"):
+            StrategySaveRequest(name="test", graph=_make_graph(), status="bogus")
+
+    def test_update_request_invalid_status(self):
+        with pytest.raises(ValueError, match="Invalid status"):
+            StrategyUpdateRequest(status="bogus")
+
+    def test_response_includes_status(self):
+        resp = SavedStrategyResponse(
+            id="abc",
+            name="test",
+            graph=_make_graph(),
+            status="production",
+            created_at="2024-01-01T00:00:00",
+            updated_at="2024-01-01T00:00:00",
+        )
+        assert resp.status == "production"
+
+    def test_response_default_status(self):
+        resp = SavedStrategyResponse(
+            id="abc",
+            name="test",
+            graph=_make_graph(),
+            created_at="2024-01-01T00:00:00",
+            updated_at="2024-01-01T00:00:00",
+        )
+        assert resp.status == "draft"
+
+
+# --- Tests: Service CRUD with status ---
+
+class TestServiceStatus:
+    def test_save_default_status(self, service):
+        req = StrategySaveRequest(name="s1", graph=_make_graph())
+        result = service.save_strategy(req)
+        assert result.status == "draft"
+
+    def test_save_custom_status(self, service):
+        req = StrategySaveRequest(name="s2", graph=_make_graph(), status="backtested")
+        result = service.save_strategy(req)
+        assert result.status == "backtested"
+
+    def test_update_status_via_update(self, service):
+        req = StrategySaveRequest(name="s3", graph=_make_graph())
+        saved = service.save_strategy(req)
+        assert saved.status == "draft"
+
+        update = StrategyUpdateRequest(status="validated")
+        updated = service.update_strategy(saved.id, update)
+        assert updated is not None
+        assert updated.status == "validated"
+
+    def test_update_status_dedicated(self, service):
+        req = StrategySaveRequest(name="s4", graph=_make_graph())
+        saved = service.save_strategy(req)
+
+        updated = service.update_status(saved.id, "production")
+        assert updated is not None
+        assert updated.status == "production"
+
+    def test_update_status_nonexistent(self, service):
+        result = service.update_status("nonexistent_id", "draft")
+        assert result is None
+
+    def test_status_persists_on_get(self, service):
+        req = StrategySaveRequest(name="s5", graph=_make_graph())
+        saved = service.save_strategy(req)
+        service.update_status(saved.id, "retired")
+
+        fetched = service.get_strategy(saved.id)
+        assert fetched is not None
+        assert fetched.status == "retired"
+
+    def test_status_in_list(self, service):
+        req = StrategySaveRequest(name="s6", graph=_make_graph(), status="validated")
+        service.save_strategy(req)
+
+        strategies = service.list_strategies()
+        assert len(strategies) >= 1
+        found = [s for s in strategies if s.name == "s6"]
+        assert found[0].status == "validated"
+
+    def test_full_lifecycle(self, service):
+        """Walk through draft → backtested → validated → production → retired."""
+        req = StrategySaveRequest(name="lifecycle", graph=_make_graph())
+        saved = service.save_strategy(req)
+        assert saved.status == "draft"
+
+        for status in ["backtested", "validated", "production", "retired"]:
+            result = service.update_status(saved.id, status)
+            assert result.status == status
+
+    def test_invalid_transition_blocked(self, service):
+        """production → backtested should be rejected."""
+        req = StrategySaveRequest(name="transition_test", graph=_make_graph())
+        saved = service.save_strategy(req)
+        service.update_status(saved.id, "production")
+
+        with pytest.raises(ValueError, match="Invalid transition"):
+            service.update_status(saved.id, "backtested")
+
+    def test_retired_can_revert_to_draft(self, service):
+        req = StrategySaveRequest(name="revert_test", graph=_make_graph())
+        saved = service.save_strategy(req)
+        service.update_status(saved.id, "retired")
+
+        result = service.update_status(saved.id, "draft")
+        assert result.status == "draft"
+
+    def test_same_status_noop(self, service):
+        """Setting same status should succeed (no-op)."""
+        req = StrategySaveRequest(name="noop_test", graph=_make_graph())
+        saved = service.save_strategy(req)
+        result = service.update_status(saved.id, "draft")
+        assert result.status == "draft"
+
+    def test_status_not_overwritten_on_name_update(self, service):
+        req = StrategySaveRequest(name="s7", graph=_make_graph())
+        saved = service.save_strategy(req)
+        service.update_status(saved.id, "production")
+
+        # Update name only — status should stay production
+        updated = service.update_strategy(saved.id, StrategyUpdateRequest(name="s7_renamed"))
+        assert updated.status == "production"
+
+
+# --- Tests: Migration ---
+
+class TestMigration:
+    def test_migrate_strategy_status_noop_when_exists(self):
+        """Migration should be a no-op when status column already exists."""
+        from api.database import _migrate_strategy_status
+        # Column already exists from create_all in fixture — should not raise
+        _migrate_strategy_status()


### PR DESCRIPTION
## Summary
- Add `status` column (`draft`/`backtested`/`validated`/`production`/`retired`) to Strategy model with DB migration for existing databases
- Add `PATCH /api/strategy/saved/{id}/status` endpoint with transition validation (e.g., `production` → `backtested` blocked, `retired` → `draft` allowed)
- Validate status on all entry points (`POST /saved`, `PUT /saved/{id}`, `PATCH /status`) using shared validator

Closes #1244

## Test plan
- [x] 26 unit tests covering model, schema validation, service CRUD, transition rules, and migration
- [x] 34 regression tests pass (graph_backtest + cross_validation)
- [ ] Manual: `curl -X PATCH localhost:8001/api/strategy/saved/{id}/status -d '{"status":"backtested"}'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Reviewed-by: Codex