### PR TITLE
feat(api): strategy live signal alert configuration and history

### DIFF
--- a/api/database.py
+++ b/api/database.py
@@ -56,6 +56,7 @@ def init_db() -> None:
     import api.models.screening_result  # noqa: F401 — register model with Base
     import api.models.strategy  # noqa: F401 — register model with Base
     import api.models.strategy_backtest_result  # noqa: F401 — register model with Base
+    import api.models.strategy_alert  # noqa: F401 — register model with Base
     import api.models.strategy_webhook  # noqa: F401 — register model with Base
     import api.models.watchlist  # noqa: F401 — register model with Base
 

--- a/api/models/strategy_alert.py
+++ b/api/models/strategy_alert.py
@@ -1,0 +1,38 @@
+"""
+SQLAlchemy models for strategy alerts.
+"""
+
+from datetime import datetime
+
+from sqlalchemy import Boolean, Column, DateTime, Float, ForeignKey, Integer, JSON, String, Text
+from sqlalchemy.dialects.postgresql import JSONB
+
+from api.database import Base
+
+
+class StrategyAlertConfig(Base):
+    """Configuration for live signal alerts on a strategy."""
+
+    __tablename__ = "strategy_alert_configs"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    strategy_id = Column(String(32), ForeignKey("strategies.id", ondelete="CASCADE"), nullable=False, unique=True, index=True)
+    enabled = Column(Boolean, nullable=False, default=False)
+    interval_minutes = Column(Integer, nullable=False, default=60)
+    channels = Column(JSON().with_variant(JSONB, "postgresql"), nullable=False, default=list)
+    tickers = Column(JSON().with_variant(JSONB, "postgresql"), nullable=False, default=list)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+
+class StrategyAlertHistory(Base):
+    """Record of a fired strategy alert."""
+
+    __tablename__ = "strategy_alert_history"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    strategy_id = Column(String(32), ForeignKey("strategies.id", ondelete="CASCADE"), nullable=False, index=True)
+    ticker = Column(String(16), nullable=False)
+    matched_conditions = Column(JSON().with_variant(JSONB, "postgresql"), nullable=False, default=list)
+    price_at_signal = Column(Float, nullable=True)
+    fired_at = Column(DateTime, default=datetime.utcnow, index=True)

--- a/api/routers/strategy.py
+++ b/api/routers/strategy.py
@@ -41,6 +41,11 @@ from api.schemas.strategy_webhook import (
     WebhookResponse,
     WebhookUpdateRequest,
 )
+from api.schemas.strategy_alert import (
+    AlertConfigResponse,
+    AlertConfigUpsertRequest,
+    AlertHistoryResponse,
+)
 from api.schemas.strategy import (
     ConditionsListResponse,
     SavedStrategiesListResponse,
@@ -435,6 +440,66 @@ async def delete_webhook(strategy_id: str, webhook_id: int) -> None:
     from api.services.strategy_webhook_service import delete_webhook as _delete
     if not _delete(strategy_id, webhook_id):
         raise HTTPException(status_code=404, detail="Webhook not found")
+
+
+# ---------------------------------------------------------------------------
+# Alert Configuration & History
+# ---------------------------------------------------------------------------
+
+@router.get(
+    "/saved/{strategy_id}/alerts/config",
+    response_model=AlertConfigResponse,
+    summary="Get alert configuration",
+)
+async def get_alert_config(strategy_id: str) -> AlertConfigResponse:
+    """Get live signal alert configuration for a strategy."""
+    from api.services.strategy_alert_service import get_alert_config as _get
+    result = _get(strategy_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Alert config not found")
+    return result
+
+
+@router.put(
+    "/saved/{strategy_id}/alerts/config",
+    response_model=AlertConfigResponse,
+    summary="Create or update alert configuration",
+)
+async def upsert_alert_config(
+    strategy_id: str, data: AlertConfigUpsertRequest
+) -> AlertConfigResponse:
+    """Create or update live signal alert configuration."""
+    from api.services.strategy_alert_service import upsert_alert_config as _upsert
+    try:
+        return _upsert(strategy_id, data)
+    except Exception as e:
+        logger.error(f"Failed to upsert alert config: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to update alert config.")
+
+
+@router.delete(
+    "/saved/{strategy_id}/alerts/config",
+    status_code=204,
+    summary="Delete alert configuration",
+)
+async def delete_alert_config(strategy_id: str) -> None:
+    """Delete alert configuration for a strategy."""
+    from api.services.strategy_alert_service import delete_alert_config as _delete
+    if not _delete(strategy_id):
+        raise HTTPException(status_code=404, detail="Alert config not found")
+
+
+@router.get(
+    "/saved/{strategy_id}/alerts/history",
+    response_model=AlertHistoryResponse,
+    summary="Get alert history",
+)
+async def get_alert_history(
+    strategy_id: str, limit: int = 50
+) -> AlertHistoryResponse:
+    """Get fired alert history for a strategy."""
+    from api.services.strategy_alert_service import get_alert_history as _history
+    return _history(strategy_id, limit=limit)
 
 
 @router.get(

--- a/api/schemas/strategy_alert.py
+++ b/api/schemas/strategy_alert.py
@@ -1,0 +1,70 @@
+"""
+Strategy Alert Schemas.
+
+Pydantic models for alert configuration and alert history.
+"""
+
+from typing import List, Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+VALID_CHANNELS = {"webhook", "in_app"}
+
+
+class AlertConfigUpsertRequest(BaseModel):
+    """Request to create or update alert configuration."""
+
+    enabled: bool = Field(default=True)
+    interval_minutes: int = Field(default=60, ge=5, le=1440)
+    channels: List[str] = Field(default_factory=lambda: ["in_app"])
+    tickers: List[str] = Field(
+        ...,
+        min_length=1,
+        max_length=20,
+        description="Tickers to monitor (1-20)",
+    )
+
+    @field_validator("channels")
+    @classmethod
+    def validate_channels(cls, v: List[str]) -> List[str]:
+        invalid = set(v) - VALID_CHANNELS
+        if invalid:
+            raise ValueError(f"Invalid channels: {invalid}. Valid: {VALID_CHANNELS}")
+        return v
+
+    @field_validator("tickers")
+    @classmethod
+    def validate_tickers(cls, v: List[str]) -> List[str]:
+        return [t.upper().strip() for t in v if t.strip()]
+
+
+class AlertConfigResponse(BaseModel):
+    """Response for alert configuration."""
+
+    id: int
+    strategy_id: str
+    enabled: bool
+    interval_minutes: int
+    channels: List[str]
+    tickers: List[str]
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+
+
+class AlertHistoryEntry(BaseModel):
+    """A single fired alert record."""
+
+    id: int
+    strategy_id: str
+    ticker: str
+    matched_conditions: List[str]
+    price_at_signal: Optional[float] = None
+    fired_at: Optional[str] = None
+
+
+class AlertHistoryResponse(BaseModel):
+    """Response listing alert history."""
+
+    strategy_id: str
+    alerts: List[AlertHistoryEntry]
+    total_count: int

--- a/api/services/strategy_alert_service.py
+++ b/api/services/strategy_alert_service.py
@@ -1,0 +1,157 @@
+"""
+Strategy Alert Service.
+
+Manages alert configurations and alert history for live signal monitoring.
+"""
+
+import logging
+from typing import Optional
+
+from api.database import SessionLocal
+from api.models.strategy_alert import StrategyAlertConfig, StrategyAlertHistory
+from api.schemas.strategy_alert import (
+    AlertConfigResponse,
+    AlertConfigUpsertRequest,
+    AlertHistoryEntry,
+    AlertHistoryResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _config_to_response(cfg: StrategyAlertConfig) -> AlertConfigResponse:
+    return AlertConfigResponse(
+        id=cfg.id,
+        strategy_id=cfg.strategy_id,
+        enabled=cfg.enabled,
+        interval_minutes=cfg.interval_minutes,
+        channels=cfg.channels or [],
+        tickers=cfg.tickers or [],
+        created_at=cfg.created_at.isoformat() if cfg.created_at else None,
+        updated_at=cfg.updated_at.isoformat() if cfg.updated_at else None,
+    )
+
+
+def _history_to_entry(h: StrategyAlertHistory) -> AlertHistoryEntry:
+    return AlertHistoryEntry(
+        id=h.id,
+        strategy_id=h.strategy_id,
+        ticker=h.ticker,
+        matched_conditions=h.matched_conditions or [],
+        price_at_signal=h.price_at_signal,
+        fired_at=h.fired_at.isoformat() if h.fired_at else None,
+    )
+
+
+def get_alert_config(strategy_id: str) -> Optional[AlertConfigResponse]:
+    """Get alert configuration for a strategy."""
+    db = SessionLocal()
+    try:
+        cfg = (
+            db.query(StrategyAlertConfig)
+            .filter(StrategyAlertConfig.strategy_id == strategy_id)
+            .first()
+        )
+        return _config_to_response(cfg) if cfg else None
+    finally:
+        db.close()
+
+
+def upsert_alert_config(
+    strategy_id: str, data: AlertConfigUpsertRequest
+) -> AlertConfigResponse:
+    """Create or update alert configuration for a strategy."""
+    db = SessionLocal()
+    try:
+        cfg = (
+            db.query(StrategyAlertConfig)
+            .filter(StrategyAlertConfig.strategy_id == strategy_id)
+            .first()
+        )
+        if cfg:
+            cfg.enabled = data.enabled
+            cfg.interval_minutes = data.interval_minutes
+            cfg.channels = data.channels
+            cfg.tickers = data.tickers
+        else:
+            cfg = StrategyAlertConfig(
+                strategy_id=strategy_id,
+                enabled=data.enabled,
+                interval_minutes=data.interval_minutes,
+                channels=data.channels,
+                tickers=data.tickers,
+            )
+            db.add(cfg)
+        db.commit()
+        db.refresh(cfg)
+        return _config_to_response(cfg)
+    finally:
+        db.close()
+
+
+def delete_alert_config(strategy_id: str) -> bool:
+    """Delete alert configuration. Returns True if deleted."""
+    db = SessionLocal()
+    try:
+        cfg = (
+            db.query(StrategyAlertConfig)
+            .filter(StrategyAlertConfig.strategy_id == strategy_id)
+            .first()
+        )
+        if not cfg:
+            return False
+        db.delete(cfg)
+        db.commit()
+        return True
+    finally:
+        db.close()
+
+
+def get_alert_history(
+    strategy_id: str, limit: int = 50
+) -> AlertHistoryResponse:
+    """Get alert history for a strategy."""
+    db = SessionLocal()
+    try:
+        total = (
+            db.query(StrategyAlertHistory)
+            .filter(StrategyAlertHistory.strategy_id == strategy_id)
+            .count()
+        )
+        alerts = (
+            db.query(StrategyAlertHistory)
+            .filter(StrategyAlertHistory.strategy_id == strategy_id)
+            .order_by(StrategyAlertHistory.fired_at.desc())
+            .limit(limit)
+            .all()
+        )
+        return AlertHistoryResponse(
+            strategy_id=strategy_id,
+            alerts=[_history_to_entry(a) for a in alerts],
+            total_count=total,
+        )
+    finally:
+        db.close()
+
+
+def record_alert(
+    strategy_id: str,
+    ticker: str,
+    matched_conditions: list,
+    price_at_signal: Optional[float] = None,
+) -> AlertHistoryEntry:
+    """Record a fired alert in history."""
+    db = SessionLocal()
+    try:
+        entry = StrategyAlertHistory(
+            strategy_id=strategy_id,
+            ticker=ticker,
+            matched_conditions=matched_conditions,
+            price_at_signal=price_at_signal,
+        )
+        db.add(entry)
+        db.commit()
+        db.refresh(entry)
+        return _history_to_entry(entry)
+    finally:
+        db.close()

--- a/tests/test_strategy_alerts.py
+++ b/tests/test_strategy_alerts.py
@@ -1,0 +1,210 @@
+"""Tests for strategy alert service."""
+
+from unittest.mock import patch
+
+import pytest
+
+from api.schemas.strategy_alert import AlertConfigUpsertRequest
+
+
+@pytest.fixture
+def db_session():
+    """Create an in-memory SQLite database for testing."""
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+    from api.database import Base
+    import api.models.strategy  # noqa: F401
+    import api.models.strategy_alert  # noqa: F401
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    yield session
+    session.close()
+
+
+@pytest.fixture
+def patch_session(db_session):
+    """Patch SessionLocal in the alert service module."""
+    with patch(
+        "api.services.strategy_alert_service.SessionLocal",
+        return_value=db_session,
+    ):
+        yield db_session
+
+
+@pytest.fixture
+def strategy_row(db_session):
+    """Insert a test strategy into the DB."""
+    from api.models.strategy import Strategy
+
+    s = Strategy(id="test-strat-1", name="Test Strategy", graph={"nodes": [], "edges": []})
+    db_session.add(s)
+    db_session.commit()
+    return s
+
+
+class TestAlertConfigCRUD:
+    """Tests for alert configuration CRUD."""
+
+    def test_upsert_creates_config(self, patch_session, strategy_row):
+        from api.services.strategy_alert_service import upsert_alert_config
+
+        req = AlertConfigUpsertRequest(
+            enabled=True,
+            interval_minutes=30,
+            channels=["webhook"],
+            tickers=["AAPL", "MSFT"],
+        )
+        result = upsert_alert_config("test-strat-1", req)
+        assert result.strategy_id == "test-strat-1"
+        assert result.enabled is True
+        assert result.interval_minutes == 30
+        assert result.channels == ["webhook"]
+        assert result.tickers == ["AAPL", "MSFT"]
+
+    def test_upsert_updates_existing(self, patch_session, strategy_row):
+        from api.services.strategy_alert_service import upsert_alert_config
+
+        upsert_alert_config(
+            "test-strat-1",
+            AlertConfigUpsertRequest(tickers=["AAPL"]),
+        )
+        updated = upsert_alert_config(
+            "test-strat-1",
+            AlertConfigUpsertRequest(
+                enabled=False,
+                interval_minutes=120,
+                tickers=["TSLA", "GOOG"],
+            ),
+        )
+        assert updated.enabled is False
+        assert updated.interval_minutes == 120
+        assert updated.tickers == ["TSLA", "GOOG"]
+
+    def test_get_config(self, patch_session, strategy_row):
+        from api.services.strategy_alert_service import (
+            get_alert_config,
+            upsert_alert_config,
+        )
+
+        upsert_alert_config(
+            "test-strat-1",
+            AlertConfigUpsertRequest(tickers=["AAPL"]),
+        )
+        result = get_alert_config("test-strat-1")
+        assert result is not None
+        assert result.tickers == ["AAPL"]
+
+    def test_get_config_not_found(self, patch_session, strategy_row):
+        from api.services.strategy_alert_service import get_alert_config
+
+        result = get_alert_config("test-strat-1")
+        assert result is None
+
+    def test_delete_config(self, patch_session, strategy_row):
+        from api.services.strategy_alert_service import (
+            delete_alert_config,
+            get_alert_config,
+            upsert_alert_config,
+        )
+
+        upsert_alert_config(
+            "test-strat-1",
+            AlertConfigUpsertRequest(tickers=["AAPL"]),
+        )
+        assert delete_alert_config("test-strat-1") is True
+        assert get_alert_config("test-strat-1") is None
+
+    def test_delete_config_not_found(self, patch_session, strategy_row):
+        from api.services.strategy_alert_service import delete_alert_config
+
+        assert delete_alert_config("test-strat-1") is False
+
+
+class TestAlertHistory:
+    """Tests for alert history recording and retrieval."""
+
+    def test_record_and_retrieve_alert(self, patch_session, strategy_row):
+        from api.services.strategy_alert_service import (
+            get_alert_history,
+            record_alert,
+        )
+
+        record_alert(
+            strategy_id="test-strat-1",
+            ticker="AAPL",
+            matched_conditions=["rsi_oversold", "ma_cross_up"],
+            price_at_signal=150.25,
+        )
+        history = get_alert_history("test-strat-1")
+        assert history.total_count == 1
+        assert len(history.alerts) == 1
+        alert = history.alerts[0]
+        assert alert.ticker == "AAPL"
+        assert alert.matched_conditions == ["rsi_oversold", "ma_cross_up"]
+        assert alert.price_at_signal == 150.25
+
+    def test_history_ordered_by_fired_at_desc(self, patch_session, strategy_row):
+        from api.services.strategy_alert_service import (
+            get_alert_history,
+            record_alert,
+        )
+
+        record_alert("test-strat-1", "AAPL", ["rsi_oversold"])
+        record_alert("test-strat-1", "MSFT", ["ma_cross_up"])
+        record_alert("test-strat-1", "GOOG", ["macd_cross_up"])
+
+        history = get_alert_history("test-strat-1")
+        assert history.total_count == 3
+        # Most recent first
+        assert history.alerts[0].ticker == "GOOG"
+
+    def test_history_limit(self, patch_session, strategy_row):
+        from api.services.strategy_alert_service import (
+            get_alert_history,
+            record_alert,
+        )
+
+        for i in range(5):
+            record_alert("test-strat-1", f"TICK{i}", ["cond"])
+
+        history = get_alert_history("test-strat-1", limit=3)
+        assert len(history.alerts) == 3
+        assert history.total_count == 5
+
+    def test_empty_history(self, patch_session, strategy_row):
+        from api.services.strategy_alert_service import get_alert_history
+
+        history = get_alert_history("test-strat-1")
+        assert history.total_count == 0
+        assert history.alerts == []
+
+
+class TestAlertValidation:
+    """Tests for alert schema validation."""
+
+    def test_invalid_channel(self):
+        with pytest.raises(Exception):
+            AlertConfigUpsertRequest(
+                channels=["invalid_channel"],
+                tickers=["AAPL"],
+            )
+
+    def test_empty_tickers(self):
+        with pytest.raises(Exception):
+            AlertConfigUpsertRequest(
+                tickers=[],
+            )
+
+    def test_interval_too_low(self):
+        with pytest.raises(Exception):
+            AlertConfigUpsertRequest(
+                interval_minutes=1,
+                tickers=["AAPL"],
+            )
+
+    def test_ticker_normalization(self):
+        req = AlertConfigUpsertRequest(tickers=["  aapl  ", "msft"])
+        assert req.tickers == ["AAPL", "MSFT"]


### PR DESCRIPTION
## Summary
- Add per-strategy alert configuration (enabled, interval, channels, tickers)
- Alert history model for recording fired signals with ticker, conditions, price
- CRUD endpoints: GET/PUT/DELETE `/api/strategy/saved/{id}/alerts/config`
- History endpoint: GET `/api/strategy/saved/{id}/alerts/history`
- `record_alert()` service function for future signal scanner integration
- Validation: channel allowlist (webhook, in_app), interval bounds (5-1440 min), ticker normalization

## Test plan
- [x] 14 pytest tests covering config CRUD, upsert idempotency, history ordering, validation

Closes #1259

🤖 Generated with [Claude Code](https://claude.com/claude-code)