### PR TITLE
feat(web): wire strategy status UI and graph backtest API

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -971,6 +971,13 @@
       "ichimoku": "Ichimoku",
       "fundamental": "Fundamental"
     },
+    "strategyStatus": {
+      "draft": "Draft",
+      "backtested": "Backtested",
+      "validated": "Validated",
+      "production": "Production",
+      "retired": "Retired"
+    },
     "loadSelected": "Load",
     "deleteConfirm": "Delete this strategy?",
     "unsavedChanges": "You have unsaved changes",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -971,6 +971,13 @@
       "ichimoku": "일목균형표",
       "fundamental": "펀더멘탈"
     },
+    "strategyStatus": {
+      "draft": "초안",
+      "backtested": "백테스트 완료",
+      "validated": "검증됨",
+      "production": "운영 중",
+      "retired": "중단됨"
+    },
     "loadSelected": "불러오기",
     "deleteConfirm": "이 전략을 삭제할까요?",
     "unsavedChanges": "저장되지 않은 변경 사항이 있습니다",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -971,6 +971,13 @@
       "ichimoku": "一目均衡表",
       "fundamental": "基本面"
     },
+    "strategyStatus": {
+      "draft": "草稿",
+      "backtested": "已回测",
+      "validated": "已验证",
+      "production": "生产中",
+      "retired": "已停用"
+    },
     "loadSelected": "加载",
     "deleteConfirm": "删除该策略？",
     "unsavedChanges": "您有未保存的更改",

--- a/web/src/app/[locale]/strategy/page.tsx
+++ b/web/src/app/[locale]/strategy/page.tsx
@@ -1793,8 +1793,21 @@ function StrategyPageInner() {
                   className="w-full text-left px-3 py-2.5 rounded-lg hover:bg-gray-50 dark:hover:bg-white/5 transition-colors mb-1 group"
                 >
                   <div className="flex items-center justify-between">
-                    <span className="text-sm font-medium text-gray-900 dark:text-gray-100">{s.name}</span>
-                    <span className="text-[10px] text-gray-400">
+                    <div className="flex items-center gap-1.5 min-w-0">
+                      <span className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">{s.name}</span>
+                      {s.status && s.status !== 'draft' && (
+                        <span className={`inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-medium leading-none shrink-0 ${
+                          s.status === 'backtested' ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300' :
+                          s.status === 'validated' ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300' :
+                          s.status === 'production' ? 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300' :
+                          s.status === 'retired' ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300' :
+                          'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
+                        }`}>
+                          {t(`strategyStatus.${s.status}` as Parameters<typeof t>[0])}
+                        </span>
+                      )}
+                    </div>
+                    <span className="text-[10px] text-gray-400 shrink-0 ml-1">
                       {new Date(s.updated_at).toLocaleDateString()}
                     </span>
                   </div>

--- a/web/src/hooks/useBacktest.ts
+++ b/web/src/hooks/useBacktest.ts
@@ -6,8 +6,10 @@ import {
   getBacktestStrategies,
   runBacktest,
   runOptimize,
+  runGraphBacktest,
   type BacktestRequest,
   type OptimizeRequest,
+  type GraphBacktestRequest,
 } from '@/lib/api';
 
 export function useBacktestStrategies(enabled: boolean = true) {
@@ -28,5 +30,11 @@ export function useRunBacktest() {
 export function useRunOptimize() {
   return useMutation({
     mutationFn: (request: OptimizeRequest) => runOptimize(request),
+  });
+}
+
+export function useRunGraphBacktest() {
+  return useMutation({
+    mutationFn: (request: GraphBacktestRequest) => runGraphBacktest(request),
   });
 }

--- a/web/src/hooks/useStrategy.ts
+++ b/web/src/hooks/useStrategy.ts
@@ -9,7 +9,9 @@ import {
   saveNewStrategy,
   updateSavedStrategy,
   deleteSavedStrategy,
+  updateStrategyStatus,
 } from '@/lib/api';
+import type { StrategyStatus } from '@/lib/api';
 import type { StrategyGraph } from '@/lib/strategy/graphSerializer';
 
 export function useStrategyConditions() {
@@ -70,6 +72,17 @@ export function useDeleteStrategy() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (id: string) => deleteSavedStrategy(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.strategy.saved() });
+    },
+  });
+}
+
+export function useUpdateStrategyStatus() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, status }: { id: string; status: StrategyStatus }) =>
+      updateStrategyStatus(id, status),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.strategy.saved() });
     },

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1061,11 +1061,14 @@ import type { StrategyGraph } from './strategy/graphSerializer';
 
 // Saved strategy types
 
+export type StrategyStatus = 'draft' | 'backtested' | 'validated' | 'production' | 'retired';
+
 export interface SavedStrategy {
   id: string;
   name: string;
   description: string | null;
   graph: StrategyGraph;
+  status: StrategyStatus;
   created_at: string;
   updated_at: string;
 }
@@ -1302,6 +1305,65 @@ export async function getSectors(market: string = 'KOSPI'): Promise<SectorListRe
 export async function deleteSavedStrategy(id: string): Promise<void> {
   return fetchApi<void>(`/api/strategy/saved/${encodeURIComponent(id)}`, {
     method: 'DELETE',
+  });
+}
+
+/**
+ * Update the lifecycle status of a saved strategy
+ */
+export async function updateStrategyStatus(
+  id: string,
+  status: StrategyStatus
+): Promise<SavedStrategy> {
+  return fetchApi<SavedStrategy>(
+    `/api/strategy/saved/${encodeURIComponent(id)}/status`,
+    {
+      method: 'PATCH',
+      body: JSON.stringify({ status }),
+    }
+  );
+}
+
+// Graph backtest types
+
+export interface GraphBacktestRequest {
+  graph: StrategyGraph;
+  ticker: string;
+  strategy_id?: string;
+  period?: string;
+  start?: string;
+  end?: string;
+  cash?: number;
+  commission?: number;
+  take_profit?: number;
+  stop_loss?: number;
+  include_trades?: boolean;
+  include_equity_curve?: boolean;
+}
+
+export interface GraphBacktestResponse {
+  ticker: string;
+  strategy: string;
+  period: string;
+  cash: number;
+  metrics: BacktestMetrics;
+  trades: BacktestTrade[];
+  equity_curve: EquityPoint[];
+  compiled_conditions: string[];
+  skipped_conditions: string[];
+  warnings: string[];
+  strategy_status?: string | null;
+}
+
+/**
+ * Run a backtest using a strategy graph
+ */
+export async function runGraphBacktest(
+  request: GraphBacktestRequest
+): Promise<GraphBacktestResponse> {
+  return fetchApi<GraphBacktestResponse>('/api/backtest/run-graph', {
+    method: 'POST',
+    body: JSON.stringify(request),
   });
 }
 


### PR DESCRIPTION
## Summary
- Add `runGraphBacktest()` and `updateStrategyStatus()` API client functions with TypeScript types
- Add `useRunGraphBacktest` and `useUpdateStrategyStatus` React Query hooks
- Show color-coded status badges (backtested=blue, validated=green, production=purple, retired=red) on strategy list
- Add i18n status label keys for en/ko/zh

## Test plan
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] ESLint passes on all changed files
- [ ] Manual: load strategy page, verify status badges render

Closes #1250

🤖 Generated with [Claude Code](https://claude.com/claude-code)