### PR TITLE
fix: node popup closes when clicking toggle buttons

### DIFF
--- a/web/src/components/strategy/nodes/NodeEditPopup.tsx
+++ b/web/src/components/strategy/nodes/NodeEditPopup.tsx
@@ -454,9 +454,11 @@ export default function NodeEditPopup({
       offset={12}
       align="center"
     >
+      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
       <div
-        className="nodrag nowheel w-[360px] rounded-xl border border-[#e1e3e5] dark:border-[#2e2e30] bg-white dark:bg-[#0b0b0c] shadow-xl"
+        className="nodrag nowheel nopan w-[360px] rounded-xl border border-[#e1e3e5] dark:border-[#2e2e30] bg-white dark:bg-[#0b0b0c] shadow-xl"
         style={{ transform: `scale(${popupScale})`, transformOrigin: 'top center' }}
+        onClick={(e) => e.stopPropagation()}
       >
         <div className="p-4 space-y-4 max-h-[480px] overflow-y-auto">
           {children}


### PR DESCRIPTION
## Summary
- Add `onClick stopPropagation` to `NodeEditPopup` container div
- Add `nopan` class to prevent ReactFlow pan interactions
- Clicking "Quick Insight" or "Indicator Disclosure" toggles no longer closes the popup

## Root Cause
Clicks inside the popup bubbled up to ReactFlow's `onPaneClick` handler, which calls `setSelectedNodeId(null)` and deselects the node (closing the popup).

## Note on code block insertion (part B of #1232)
Investigation shows code block node insertion in plain markdown messages was never fully implemented — it only works through structured suggestion payloads in `SectionedMessage`. This would require a separate feature implementation, not a bug fix.

## Test plan
- [x] `cd web && npm run build` — builds successfully
- [ ] Manual: Open strategy → click condition node → click "Quick Insight" → popup stays open
- [ ] Manual: Click "Indicator Disclosure" → popup stays open
- [ ] Manual: Click outside popup → popup closes (deselect still works)

Closes #1232

🤖 Generated with [Claude Code](https://claude.com/claude-code)