### PR TITLE
feat(api): strategy event webhooks with HMAC signatures

### DIFF
--- a/api/database.py
+++ b/api/database.py
@@ -56,6 +56,7 @@ def init_db() -> None:
     import api.models.screening_result  # noqa: F401 — register model with Base
     import api.models.strategy  # noqa: F401 — register model with Base
     import api.models.strategy_backtest_result  # noqa: F401 — register model with Base
+    import api.models.strategy_webhook  # noqa: F401 — register model with Base
     import api.models.watchlist  # noqa: F401 — register model with Base
 
     Base.metadata.create_all(bind=engine)

--- a/api/models/strategy_webhook.py
+++ b/api/models/strategy_webhook.py
@@ -1,0 +1,23 @@
+"""
+SQLAlchemy model for the strategy_webhooks table.
+"""
+
+from datetime import datetime
+
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, JSON, String, Text
+from sqlalchemy.dialects.postgresql import JSONB
+
+from api.database import Base
+
+
+class StrategyWebhook(Base):
+    __tablename__ = "strategy_webhooks"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    strategy_id = Column(String(32), ForeignKey("strategies.id", ondelete="CASCADE"), nullable=False, index=True)
+    url = Column(Text, nullable=False)
+    events = Column(JSON().with_variant(JSONB, "postgresql"), nullable=False, default=list)
+    secret = Column(String(128), nullable=True)
+    active = Column(Boolean, nullable=False, default=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)

--- a/api/routers/strategy.py
+++ b/api/routers/strategy.py
@@ -35,6 +35,12 @@ from api.schemas.pine_script import (
     PineScriptExportRequest,
     PineScriptExportResponse,
 )
+from api.schemas.strategy_webhook import (
+    WebhookCreateRequest,
+    WebhookListResponse,
+    WebhookResponse,
+    WebhookUpdateRequest,
+)
 from api.schemas.strategy import (
     ConditionsListResponse,
     SavedStrategiesListResponse,
@@ -370,6 +376,65 @@ async def delete_saved_strategy(strategy_id: str) -> None:
             status_code=500,
             detail=f"Failed to delete strategy: {str(e)}",
         )
+
+
+# ---------------------------------------------------------------------------
+# Webhook CRUD
+# ---------------------------------------------------------------------------
+
+@router.get(
+    "/saved/{strategy_id}/webhooks",
+    response_model=WebhookListResponse,
+    summary="List webhooks for a strategy",
+)
+async def list_webhooks(strategy_id: str) -> WebhookListResponse:
+    """List all webhook configurations for a strategy."""
+    from api.services.strategy_webhook_service import list_webhooks as _list
+    return _list(strategy_id)
+
+
+@router.post(
+    "/saved/{strategy_id}/webhooks",
+    response_model=WebhookResponse,
+    status_code=201,
+    summary="Create webhook",
+)
+async def create_webhook(strategy_id: str, data: WebhookCreateRequest) -> WebhookResponse:
+    """Create a new webhook for a strategy."""
+    from api.services.strategy_webhook_service import create_webhook as _create
+    try:
+        return _create(strategy_id, data)
+    except Exception as e:
+        logger.error(f"Failed to create webhook: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to create webhook.")
+
+
+@router.put(
+    "/saved/{strategy_id}/webhooks/{webhook_id}",
+    response_model=WebhookResponse,
+    summary="Update webhook",
+)
+async def update_webhook(
+    strategy_id: str, webhook_id: int, data: WebhookUpdateRequest
+) -> WebhookResponse:
+    """Update a webhook configuration."""
+    from api.services.strategy_webhook_service import update_webhook as _update
+    result = _update(strategy_id, webhook_id, data)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Webhook not found")
+    return result
+
+
+@router.delete(
+    "/saved/{strategy_id}/webhooks/{webhook_id}",
+    status_code=204,
+    summary="Delete webhook",
+)
+async def delete_webhook(strategy_id: str, webhook_id: int) -> None:
+    """Delete a webhook."""
+    from api.services.strategy_webhook_service import delete_webhook as _delete
+    if not _delete(strategy_id, webhook_id):
+        raise HTTPException(status_code=404, detail="Webhook not found")
 
 
 @router.get(

--- a/api/schemas/strategy_webhook.py
+++ b/api/schemas/strategy_webhook.py
@@ -1,0 +1,104 @@
+"""
+Strategy Webhook Schemas.
+
+Pydantic models for webhook configuration and event payloads.
+"""
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+VALID_WEBHOOK_EVENTS = {
+    "status_changed",
+    "backtest_completed",
+    "validation_passed",
+    "validation_failed",
+}
+
+
+class WebhookCreateRequest(BaseModel):
+    """Request to create a new webhook."""
+
+    url: str = Field(..., description="Webhook endpoint URL")
+    events: List[str] = Field(
+        ...,
+        min_length=1,
+        description="Events to subscribe to",
+    )
+    secret: Optional[str] = Field(
+        None,
+        max_length=128,
+        description="Shared secret for HMAC signature verification",
+    )
+    active: bool = Field(default=True)
+
+    @field_validator("url")
+    @classmethod
+    def validate_url(cls, v: str) -> str:
+        if not v.startswith(("http://", "https://")):
+            raise ValueError("URL must start with http:// or https://")
+        return v
+
+    @field_validator("events")
+    @classmethod
+    def validate_events(cls, v: List[str]) -> List[str]:
+        invalid = set(v) - VALID_WEBHOOK_EVENTS
+        if invalid:
+            raise ValueError(f"Invalid events: {invalid}. Valid: {VALID_WEBHOOK_EVENTS}")
+        return v
+
+
+class WebhookUpdateRequest(BaseModel):
+    """Request to update a webhook."""
+
+    url: Optional[str] = None
+    events: Optional[List[str]] = None
+    secret: Optional[str] = Field(None, max_length=128)
+    active: Optional[bool] = None
+
+    @field_validator("url")
+    @classmethod
+    def validate_url(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None and not v.startswith(("http://", "https://")):
+            raise ValueError("URL must start with http:// or https://")
+        return v
+
+    @field_validator("events")
+    @classmethod
+    def validate_events(cls, v: Optional[List[str]]) -> Optional[List[str]]:
+        if v is not None:
+            invalid = set(v) - VALID_WEBHOOK_EVENTS
+            if invalid:
+                raise ValueError(f"Invalid events: {invalid}. Valid: {VALID_WEBHOOK_EVENTS}")
+        return v
+
+
+class WebhookResponse(BaseModel):
+    """Response for a single webhook."""
+
+    id: int
+    strategy_id: str
+    url: str
+    events: List[str]
+    has_secret: bool = Field(description="Whether a secret is configured (secret itself is not exposed)")
+    active: bool
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+
+
+class WebhookListResponse(BaseModel):
+    """Response listing all webhooks for a strategy."""
+
+    strategy_id: str
+    webhooks: List[WebhookResponse]
+    total_count: int
+
+
+class WebhookEventPayload(BaseModel):
+    """Payload sent to webhook endpoints."""
+
+    event: str
+    strategy_id: str
+    strategy_name: str
+    timestamp: str
+    data: Dict[str, Any] = Field(default_factory=dict)

--- a/api/services/strategy_webhook_service.py
+++ b/api/services/strategy_webhook_service.py
@@ -1,0 +1,239 @@
+"""
+Strategy Webhook Service.
+
+CRUD operations for webhook configurations and async event dispatching
+with HMAC signatures and exponential backoff retry.
+"""
+
+import hashlib
+import hmac
+import json
+import logging
+import threading
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from api.database import SessionLocal
+from api.models.strategy_webhook import StrategyWebhook
+from api.schemas.strategy_webhook import (
+    WebhookCreateRequest,
+    WebhookEventPayload,
+    WebhookListResponse,
+    WebhookResponse,
+    WebhookUpdateRequest,
+)
+
+logger = logging.getLogger(__name__)
+
+MAX_RETRIES = 3
+RETRY_BASE_DELAY = 1  # seconds
+
+
+def _to_response(wh: StrategyWebhook) -> WebhookResponse:
+    return WebhookResponse(
+        id=wh.id,
+        strategy_id=wh.strategy_id,
+        url=wh.url,
+        events=wh.events or [],
+        has_secret=bool(wh.secret),
+        active=wh.active,
+        created_at=wh.created_at.isoformat() if wh.created_at else None,
+        updated_at=wh.updated_at.isoformat() if wh.updated_at else None,
+    )
+
+
+def list_webhooks(strategy_id: str) -> WebhookListResponse:
+    """List all webhooks for a strategy."""
+    db = SessionLocal()
+    try:
+        webhooks = (
+            db.query(StrategyWebhook)
+            .filter(StrategyWebhook.strategy_id == strategy_id)
+            .order_by(StrategyWebhook.created_at)
+            .all()
+        )
+        return WebhookListResponse(
+            strategy_id=strategy_id,
+            webhooks=[_to_response(w) for w in webhooks],
+            total_count=len(webhooks),
+        )
+    finally:
+        db.close()
+
+
+def create_webhook(strategy_id: str, data: WebhookCreateRequest) -> WebhookResponse:
+    """Create a new webhook for a strategy."""
+    db = SessionLocal()
+    try:
+        wh = StrategyWebhook(
+            strategy_id=strategy_id,
+            url=data.url,
+            events=data.events,
+            secret=data.secret,
+            active=data.active,
+        )
+        db.add(wh)
+        db.commit()
+        db.refresh(wh)
+        return _to_response(wh)
+    finally:
+        db.close()
+
+
+def get_webhook(strategy_id: str, webhook_id: int) -> Optional[WebhookResponse]:
+    """Get a specific webhook."""
+    db = SessionLocal()
+    try:
+        wh = (
+            db.query(StrategyWebhook)
+            .filter(
+                StrategyWebhook.id == webhook_id,
+                StrategyWebhook.strategy_id == strategy_id,
+            )
+            .first()
+        )
+        return _to_response(wh) if wh else None
+    finally:
+        db.close()
+
+
+def update_webhook(
+    strategy_id: str, webhook_id: int, data: WebhookUpdateRequest
+) -> Optional[WebhookResponse]:
+    """Update a webhook configuration."""
+    db = SessionLocal()
+    try:
+        wh = (
+            db.query(StrategyWebhook)
+            .filter(
+                StrategyWebhook.id == webhook_id,
+                StrategyWebhook.strategy_id == strategy_id,
+            )
+            .first()
+        )
+        if not wh:
+            return None
+        if data.url is not None:
+            wh.url = data.url
+        if data.events is not None:
+            wh.events = data.events
+        if data.secret is not None:
+            wh.secret = data.secret
+        if data.active is not None:
+            wh.active = data.active
+        db.commit()
+        db.refresh(wh)
+        return _to_response(wh)
+    finally:
+        db.close()
+
+
+def delete_webhook(strategy_id: str, webhook_id: int) -> bool:
+    """Delete a webhook. Returns True if deleted."""
+    db = SessionLocal()
+    try:
+        wh = (
+            db.query(StrategyWebhook)
+            .filter(
+                StrategyWebhook.id == webhook_id,
+                StrategyWebhook.strategy_id == strategy_id,
+            )
+            .first()
+        )
+        if not wh:
+            return False
+        db.delete(wh)
+        db.commit()
+        return True
+    finally:
+        db.close()
+
+
+def _compute_signature(payload_bytes: bytes, secret: str) -> str:
+    """Compute HMAC-SHA256 signature for webhook payload."""
+    return hmac.new(secret.encode("utf-8"), payload_bytes, hashlib.sha256).hexdigest()
+
+
+def _send_webhook(url: str, payload: dict, secret: Optional[str]) -> bool:
+    """Send webhook with retry logic. Returns True if successful."""
+    import urllib.request
+    import urllib.error
+
+    payload_bytes = json.dumps(payload, default=str).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    if secret:
+        sig = _compute_signature(payload_bytes, secret)
+        headers["X-Webhook-Signature"] = f"sha256={sig}"
+
+    for attempt in range(MAX_RETRIES):
+        try:
+            req = urllib.request.Request(
+                url, data=payload_bytes, headers=headers, method="POST"
+            )
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                if resp.status < 300:
+                    return True
+                logger.warning(
+                    "Webhook %s returned status %d (attempt %d/%d)",
+                    url, resp.status, attempt + 1, MAX_RETRIES,
+                )
+        except Exception as e:
+            logger.warning(
+                "Webhook %s failed (attempt %d/%d): %s",
+                url, attempt + 1, MAX_RETRIES, e,
+            )
+        if attempt < MAX_RETRIES - 1:
+            time.sleep(RETRY_BASE_DELAY * (2 ** attempt))
+
+    logger.error("Webhook %s failed after %d attempts", url, MAX_RETRIES)
+    return False
+
+
+def dispatch_event(
+    strategy_id: str,
+    strategy_name: str,
+    event: str,
+    data: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Dispatch a webhook event to all matching active webhooks (async).
+
+    This fires off delivery in a background thread so the caller
+    is not blocked.
+    """
+    db = SessionLocal()
+    try:
+        webhooks = (
+            db.query(StrategyWebhook)
+            .filter(
+                StrategyWebhook.strategy_id == strategy_id,
+                StrategyWebhook.active.is_(True),
+            )
+            .all()
+        )
+
+        targets = []
+        for wh in webhooks:
+            if event in (wh.events or []):
+                targets.append((wh.url, wh.secret))
+
+        if not targets:
+            return
+
+        payload = WebhookEventPayload(
+            event=event,
+            strategy_id=strategy_id,
+            strategy_name=strategy_name,
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            data=data or {},
+        ).model_dump()
+
+    finally:
+        db.close()
+
+    def _deliver():
+        for url, secret in targets:
+            _send_webhook(url, payload, secret)
+
+    thread = threading.Thread(target=_deliver, daemon=True)
+    thread.start()

--- a/tests/test_strategy_webhooks.py
+++ b/tests/test_strategy_webhooks.py
@@ -1,0 +1,296 @@
+"""Tests for strategy webhook service."""
+
+import hashlib
+import hmac
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from api.schemas.strategy_webhook import WebhookCreateRequest, WebhookUpdateRequest
+
+
+@pytest.fixture
+def db_session():
+    """Create an in-memory SQLite database for testing."""
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+    from api.database import Base
+    import api.models.strategy  # noqa: F401
+    import api.models.strategy_webhook  # noqa: F401
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    yield session
+    session.close()
+
+
+@pytest.fixture
+def patch_session(db_session):
+    """Patch SessionLocal in the webhook service module."""
+    with patch(
+        "api.services.strategy_webhook_service.SessionLocal",
+        return_value=db_session,
+    ):
+        yield db_session
+
+
+@pytest.fixture
+def strategy_row(db_session):
+    """Insert a test strategy into the DB."""
+    from api.models.strategy import Strategy
+
+    s = Strategy(id="test-strat-1", name="Test Strategy", graph={"nodes": [], "edges": []})
+    db_session.add(s)
+    db_session.commit()
+    return s
+
+
+class TestWebhookCRUD:
+    """Tests for webhook CRUD operations."""
+
+    def test_create_webhook(self, patch_session, strategy_row):
+        from api.services.strategy_webhook_service import create_webhook
+
+        req = WebhookCreateRequest(
+            url="https://example.com/webhook",
+            events=["status_changed"],
+            secret="mysecret",
+        )
+        result = create_webhook("test-strat-1", req)
+        assert result.strategy_id == "test-strat-1"
+        assert result.url == "https://example.com/webhook"
+        assert result.events == ["status_changed"]
+        assert result.has_secret is True
+        assert result.active is True
+
+    def test_list_webhooks(self, patch_session, strategy_row):
+        from api.services.strategy_webhook_service import create_webhook, list_webhooks
+
+        create_webhook(
+            "test-strat-1",
+            WebhookCreateRequest(url="https://a.com/hook", events=["status_changed"]),
+        )
+        create_webhook(
+            "test-strat-1",
+            WebhookCreateRequest(url="https://b.com/hook", events=["backtest_completed"]),
+        )
+        result = list_webhooks("test-strat-1")
+        assert result.total_count == 2
+        assert len(result.webhooks) == 2
+
+    def test_list_empty(self, patch_session, strategy_row):
+        from api.services.strategy_webhook_service import list_webhooks
+
+        result = list_webhooks("test-strat-1")
+        assert result.total_count == 0
+
+    def test_get_webhook(self, patch_session, strategy_row):
+        from api.services.strategy_webhook_service import create_webhook, get_webhook
+
+        created = create_webhook(
+            "test-strat-1",
+            WebhookCreateRequest(url="https://a.com/hook", events=["status_changed"]),
+        )
+        result = get_webhook("test-strat-1", created.id)
+        assert result is not None
+        assert result.url == "https://a.com/hook"
+
+    def test_get_webhook_not_found(self, patch_session, strategy_row):
+        from api.services.strategy_webhook_service import get_webhook
+
+        result = get_webhook("test-strat-1", 999)
+        assert result is None
+
+    def test_update_webhook(self, patch_session, strategy_row):
+        from api.services.strategy_webhook_service import create_webhook, update_webhook
+
+        created = create_webhook(
+            "test-strat-1",
+            WebhookCreateRequest(url="https://a.com/hook", events=["status_changed"]),
+        )
+        updated = update_webhook(
+            "test-strat-1",
+            created.id,
+            WebhookUpdateRequest(url="https://new.com/hook", active=False),
+        )
+        assert updated is not None
+        assert updated.url == "https://new.com/hook"
+        assert updated.active is False
+
+    def test_update_webhook_not_found(self, patch_session, strategy_row):
+        from api.services.strategy_webhook_service import update_webhook
+
+        result = update_webhook(
+            "test-strat-1", 999, WebhookUpdateRequest(active=False)
+        )
+        assert result is None
+
+    def test_delete_webhook(self, patch_session, strategy_row):
+        from api.services.strategy_webhook_service import (
+            create_webhook,
+            delete_webhook,
+            list_webhooks,
+        )
+
+        created = create_webhook(
+            "test-strat-1",
+            WebhookCreateRequest(url="https://a.com/hook", events=["status_changed"]),
+        )
+        assert delete_webhook("test-strat-1", created.id) is True
+        assert list_webhooks("test-strat-1").total_count == 0
+
+    def test_delete_webhook_not_found(self, patch_session, strategy_row):
+        from api.services.strategy_webhook_service import delete_webhook
+
+        assert delete_webhook("test-strat-1", 999) is False
+
+    def test_webhook_without_secret(self, patch_session, strategy_row):
+        from api.services.strategy_webhook_service import create_webhook
+
+        req = WebhookCreateRequest(
+            url="https://a.com/hook",
+            events=["backtest_completed"],
+        )
+        result = create_webhook("test-strat-1", req)
+        assert result.has_secret is False
+
+
+class TestWebhookValidation:
+    """Tests for webhook schema validation."""
+
+    def test_invalid_url(self):
+        with pytest.raises(Exception):
+            WebhookCreateRequest(url="not-a-url", events=["status_changed"])
+
+    def test_invalid_event(self):
+        with pytest.raises(Exception):
+            WebhookCreateRequest(
+                url="https://a.com/hook", events=["nonexistent_event"]
+            )
+
+    def test_empty_events(self):
+        with pytest.raises(Exception):
+            WebhookCreateRequest(url="https://a.com/hook", events=[])
+
+
+class TestWebhookDispatcher:
+    """Tests for webhook event dispatching."""
+
+    def test_compute_signature(self):
+        from api.services.strategy_webhook_service import _compute_signature
+
+        payload = b'{"event":"test"}'
+        secret = "mysecret"
+        sig = _compute_signature(payload, secret)
+        expected = hmac.new(
+            secret.encode("utf-8"), payload, hashlib.sha256
+        ).hexdigest()
+        assert sig == expected
+
+    @patch("api.services.strategy_webhook_service._send_webhook")
+    def test_dispatch_event_calls_matching_webhooks(
+        self, mock_send, patch_session, strategy_row
+    ):
+        from api.services.strategy_webhook_service import (
+            create_webhook,
+            dispatch_event,
+        )
+
+        create_webhook(
+            "test-strat-1",
+            WebhookCreateRequest(
+                url="https://a.com/hook",
+                events=["status_changed"],
+                secret="sec1",
+            ),
+        )
+        create_webhook(
+            "test-strat-1",
+            WebhookCreateRequest(
+                url="https://b.com/hook",
+                events=["backtest_completed"],
+            ),
+        )
+
+        dispatch_event(
+            strategy_id="test-strat-1",
+            strategy_name="Test Strategy",
+            event="status_changed",
+            data={"old_status": "draft", "new_status": "backtested"},
+        )
+
+        # Wait for background thread
+        import time
+        time.sleep(0.5)
+
+        # Only the first webhook matches status_changed
+        assert mock_send.call_count == 1
+        call_args = mock_send.call_args
+        assert call_args[0][0] == "https://a.com/hook"
+        payload = call_args[0][1]
+        assert payload["event"] == "status_changed"
+        assert payload["strategy_id"] == "test-strat-1"
+        assert call_args[0][2] == "sec1"
+
+    @patch("api.services.strategy_webhook_service._send_webhook")
+    def test_dispatch_skips_inactive_webhooks(
+        self, mock_send, patch_session, strategy_row
+    ):
+        from api.services.strategy_webhook_service import (
+            create_webhook,
+            dispatch_event,
+            update_webhook,
+        )
+
+        created = create_webhook(
+            "test-strat-1",
+            WebhookCreateRequest(
+                url="https://a.com/hook",
+                events=["status_changed"],
+            ),
+        )
+        update_webhook(
+            "test-strat-1",
+            created.id,
+            WebhookUpdateRequest(active=False),
+        )
+
+        dispatch_event(
+            strategy_id="test-strat-1",
+            strategy_name="Test Strategy",
+            event="status_changed",
+        )
+
+        import time
+        time.sleep(0.5)
+        mock_send.assert_not_called()
+
+    @patch("api.services.strategy_webhook_service._send_webhook")
+    def test_dispatch_no_matching_event(
+        self, mock_send, patch_session, strategy_row
+    ):
+        from api.services.strategy_webhook_service import (
+            create_webhook,
+            dispatch_event,
+        )
+
+        create_webhook(
+            "test-strat-1",
+            WebhookCreateRequest(
+                url="https://a.com/hook",
+                events=["backtest_completed"],
+            ),
+        )
+
+        dispatch_event(
+            strategy_id="test-strat-1",
+            strategy_name="Test Strategy",
+            event="status_changed",
+        )
+
+        import time
+        time.sleep(0.5)
+        mock_send.assert_not_called()


### PR DESCRIPTION
## Summary
- Add outbound webhook system for strategy lifecycle events
- CRUD endpoints: GET/POST/PUT/DELETE `/api/strategy/saved/{id}/webhooks`
- Supported events: `status_changed`, `backtest_completed`, `validation_passed`, `validation_failed`
- Async HTTP POST dispatch with HMAC-SHA256 signature header (`X-Webhook-Signature`)
- 3x exponential backoff retry on failure
- URL and event type validation in Pydantic schemas

## Test plan
- [x] 17 pytest tests covering CRUD operations, schema validation, and dispatch logic
- [x] Tests verify signature computation, event filtering, inactive webhook skipping

Closes #1258

🤖 Generated with [Claude Code](https://claude.com/claude-code)