### PR TITLE
fix: prevent SSR bailout on dashboard caused by AgentationProvider

### DIFF
--- a/web/src/components/dev/AgentationProvider.tsx
+++ b/web/src/components/dev/AgentationProvider.tsx
@@ -1,13 +1,28 @@
 'use client';
 
-import dynamic from 'next/dynamic';
-
-const AgentationLazy = dynamic(
-  () => import('agentation').then((m) => ({ default: m.Agentation })),
-  { ssr: false },
-);
+import { lazy, Suspense, useState, useEffect } from 'react';
 
 export default function AgentationProvider() {
   if (process.env.NODE_ENV !== 'development') return null;
-  return <AgentationLazy />;
+  return <AgentationLoader />;
+}
+
+function AgentationLoader() {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) return null;
+
+  const AgentationLazy = lazy(() =>
+    import('agentation').then((m) => ({ default: m.Agentation }))
+  );
+
+  return (
+    <Suspense fallback={null}>
+      <AgentationLazy />
+    </Suspense>
+  );
 }


### PR DESCRIPTION
## Summary
- Replace module-level `next/dynamic` with `React.lazy` + `useEffect` mount guard in `AgentationProvider`
- The module-level dynamic import was evaluated during SSR, causing `BAILOUT_TO_CLIENT_SIDE_RENDERING` on all locale pages

## Test plan
- [x] `cd web && npm run build` — builds successfully
- [ ] Manual: View source of /ko — no `BAILOUT_TO_CLIENT_SIDE_RENDERING` marker
- [ ] Manual: AgentationProvider still works in dev mode

Closes #1279

🤖 Generated with [Claude Code](https://claude.com/claude-code)