### PR TITLE
fix(strategy): logic group child conditions reflect upstream filtering

### DIFF
--- a/api/services/strategy_service.py
+++ b/api/services/strategy_service.py
@@ -1005,6 +1005,7 @@ def _compute_node_survivors(
     node_meta: Dict[str, dict],
     child_ids_set: set,
     cache: Dict[str, set],
+    child_to_parent: Optional[Dict[str, str]] = None,
 ) -> set:
     """Compute the set of result indices that survive up to this node.
 
@@ -1043,11 +1044,23 @@ def _compute_node_survivors(
                     own_passers.add(i)
         # Intersect with upstream survivors (pipeline filtering)
         upstream_ids = incoming.get(node_id, [])
+        # If this condition is a child of a logic group and has no direct
+        # upstream edges, inherit the parent group's upstream so that
+        # intermediate counts reflect cumulative pipeline filtering.
+        if not upstream_ids and child_to_parent and node_id in child_to_parent:
+            parent_id = child_to_parent[node_id]
+            parent = nodes_by_id.get(parent_id)
+            if parent and parent.data.child_node_ids:
+                upstream_ids = [
+                    uid
+                    for uid in incoming.get(parent_id, [])
+                    if uid not in set(parent.data.child_node_ids)
+                ]
         if upstream_ids:
             upstream = set.intersection(*(
                 _compute_node_survivors(
                     uid, all_results, nodes_by_id, incoming,
-                    node_meta, child_ids_set, cache,
+                    node_meta, child_ids_set, cache, child_to_parent,
                 )
                 for uid in upstream_ids
             ))
@@ -1065,7 +1078,7 @@ def _compute_node_survivors(
         child_sets = [
             _compute_node_survivors(
                 sid, all_results, nodes_by_id, incoming,
-                node_meta, child_ids_set, cache,
+                node_meta, child_ids_set, cache, child_to_parent,
             )
             for sid in source_ids
             if nodes_by_id.get(sid) and nodes_by_id[sid].data.node_type != "universe"
@@ -1090,7 +1103,7 @@ def _compute_node_survivors(
                 upstream = set.intersection(*(
                     _compute_node_survivors(
                         uid, all_results, nodes_by_id, incoming,
-                        node_meta, child_ids_set, cache,
+                        node_meta, child_ids_set, cache, child_to_parent,
                     )
                     for uid in upstream_ids
                 ))
@@ -1108,7 +1121,7 @@ def _compute_node_survivors(
                 child_sets.append(
                     _compute_node_survivors(
                         sid, all_results, nodes_by_id, incoming,
-                        node_meta, child_ids_set, cache,
+                        node_meta, child_ids_set, cache, child_to_parent,
                     )
                 )
         # Top-level nodes not connected via edges
@@ -1121,7 +1134,7 @@ def _compute_node_survivors(
                 child_sets.append(
                     _compute_node_survivors(
                         n.id, all_results, nodes_by_id, incoming,
-                        node_meta, child_ids_set, cache,
+                        node_meta, child_ids_set, cache, child_to_parent,
                     )
                 )
         if not child_sets:
@@ -1300,9 +1313,12 @@ def execute_strategy(
         if edge.target in incoming:
             incoming[edge.target].append(edge.source)
     child_ids_set: set[str] = set()
+    child_to_parent: Dict[str, str] = {}
     for n in graph.nodes:
         if n.data.child_node_ids:
             child_ids_set.update(n.data.child_node_ids)
+            for cid in n.data.child_node_ids:
+                child_to_parent[cid] = n.id
 
     # Compute per-node survivors using graph-aware cumulative filtering
     survivor_cache: Dict[str, set] = {}
@@ -1315,7 +1331,7 @@ def execute_strategy(
 
         survivor_indices = _compute_node_survivors(
             node_id, all_results, nodes_by_id, incoming,
-            node_meta, child_ids_set, survivor_cache,
+            node_meta, child_ids_set, survivor_cache, child_to_parent,
         )
         passing_stocks: List[StrategyResultItem] = []
         for i in sorted(survivor_indices):


### PR DESCRIPTION
## Summary
- OR/AND 그룹 내 개별 조건 노드(PER, PBR, E/P 등)의 중간 결과 카운트가 전체 모집단 기준으로 표시되던 버그 수정
- `_compute_node_survivors()`에서 그룹 자식 조건이 부모의 upstream을 상속받도록 `child_to_parent` 맵 추가
- 예: Input(837) → MA Touch(89) → OR(PER, PBR, E/P) 에서 PER이 211이 아닌 89 이하의 올바른 카운트 표시

## Root Cause
- 그래프 엣지는 `MA Touch → OR Group`으로만 연결되고, `MA Touch → PER` 직접 엣지는 없음
- `incoming.get(node_id, [])`가 그룹 자식에 대해 빈 리스트를 반환하여 upstream 교집합이 생략됨

## Changes
- `child_to_parent` 딕셔너리를 프리컴퓨팅하여 O(1) 부모 조회
- 그룹 자식 조건이 직접 incoming 엣지가 없을 때 부모의 upstream을 상속
- 모든 재귀 호출에 `child_to_parent` 전달

## Test plan
- [ ] 백엔드 서버 재시작 후 전략 빌더에서 OR/AND 그룹 포함 파이프라인 실행
- [ ] 그룹 내 개별 조건의 중간 카운트가 상위 필터 결과 이하인지 확인
- [ ] 그룹 없는 단일 조건 파이프라인이 기존과 동일하게 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)