### PR TITLE
feat(api): add strategy backtest results persistence

### DIFF
--- a/api/database.py
+++ b/api/database.py
@@ -55,6 +55,7 @@ def init_db() -> None:
     import api.models.portfolio  # noqa: F401 — register model with Base
     import api.models.screening_result  # noqa: F401 — register model with Base
     import api.models.strategy  # noqa: F401 — register model with Base
+    import api.models.strategy_backtest_result  # noqa: F401 — register model with Base
     import api.models.watchlist  # noqa: F401 — register model with Base
 
     Base.metadata.create_all(bind=engine)

--- a/api/models/strategy_backtest_result.py
+++ b/api/models/strategy_backtest_result.py
@@ -1,0 +1,42 @@
+"""
+SQLAlchemy model for strategy backtest results.
+
+Stores backtest metrics, trades, and equity curve per strategy run.
+"""
+
+from datetime import datetime
+
+from sqlalchemy import Column, DateTime, Float, Integer, JSON, String, Text
+from sqlalchemy.dialects.postgresql import JSONB
+
+from api.database import Base
+
+
+class StrategyBacktestResult(Base):
+    __tablename__ = "strategy_backtest_results"
+
+    id = Column(String(32), primary_key=True)
+    strategy_id = Column(String(32), nullable=False, index=True)
+    ticker = Column(String(32), nullable=False)
+    period = Column(String(16), nullable=False, default="1y")
+    initial_cash = Column(Float, nullable=False, default=10_000_000)
+
+    # Core metrics
+    sharpe_ratio = Column(Float, nullable=True)
+    sortino_ratio = Column(Float, nullable=True)
+    cagr = Column(Float, nullable=True)
+    max_drawdown = Column(Float, nullable=True)
+    win_rate = Column(Float, nullable=True)
+    total_return = Column(Float, nullable=True)
+    profit_factor = Column(Float, nullable=True)
+    total_trades = Column(Integer, nullable=False, default=0)
+    avg_trade_return = Column(Float, nullable=True)
+
+    # Detailed data (JSON)
+    equity_curve = Column(JSON().with_variant(JSONB, "postgresql"), nullable=True)
+    trades = Column(JSON().with_variant(JSONB, "postgresql"), nullable=True)
+    compiled_conditions = Column(JSON().with_variant(JSONB, "postgresql"), nullable=True)
+    skipped_conditions = Column(JSON().with_variant(JSONB, "postgresql"), nullable=True)
+    warnings = Column(JSON().with_variant(JSONB, "postgresql"), nullable=True)
+
+    created_at = Column(DateTime, default=datetime.utcnow)

--- a/api/routers/strategy.py
+++ b/api/routers/strategy.py
@@ -18,6 +18,10 @@ from api.schemas.strategy_chat import (
     ValidatePayloadRequest,
     ValidatePayloadResponse,
 )
+from api.schemas.strategy_backtest_result import (
+    StrategyBacktestResultResponse,
+    StrategyBacktestResultsListResponse,
+)
 from api.schemas.strategy import (
     ConditionsListResponse,
     SavedStrategiesListResponse,
@@ -177,6 +181,43 @@ async def update_strategy_status(
             status_code=500,
             detail="Failed to update strategy status. Check server logs.",
         )
+
+
+@router.get(
+    "/saved/{strategy_id}/backtest-results",
+    response_model=StrategyBacktestResultsListResponse,
+    summary="List backtest results for a strategy",
+    description="Return all backtest results for a saved strategy, most recent first.",
+)
+async def list_backtest_results(strategy_id: str) -> StrategyBacktestResultsListResponse:
+    """List all backtest results for a strategy."""
+    from api.services.strategy_backtest_result_service import get_results
+
+    results = get_results(strategy_id)
+    return StrategyBacktestResultsListResponse(
+        strategy_id=strategy_id,
+        results=results,
+        total_count=len(results),
+    )
+
+
+@router.get(
+    "/saved/{strategy_id}/backtest-results/latest",
+    response_model=StrategyBacktestResultResponse,
+    summary="Get latest backtest result",
+    description="Return the most recent backtest result for a saved strategy.",
+)
+async def get_latest_backtest_result(strategy_id: str) -> StrategyBacktestResultResponse:
+    """Get the latest backtest result for a strategy."""
+    from api.services.strategy_backtest_result_service import get_latest
+
+    result = get_latest(strategy_id)
+    if result is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No backtest results found for strategy: {strategy_id}",
+        )
+    return result
 
 
 @router.delete(

--- a/api/schemas/strategy_backtest_result.py
+++ b/api/schemas/strategy_backtest_result.py
@@ -1,0 +1,47 @@
+"""
+Strategy Backtest Result Schemas.
+
+Pydantic models for persisted backtest results.
+"""
+
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+from api.schemas.backtest import EquityPoint, TradeRecord
+
+
+class StrategyBacktestResultResponse(BaseModel):
+    """Persisted backtest result for a strategy."""
+
+    id: str
+    strategy_id: str
+    ticker: str
+    period: str
+    initial_cash: float
+
+    sharpe_ratio: Optional[float] = None
+    sortino_ratio: Optional[float] = None
+    cagr: Optional[float] = None
+    max_drawdown: Optional[float] = None
+    win_rate: Optional[float] = None
+    total_return: Optional[float] = None
+    profit_factor: Optional[float] = None
+    total_trades: int = 0
+    avg_trade_return: Optional[float] = None
+
+    equity_curve: List[EquityPoint] = Field(default_factory=list)
+    trades: List[TradeRecord] = Field(default_factory=list)
+    compiled_conditions: List[str] = Field(default_factory=list)
+    skipped_conditions: List[str] = Field(default_factory=list)
+    warnings: List[str] = Field(default_factory=list)
+
+    created_at: str
+
+
+class StrategyBacktestResultsListResponse(BaseModel):
+    """Response listing backtest results for a strategy."""
+
+    strategy_id: str
+    results: List[StrategyBacktestResultResponse]
+    total_count: int

--- a/api/services/strategy_backtest_result_service.py
+++ b/api/services/strategy_backtest_result_service.py
@@ -1,0 +1,125 @@
+"""
+Strategy Backtest Result Service.
+
+Persists and retrieves backtest results for saved strategies.
+"""
+
+import logging
+import uuid
+from typing import List, Optional
+
+from api.database import SessionLocal
+from api.models.strategy_backtest_result import StrategyBacktestResult
+from api.schemas.backtest import GraphBacktestResponse
+from api.schemas.strategy_backtest_result import StrategyBacktestResultResponse
+
+logger = logging.getLogger(__name__)
+
+
+def _row_to_response(row: StrategyBacktestResult) -> StrategyBacktestResultResponse:
+    return StrategyBacktestResultResponse(
+        id=row.id,
+        strategy_id=row.strategy_id,
+        ticker=row.ticker,
+        period=row.period,
+        initial_cash=row.initial_cash,
+        sharpe_ratio=row.sharpe_ratio,
+        sortino_ratio=row.sortino_ratio,
+        cagr=row.cagr,
+        max_drawdown=row.max_drawdown,
+        win_rate=row.win_rate,
+        total_return=row.total_return,
+        profit_factor=row.profit_factor,
+        total_trades=row.total_trades,
+        avg_trade_return=row.avg_trade_return,
+        equity_curve=row.equity_curve or [],
+        trades=row.trades or [],
+        compiled_conditions=row.compiled_conditions or [],
+        skipped_conditions=row.skipped_conditions or [],
+        warnings=row.warnings or [],
+        created_at=row.created_at.isoformat() if row.created_at else "",
+    )
+
+
+def save_backtest_result(
+    strategy_id: str,
+    response: GraphBacktestResponse,
+) -> StrategyBacktestResultResponse:
+    """Persist a backtest result from a GraphBacktestResponse.
+
+    Args:
+        strategy_id: The strategy ID this result belongs to.
+        response: The backtest response to persist.
+
+    Returns:
+        The persisted result.
+    """
+    result_id = uuid.uuid4().hex
+    metrics = response.metrics
+
+    row = StrategyBacktestResult(
+        id=result_id,
+        strategy_id=strategy_id,
+        ticker=response.ticker,
+        period=response.period,
+        initial_cash=response.cash,
+        sharpe_ratio=metrics.sharpe_ratio,
+        sortino_ratio=metrics.sortino_ratio,
+        cagr=metrics.cagr,
+        max_drawdown=metrics.mdd,
+        win_rate=metrics.win_rate,
+        total_return=metrics.total_return,
+        profit_factor=metrics.profit_factor,
+        total_trades=metrics.num_trades,
+        avg_trade_return=metrics.avg_trade_return,
+        equity_curve=[p.model_dump() for p in response.equity_curve],
+        trades=[t.model_dump() for t in response.trades],
+        compiled_conditions=response.compiled_conditions,
+        skipped_conditions=response.skipped_conditions,
+        warnings=response.warnings,
+    )
+
+    db = SessionLocal()
+    try:
+        db.add(row)
+        db.commit()
+        db.refresh(row)
+        logger.info("Saved backtest result %s for strategy %s", result_id, strategy_id)
+        return _row_to_response(row)
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()
+
+
+def get_results(strategy_id: str) -> List[StrategyBacktestResultResponse]:
+    """List all backtest results for a strategy, most recent first."""
+    db = SessionLocal()
+    try:
+        rows = (
+            db.query(StrategyBacktestResult)
+            .filter(StrategyBacktestResult.strategy_id == strategy_id)
+            .order_by(StrategyBacktestResult.created_at.desc())
+            .all()
+        )
+        return [_row_to_response(r) for r in rows]
+    finally:
+        db.close()
+
+
+def get_latest(strategy_id: str) -> Optional[StrategyBacktestResultResponse]:
+    """Get the most recent backtest result for a strategy."""
+    db = SessionLocal()
+    try:
+        row = (
+            db.query(StrategyBacktestResult)
+            .filter(StrategyBacktestResult.strategy_id == strategy_id)
+            .order_by(StrategyBacktestResult.created_at.desc())
+            .first()
+        )
+        if row is None:
+            return None
+        return _row_to_response(row)
+    finally:
+        db.close()

--- a/tests/test_strategy_backtest_results.py
+++ b/tests/test_strategy_backtest_results.py
@@ -1,0 +1,197 @@
+"""
+Tests for strategy backtest result persistence.
+
+Verifies:
+  - Model creation and defaults
+  - Service: save, list, get_latest
+  - Schema response structure
+"""
+
+import sys
+import os
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from api.schemas.backtest import (
+    BacktestMetrics,
+    EquityPoint,
+    GraphBacktestResponse,
+    TradeRecord,
+)
+from api.schemas.strategy_backtest_result import (
+    StrategyBacktestResultResponse,
+    StrategyBacktestResultsListResponse,
+)
+from api.services.strategy_backtest_result_service import (
+    get_latest,
+    get_results,
+    save_backtest_result,
+)
+
+
+def _make_response(ticker: str = "AAPL", period: str = "1y") -> GraphBacktestResponse:
+    return GraphBacktestResponse(
+        ticker=ticker,
+        strategy="graph",
+        period=period,
+        cash=10_000_000,
+        metrics=BacktestMetrics(
+            sharpe_ratio=1.5,
+            sortino_ratio=2.0,
+            mdd=0.15,
+            win_rate=0.6,
+            profit_factor=1.8,
+            cagr=0.12,
+            total_return=0.25,
+            num_trades=42,
+            avg_trade_return=0.006,
+            max_consecutive_wins=5,
+            max_consecutive_losses=3,
+        ),
+        trades=[
+            TradeRecord(
+                entry_date="2024-01-01", exit_date="2024-02-01",
+                entry_price=100.0, exit_price=110.0,
+                pnl=1000.0, return_pct=0.10, size=100,
+            ),
+        ],
+        equity_curve=[
+            EquityPoint(date="2024-01-01", equity=10_000_000),
+            EquityPoint(date="2024-12-31", equity=12_500_000),
+        ],
+        compiled_conditions=["rsi_oversold", "ma_cross_up"],
+        skipped_conditions=["min_market_cap"],
+        warnings=["Universe node ignored in backtest"],
+    )
+
+
+@pytest.fixture(autouse=True)
+def _use_in_memory_db(monkeypatch):
+    """Override database to use in-memory SQLite for tests."""
+    from api import database
+    from api.services import strategy_backtest_result_service
+
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+
+    test_engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    TestSession = sessionmaker(bind=test_engine)
+
+    monkeypatch.setattr(database, "engine", test_engine)
+    monkeypatch.setattr(database, "SessionLocal", TestSession)
+    monkeypatch.setattr(strategy_backtest_result_service, "SessionLocal", TestSession)
+
+    database.Base.metadata.create_all(bind=test_engine)
+    yield
+    database.Base.metadata.drop_all(bind=test_engine)
+
+
+# --- Tests: Save ---
+
+class TestSaveResult:
+    def test_save_returns_response(self):
+        resp = _make_response()
+        result = save_backtest_result("strategy_abc", resp)
+        assert isinstance(result, StrategyBacktestResultResponse)
+        assert result.strategy_id == "strategy_abc"
+        assert result.ticker == "AAPL"
+        assert result.period == "1y"
+
+    def test_save_persists_metrics(self):
+        resp = _make_response()
+        result = save_backtest_result("strat1", resp)
+        assert result.sharpe_ratio == 1.5
+        assert result.cagr == 0.12
+        assert result.max_drawdown == 0.15
+        assert result.win_rate == 0.6
+        assert result.total_return == 0.25
+        assert result.total_trades == 42
+
+    def test_save_persists_trades(self):
+        resp = _make_response()
+        result = save_backtest_result("strat2", resp)
+        assert len(result.trades) == 1
+        assert result.trades[0].entry_price == 100.0
+
+    def test_save_persists_equity_curve(self):
+        resp = _make_response()
+        result = save_backtest_result("strat3", resp)
+        assert len(result.equity_curve) == 2
+
+    def test_save_persists_conditions(self):
+        resp = _make_response()
+        result = save_backtest_result("strat4", resp)
+        assert result.compiled_conditions == ["rsi_oversold", "ma_cross_up"]
+        assert result.skipped_conditions == ["min_market_cap"]
+        assert result.warnings == ["Universe node ignored in backtest"]
+
+    def test_save_generates_unique_id(self):
+        resp = _make_response()
+        r1 = save_backtest_result("strat5", resp)
+        r2 = save_backtest_result("strat5", resp)
+        assert r1.id != r2.id
+
+
+# --- Tests: List ---
+
+class TestListResults:
+    def test_list_empty(self):
+        results = get_results("nonexistent")
+        assert results == []
+
+    def test_list_multiple(self):
+        resp = _make_response()
+        save_backtest_result("strat_list", resp)
+        save_backtest_result("strat_list", _make_response(ticker="MSFT"))
+
+        results = get_results("strat_list")
+        assert len(results) == 2
+
+    def test_list_ordered_newest_first(self):
+        save_backtest_result("strat_order", _make_response(ticker="A"))
+        save_backtest_result("strat_order", _make_response(ticker="B"))
+
+        results = get_results("strat_order")
+        # Most recent first — B was saved last
+        assert results[0].ticker == "B"
+        assert results[1].ticker == "A"
+
+    def test_list_filters_by_strategy_id(self):
+        save_backtest_result("strat_a", _make_response())
+        save_backtest_result("strat_b", _make_response())
+
+        results_a = get_results("strat_a")
+        results_b = get_results("strat_b")
+        assert len(results_a) == 1
+        assert len(results_b) == 1
+
+
+# --- Tests: Get Latest ---
+
+class TestGetLatest:
+    def test_latest_returns_none_when_empty(self):
+        result = get_latest("nonexistent")
+        assert result is None
+
+    def test_latest_returns_most_recent(self):
+        save_backtest_result("strat_latest", _make_response(ticker="OLD"))
+        save_backtest_result("strat_latest", _make_response(ticker="NEW"))
+
+        latest = get_latest("strat_latest")
+        assert latest is not None
+        assert latest.ticker == "NEW"
+
+
+# --- Tests: Schema ---
+
+class TestSchema:
+    def test_list_response_model(self):
+        resp = StrategyBacktestResultsListResponse(
+            strategy_id="abc",
+            results=[],
+            total_count=0,
+        )
+        assert resp.strategy_id == "abc"
+        assert resp.total_count == 0


### PR DESCRIPTION
## Summary
- Add `strategy_backtest_results` table to persist backtest metrics (Sharpe, CAGR, MDD, win rate) per strategy run
- Service layer: `save_backtest_result()`, `get_results()`, `get_latest()`
- Endpoints: `GET /api/strategy/saved/{id}/backtest-results` and `.../latest`

Closes #1249

## Test plan
- [x] 13 unit tests (save, list, get_latest, schema)
- [ ] Manual: save a strategy, run graph backtest, verify results persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Reviewed-by: Codex