### PR TITLE
feat(api): strategy comparison and leaderboard API

### DIFF
--- a/api/routers/strategy.py
+++ b/api/routers/strategy.py
@@ -26,6 +26,11 @@ from api.schemas.strategy_validation import (
     StrategyValidateRequest,
     StrategyValidateResponse,
 )
+from api.schemas.strategy_comparison import (
+    LeaderboardResponse,
+    StrategyCompareRequest,
+    StrategyCompareResponse,
+)
 from api.schemas.strategy import (
     ConditionsListResponse,
     SavedStrategiesListResponse,
@@ -215,6 +220,49 @@ async def validate_strategy(
             status_code=500,
             detail="Strategy validation failed. Check server logs.",
         )
+
+
+@router.post(
+    "/compare",
+    response_model=StrategyCompareResponse,
+    summary="Compare strategies",
+    description="Compare 2-4 strategies side by side using their latest backtest metrics.",
+)
+async def compare_strategies(data: StrategyCompareRequest) -> StrategyCompareResponse:
+    """Compare multiple strategies using their latest backtest results."""
+    from api.services.strategy_comparison_service import compare_strategies as _compare
+
+    try:
+        return _compare(data.strategy_ids)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error(f"Strategy comparison failed: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Strategy comparison failed.")
+
+
+@router.get(
+    "/leaderboard",
+    response_model=LeaderboardResponse,
+    summary="Strategy leaderboard",
+    description="Ranked list of strategies by backtest performance metrics.",
+)
+async def strategy_leaderboard(
+    sort_by: str = "sharpe_ratio",
+    order: str = "desc",
+    status: str | None = None,
+    limit: int = 20,
+) -> LeaderboardResponse:
+    """Get strategy leaderboard ranked by performance."""
+    from api.services.strategy_comparison_service import get_leaderboard
+
+    try:
+        return get_leaderboard(sort_by=sort_by, order=order, status=status, limit=limit)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error(f"Leaderboard failed: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Leaderboard failed.")
 
 
 @router.get(

--- a/api/schemas/strategy_comparison.py
+++ b/api/schemas/strategy_comparison.py
@@ -1,0 +1,75 @@
+"""
+Strategy Comparison & Leaderboard Schemas.
+
+Pydantic models for comparing strategies and ranking them.
+"""
+
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class StrategyCompareRequest(BaseModel):
+    """Request to compare multiple strategies."""
+
+    strategy_ids: List[str] = Field(
+        ...,
+        min_length=2,
+        max_length=4,
+        description="Strategy IDs to compare (2-4)",
+    )
+
+
+class StrategyMetricsSummary(BaseModel):
+    """Summary metrics for a strategy (from its latest backtest)."""
+
+    strategy_id: str
+    strategy_name: str
+    status: str = "draft"
+    ticker: str = ""
+    period: str = ""
+    sharpe_ratio: Optional[float] = None
+    sortino_ratio: Optional[float] = None
+    cagr: Optional[float] = None
+    max_drawdown: Optional[float] = None
+    win_rate: Optional[float] = None
+    total_return: Optional[float] = None
+    profit_factor: Optional[float] = None
+    total_trades: int = 0
+    avg_trade_return: Optional[float] = None
+    backtested_at: Optional[str] = None
+
+
+class StrategyCompareResponse(BaseModel):
+    """Response comparing multiple strategies."""
+
+    strategies: List[StrategyMetricsSummary]
+    best_sharpe: Optional[str] = Field(None, description="Strategy ID with best Sharpe ratio")
+    best_cagr: Optional[str] = Field(None, description="Strategy ID with best CAGR")
+    best_win_rate: Optional[str] = Field(None, description="Strategy ID with best win rate")
+    lowest_drawdown: Optional[str] = Field(None, description="Strategy ID with lowest max drawdown")
+
+
+class LeaderboardEntry(BaseModel):
+    """A single entry on the strategy leaderboard."""
+
+    rank: int
+    strategy_id: str
+    strategy_name: str
+    status: str = "draft"
+    sharpe_ratio: Optional[float] = None
+    cagr: Optional[float] = None
+    max_drawdown: Optional[float] = None
+    win_rate: Optional[float] = None
+    total_return: Optional[float] = None
+    total_trades: int = 0
+    backtested_at: Optional[str] = None
+
+
+class LeaderboardResponse(BaseModel):
+    """Response from the strategy leaderboard."""
+
+    entries: List[LeaderboardEntry]
+    sort_by: str
+    order: str
+    total_count: int

--- a/api/services/strategy_comparison_service.py
+++ b/api/services/strategy_comparison_service.py
@@ -1,0 +1,197 @@
+"""
+Strategy Comparison & Leaderboard Service.
+
+Business logic for comparing strategies and building leaderboards.
+"""
+
+import logging
+from typing import List, Optional
+
+from sqlalchemy import func
+
+from api.database import SessionLocal
+from api.models.strategy import Strategy
+from api.models.strategy_backtest_result import StrategyBacktestResult
+from api.schemas.strategy_comparison import (
+    LeaderboardEntry,
+    LeaderboardResponse,
+    StrategyCompareResponse,
+    StrategyMetricsSummary,
+)
+
+logger = logging.getLogger(__name__)
+
+_SORT_COLUMNS = {
+    "sharpe_ratio": StrategyBacktestResult.sharpe_ratio,
+    "cagr": StrategyBacktestResult.cagr,
+    "max_drawdown": StrategyBacktestResult.max_drawdown,
+    "win_rate": StrategyBacktestResult.win_rate,
+    "total_return": StrategyBacktestResult.total_return,
+}
+
+
+def _best_by(
+    strategies: List[StrategyMetricsSummary],
+    attr: str,
+    higher_is_better: bool = True,
+) -> Optional[str]:
+    """Return strategy_id with the best value for a metric."""
+    candidates = [(s.strategy_id, getattr(s, attr)) for s in strategies if getattr(s, attr) is not None]
+    if not candidates:
+        return None
+    candidates.sort(key=lambda x: x[1], reverse=higher_is_better)
+    return candidates[0][0]
+
+
+def compare_strategies(strategy_ids: List[str]) -> StrategyCompareResponse:
+    """Compare 2-4 strategies using their latest backtest results.
+
+    Args:
+        strategy_ids: List of strategy IDs to compare.
+
+    Returns:
+        StrategyCompareResponse with metrics side by side.
+
+    Raises:
+        ValueError: If fewer than 2 IDs or any not found.
+    """
+    if len(strategy_ids) < 2:
+        raise ValueError("At least 2 strategy IDs required for comparison")
+
+    db = SessionLocal()
+    try:
+        summaries: List[StrategyMetricsSummary] = []
+
+        for sid in strategy_ids:
+            strategy = db.get(Strategy, sid)
+            if strategy is None:
+                raise ValueError(f"Strategy not found: {sid}")
+
+            # Get latest backtest result
+            latest = (
+                db.query(StrategyBacktestResult)
+                .filter(StrategyBacktestResult.strategy_id == sid)
+                .order_by(StrategyBacktestResult.created_at.desc())
+                .first()
+            )
+
+            summary = StrategyMetricsSummary(
+                strategy_id=sid,
+                strategy_name=strategy.name,
+                status=strategy.status or "draft",
+            )
+
+            if latest:
+                summary.ticker = latest.ticker
+                summary.period = latest.period
+                summary.sharpe_ratio = latest.sharpe_ratio
+                summary.sortino_ratio = latest.sortino_ratio
+                summary.cagr = latest.cagr
+                summary.max_drawdown = latest.max_drawdown
+                summary.win_rate = latest.win_rate
+                summary.total_return = latest.total_return
+                summary.profit_factor = latest.profit_factor
+                summary.total_trades = latest.total_trades
+                summary.avg_trade_return = latest.avg_trade_return
+                summary.backtested_at = (
+                    latest.created_at.isoformat() if latest.created_at else None
+                )
+
+            summaries.append(summary)
+
+        return StrategyCompareResponse(
+            strategies=summaries,
+            best_sharpe=_best_by(summaries, "sharpe_ratio"),
+            best_cagr=_best_by(summaries, "cagr"),
+            best_win_rate=_best_by(summaries, "win_rate"),
+            lowest_drawdown=_best_by(summaries, "max_drawdown", higher_is_better=False),
+        )
+    finally:
+        db.close()
+
+
+def get_leaderboard(
+    sort_by: str = "sharpe_ratio",
+    order: str = "desc",
+    status: Optional[str] = None,
+    limit: int = 20,
+) -> LeaderboardResponse:
+    """Get a ranked leaderboard of strategies based on backtest metrics.
+
+    Only includes strategies that have at least one backtest result.
+
+    Args:
+        sort_by: Metric to sort by (sharpe_ratio, cagr, max_drawdown, win_rate, total_return).
+        order: Sort order (asc, desc).
+        status: Optional status filter (draft, backtested, validated, production, retired).
+        limit: Maximum entries to return.
+
+    Returns:
+        LeaderboardResponse with ranked entries.
+    """
+    if sort_by not in _SORT_COLUMNS:
+        raise ValueError(f"Invalid sort_by: '{sort_by}'. Valid: {', '.join(_SORT_COLUMNS)}")
+    if order not in ("asc", "desc"):
+        raise ValueError(f"Invalid order: '{order}'. Must be 'asc' or 'desc'")
+
+    db = SessionLocal()
+    try:
+        # Subquery to get the latest result ID per strategy
+        latest_subq = (
+            db.query(
+                StrategyBacktestResult.strategy_id,
+                func.max(StrategyBacktestResult.created_at).label("max_created"),
+            )
+            .group_by(StrategyBacktestResult.strategy_id)
+            .subquery()
+        )
+
+        query = (
+            db.query(StrategyBacktestResult, Strategy)
+            .join(
+                latest_subq,
+                (StrategyBacktestResult.strategy_id == latest_subq.c.strategy_id)
+                & (StrategyBacktestResult.created_at == latest_subq.c.max_created),
+            )
+            .join(Strategy, Strategy.id == StrategyBacktestResult.strategy_id)
+        )
+
+        if status:
+            query = query.filter(Strategy.status == status)
+
+        sort_col = _SORT_COLUMNS[sort_by]
+        if order == "desc":
+            query = query.order_by(sort_col.desc().nullslast())
+        else:
+            query = query.order_by(sort_col.asc().nullsfirst())
+
+        rows = query.limit(limit).all()
+
+        entries = []
+        for rank, (result, strategy) in enumerate(rows, start=1):
+            entries.append(
+                LeaderboardEntry(
+                    rank=rank,
+                    strategy_id=strategy.id,
+                    strategy_name=strategy.name,
+                    status=strategy.status or "draft",
+                    sharpe_ratio=result.sharpe_ratio,
+                    cagr=result.cagr,
+                    max_drawdown=result.max_drawdown,
+                    win_rate=result.win_rate,
+                    total_return=result.total_return,
+                    total_trades=result.total_trades,
+                    backtested_at=(
+                        result.created_at.isoformat() if result.created_at else None
+                    ),
+                )
+            )
+
+        return LeaderboardResponse(
+            entries=entries,
+            sort_by=sort_by,
+            order=order,
+            total_count=len(entries),
+        )
+    finally:
+        db.close()

--- a/tests/test_strategy_comparison.py
+++ b/tests/test_strategy_comparison.py
@@ -1,0 +1,199 @@
+"""
+Tests for strategy comparison and leaderboard.
+
+Verifies:
+  - Compare 2-4 strategies with metrics side by side
+  - Best-of fields (best_sharpe, best_cagr, etc.)
+  - Leaderboard ranking with sort/order/status/limit
+  - Edge cases: no results, missing strategies
+"""
+
+import sys
+import os
+from datetime import datetime
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from api.schemas.strategy import StrategySaveRequest, StrategyGraph, StrategyNode, StrategyNodeData, StrategyEdge
+from api.services.strategy_save_service import StrategySaveService
+from api.services.strategy_comparison_service import compare_strategies, get_leaderboard
+from api.models.strategy_backtest_result import StrategyBacktestResult
+
+
+def _make_graph():
+    return StrategyGraph(
+        nodes=[
+            StrategyNode(id="u1", data=StrategyNodeData(node_type="universe", universe="SP500", universes=["SP500"])),
+            StrategyNode(id="c1", data=StrategyNodeData(node_type="condition", condition_type="rsi_oversold", params={"period": 14, "threshold": 30})),
+            StrategyNode(id="o1", data=StrategyNodeData(node_type="output")),
+        ],
+        edges=[
+            StrategyEdge(id="e1", source="u1", target="c1"),
+            StrategyEdge(id="e2", source="c1", target="o1"),
+        ],
+    )
+
+
+@pytest.fixture(autouse=True)
+def _use_in_memory_db(monkeypatch):
+    from api import database
+    from api.services import strategy_save_service, strategy_backtest_result_service, strategy_comparison_service
+
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+
+    test_engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    TestSession = sessionmaker(bind=test_engine)
+
+    monkeypatch.setattr(database, "engine", test_engine)
+    monkeypatch.setattr(database, "SessionLocal", TestSession)
+    monkeypatch.setattr(strategy_save_service, "SessionLocal", TestSession)
+    monkeypatch.setattr(strategy_backtest_result_service, "SessionLocal", TestSession)
+    monkeypatch.setattr(strategy_comparison_service, "SessionLocal", TestSession)
+    monkeypatch.setattr(strategy_save_service, "_strategy_save_service", None)
+
+    database.Base.metadata.create_all(bind=test_engine)
+    yield TestSession
+    database.Base.metadata.drop_all(bind=test_engine)
+
+
+@pytest.fixture
+def service():
+    return StrategySaveService()
+
+
+def _insert_backtest_result(session_factory, strategy_id, sharpe=1.0, cagr=0.1, win_rate=0.5, max_drawdown=0.15, total_return=0.2):
+    """Insert a backtest result directly into DB."""
+    import uuid
+    db = session_factory()
+    try:
+        row = StrategyBacktestResult(
+            id=uuid.uuid4().hex,
+            strategy_id=strategy_id,
+            ticker="AAPL",
+            period="1y",
+            initial_cash=10_000_000,
+            sharpe_ratio=sharpe,
+            cagr=cagr,
+            win_rate=win_rate,
+            max_drawdown=max_drawdown,
+            total_return=total_return,
+            total_trades=10,
+            created_at=datetime.utcnow(),
+        )
+        db.add(row)
+        db.commit()
+    finally:
+        db.close()
+
+
+class TestCompareStrategies:
+    def test_compare_two(self, service, _use_in_memory_db):
+        s1 = service.save_strategy(StrategySaveRequest(name="Alpha", graph=_make_graph()))
+        s2 = service.save_strategy(StrategySaveRequest(name="Beta", graph=_make_graph()))
+
+        _insert_backtest_result(_use_in_memory_db, s1.id, sharpe=1.5, cagr=0.12)
+        _insert_backtest_result(_use_in_memory_db, s2.id, sharpe=0.8, cagr=0.20)
+
+        result = compare_strategies([s1.id, s2.id])
+
+        assert len(result.strategies) == 2
+        assert result.best_sharpe == s1.id
+        assert result.best_cagr == s2.id
+
+    def test_compare_without_results(self, service):
+        s1 = service.save_strategy(StrategySaveRequest(name="A", graph=_make_graph()))
+        s2 = service.save_strategy(StrategySaveRequest(name="B", graph=_make_graph()))
+
+        result = compare_strategies([s1.id, s2.id])
+
+        assert len(result.strategies) == 2
+        assert result.best_sharpe is None
+
+    def test_compare_not_found(self, service):
+        s1 = service.save_strategy(StrategySaveRequest(name="A", graph=_make_graph()))
+
+        with pytest.raises(ValueError, match="not found"):
+            compare_strategies([s1.id, "nonexistent"])
+
+    def test_compare_too_few(self, service):
+        s1 = service.save_strategy(StrategySaveRequest(name="A", graph=_make_graph()))
+
+        with pytest.raises(ValueError, match="At least 2"):
+            compare_strategies([s1.id])
+
+    def test_best_lowest_drawdown(self, service, _use_in_memory_db):
+        s1 = service.save_strategy(StrategySaveRequest(name="A", graph=_make_graph()))
+        s2 = service.save_strategy(StrategySaveRequest(name="B", graph=_make_graph()))
+
+        _insert_backtest_result(_use_in_memory_db, s1.id, max_drawdown=0.30)
+        _insert_backtest_result(_use_in_memory_db, s2.id, max_drawdown=0.05)
+
+        result = compare_strategies([s1.id, s2.id])
+        assert result.lowest_drawdown == s2.id
+
+
+class TestLeaderboard:
+    def test_leaderboard_sorted_desc(self, service, _use_in_memory_db):
+        s1 = service.save_strategy(StrategySaveRequest(name="Alpha", graph=_make_graph()))
+        s2 = service.save_strategy(StrategySaveRequest(name="Beta", graph=_make_graph()))
+        s3 = service.save_strategy(StrategySaveRequest(name="Gamma", graph=_make_graph()))
+
+        _insert_backtest_result(_use_in_memory_db, s1.id, sharpe=1.5)
+        _insert_backtest_result(_use_in_memory_db, s2.id, sharpe=2.0)
+        _insert_backtest_result(_use_in_memory_db, s3.id, sharpe=0.5)
+
+        result = get_leaderboard(sort_by="sharpe_ratio", order="desc")
+
+        assert len(result.entries) == 3
+        assert result.entries[0].strategy_name == "Beta"
+        assert result.entries[0].rank == 1
+        assert result.entries[1].strategy_name == "Alpha"
+        assert result.entries[2].strategy_name == "Gamma"
+
+    def test_leaderboard_sorted_asc(self, service, _use_in_memory_db):
+        s1 = service.save_strategy(StrategySaveRequest(name="A", graph=_make_graph()))
+        s2 = service.save_strategy(StrategySaveRequest(name="B", graph=_make_graph()))
+
+        _insert_backtest_result(_use_in_memory_db, s1.id, cagr=0.20)
+        _insert_backtest_result(_use_in_memory_db, s2.id, cagr=0.05)
+
+        result = get_leaderboard(sort_by="cagr", order="asc")
+        assert result.entries[0].strategy_name == "B"
+
+    def test_leaderboard_status_filter(self, service, _use_in_memory_db):
+        s1 = service.save_strategy(StrategySaveRequest(name="A", graph=_make_graph()))
+        s2 = service.save_strategy(StrategySaveRequest(name="B", graph=_make_graph()))
+
+        service.update_status(s1.id, "backtested")
+        # s2 stays draft
+
+        _insert_backtest_result(_use_in_memory_db, s1.id, sharpe=1.0)
+        _insert_backtest_result(_use_in_memory_db, s2.id, sharpe=2.0)
+
+        result = get_leaderboard(status="backtested")
+        assert len(result.entries) == 1
+        assert result.entries[0].strategy_name == "A"
+
+    def test_leaderboard_limit(self, service, _use_in_memory_db):
+        for i in range(5):
+            s = service.save_strategy(StrategySaveRequest(name=f"S{i}", graph=_make_graph()))
+            _insert_backtest_result(_use_in_memory_db, s.id, sharpe=float(i))
+
+        result = get_leaderboard(limit=3)
+        assert len(result.entries) == 3
+
+    def test_leaderboard_empty(self):
+        result = get_leaderboard()
+        assert len(result.entries) == 0
+        assert result.total_count == 0
+
+    def test_leaderboard_invalid_sort(self):
+        with pytest.raises(ValueError, match="Invalid sort_by"):
+            get_leaderboard(sort_by="invalid_metric")
+
+    def test_leaderboard_invalid_order(self):
+        with pytest.raises(ValueError, match="Invalid order"):
+            get_leaderboard(order="random")


### PR DESCRIPTION
## Summary
- `POST /api/strategy/compare`: compare 2-4 strategies using latest backtest metrics
- `GET /api/strategy/leaderboard`: ranked list with `sort_by`, `order`, `status` filter, `limit`
- Best-of identification (Sharpe, CAGR, win rate, lowest drawdown)
- 12 unit tests covering all scenarios

## Test plan
- [x] 12 tests pass (`pytest tests/test_strategy_comparison.py`)
- [ ] Manual: POST compare with two strategy IDs
- [ ] Manual: GET leaderboard with sorting

Closes #1254

🤖 Generated with [Claude Code](https://claude.com/claude-code)