### PR TITLE
fix(macro): data sufficiency gating and insufficient data banner

### DIFF
--- a/api/routers/market.py
+++ b/api/routers/market.py
@@ -295,19 +295,30 @@ def _compute_data_quality(bundle: dict, is_kr: bool) -> MacroDataQuality:
         return "stale"  # has data but no timestamp → conservative
 
     if is_kr:
+        fx_q = _series_quality("fx")
+        futures_q = _series_quality("futures")
+        flow_q = _series_quality("flow")
+        vol_q = _vol_quality()
+        # Insufficient when 2+ core sources (fx/futures/flow) are missing or stale
+        bad_count = sum(1 for q in (fx_q, futures_q, flow_q) if q in ("missing", "stale"))
+        overall = "insufficient" if bad_count >= 2 else "sufficient"
         return MacroDataQuality(
-            fx=_series_quality("fx"),
-            futures=_series_quality("futures"),
-            flow=_series_quality("flow"),
-            volatility=_vol_quality(),
+            fx=fx_q,
+            futures=futures_q,
+            flow=flow_q,
+            volatility=vol_q,
+            overall=overall,
         )
     else:
-        # US mode: fx/futures/flow are not used
+        # US mode: fx/futures/flow are not used; US scoring uses VIX/bonds/S&P500
+        # which have separate display logic. Overall is always "sufficient" here
+        # because the KR-specific gating (2/3 core sources) doesn't apply.
         return MacroDataQuality(
             fx=None,
             futures=None,
             flow=None,
             volatility=_vol_quality(),
+            overall="sufficient",
         )
 
 

--- a/api/schemas/market.py
+++ b/api/schemas/market.py
@@ -267,6 +267,9 @@ class MacroDataQuality(BaseModel):
     futures: Optional[Literal["ok", "stale", "missing"]] = Field(None, description="Futures data quality")
     flow: Optional[Literal["ok", "stale", "missing"]] = Field(None, description="Investor flow data quality")
     volatility: Optional[Literal["ok", "stale", "missing"]] = Field(None, description="Volatility data quality")
+    overall: Optional[Literal["sufficient", "insufficient"]] = Field(
+        None, description="Overall data sufficiency: insufficient when 2+ core sources (fx/futures/flow) are missing or stale"
+    )
 
 
 class MacroBundleResponse(BaseModel):

--- a/tests/test_macro_data_quality.py
+++ b/tests/test_macro_data_quality.py
@@ -1,0 +1,96 @@
+"""Tests for _compute_data_quality overall field in api/routers/market.py."""
+
+from __future__ import annotations
+
+import pytest
+
+from api.routers.market import _compute_data_quality
+
+
+def _make_bundle(
+    fx_age: float | None = 100,
+    futures_age: float | None = 100,
+    flow_age: float | None = 100,
+    *,
+    fx_present: bool = True,
+    futures_present: bool = True,
+    flow_present: bool = True,
+) -> dict:
+    """Build a minimal bundle dict for _compute_data_quality."""
+    bundle: dict = {
+        "freshness": {
+            "fx_age_sec": fx_age,
+            "futures_age_sec": futures_age,
+            "flow_age_sec": flow_age,
+        },
+    }
+    if fx_present:
+        bundle["fx"] = {"value": 1350.0}
+    if futures_present:
+        bundle["futures"] = {"value": 350.0}
+    if flow_present:
+        bundle["flow"] = {"foreign_net": -100_000_000}
+    return bundle
+
+
+class TestDataQualityOverall:
+    """Test overall sufficiency gating logic."""
+
+    def test_all_ok(self):
+        """0 bad sources → sufficient."""
+        dq = _compute_data_quality(_make_bundle(), is_kr=True)
+        assert dq.overall == "sufficient"
+        assert dq.fx == "ok"
+        assert dq.futures == "ok"
+        assert dq.flow == "ok"
+
+    def test_one_stale(self):
+        """1 bad source → sufficient."""
+        dq = _compute_data_quality(
+            _make_bundle(fx_age=5000),  # stale (>1200s)
+            is_kr=True,
+        )
+        assert dq.overall == "sufficient"
+        assert dq.fx == "stale"
+
+    def test_two_stale(self):
+        """2 bad sources → insufficient."""
+        dq = _compute_data_quality(
+            _make_bundle(fx_age=5000, futures_age=5000),
+            is_kr=True,
+        )
+        assert dq.overall == "insufficient"
+
+    def test_two_missing(self):
+        """2 missing sources → insufficient."""
+        dq = _compute_data_quality(
+            _make_bundle(fx_present=False, flow_present=False),
+            is_kr=True,
+        )
+        assert dq.overall == "insufficient"
+        assert dq.fx == "missing"
+        assert dq.flow == "missing"
+
+    def test_mixed_stale_and_missing(self):
+        """1 stale + 1 missing = 2 bad → insufficient."""
+        dq = _compute_data_quality(
+            _make_bundle(fx_age=5000, futures_present=False),
+            is_kr=True,
+        )
+        assert dq.overall == "insufficient"
+
+    def test_all_missing(self):
+        """3 bad sources → insufficient."""
+        dq = _compute_data_quality(
+            _make_bundle(fx_present=False, futures_present=False, flow_present=False),
+            is_kr=True,
+        )
+        assert dq.overall == "insufficient"
+
+    def test_us_mode_always_sufficient(self):
+        """US mode always returns sufficient (KR gating doesn't apply)."""
+        dq = _compute_data_quality({}, is_kr=False)
+        assert dq.overall == "sufficient"
+        assert dq.fx is None
+        assert dq.futures is None
+        assert dq.flow is None

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -222,6 +222,7 @@
     "quality_ok": "Data is fresh",
     "quality_stale": "Data is stale",
     "quality_missing": "Data is missing",
+    "dataInsufficientBanner": "Insufficient data sources available. The macro score may not be reliable for investment decisions. Please check data collectors.",
     "confidence_high": "High confidence",
     "confidence_medium": "Medium confidence",
     "confidence_low": "Low confidence",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -222,6 +222,7 @@
     "quality_ok": "데이터 최신",
     "quality_stale": "데이터 지연",
     "quality_missing": "데이터 없음",
+    "dataInsufficientBanner": "데이터 소스가 충분하지 않습니다. 매크로 점수가 투자 판단에 신뢰할 수 없을 수 있습니다. 데이터 수집기를 확인해 주세요.",
     "confidence_high": "높은 신뢰도",
     "confidence_medium": "보통 신뢰도",
     "confidence_low": "낮은 신뢰도",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -222,6 +222,7 @@
     "quality_ok": "数据最新",
     "quality_stale": "数据延迟",
     "quality_missing": "数据缺失",
+    "dataInsufficientBanner": "可用数据源不足。宏观评分可能不可靠，请检查数据收集器。",
     "confidence_high": "高置信度",
     "confidence_medium": "中置信度",
     "confidence_low": "低置信度",

--- a/web/src/app/[locale]/macro/page.tsx
+++ b/web/src/app/[locale]/macro/page.tsx
@@ -469,6 +469,12 @@ export default function MacroPage() {
 
       {/* Gauge Hero — Regime + Entry Assessment unified (KR only) */}
       {marketMode === 'kr' && <div className="rounded-xl border border-[var(--border)] bg-gradient-to-b from-slate-900 to-slate-800 dark:from-slate-950 dark:to-slate-900 p-6 text-white">
+        {bundleQuery.data?.data_quality?.overall === 'insufficient' && (
+          <div className="mb-4 flex items-center gap-2 rounded-lg border border-amber-500/30 bg-amber-900/20 px-4 py-3 text-sm text-amber-300">
+            <AlertTriangle className="h-4 w-4 shrink-0" />
+            <span>{t('dataInsufficientBanner')}</span>
+          </div>
+        )}
         <div className="flex flex-col items-center gap-6 lg:flex-row lg:items-start lg:gap-10">
           {/* Gauge */}
           <div className="flex flex-col items-center">

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -465,6 +465,7 @@ export interface MacroDataQuality {
   futures: DataQualityLevel | null;
   flow: DataQualityLevel | null;
   volatility: DataQualityLevel | null;
+  overall: 'sufficient' | 'insufficient' | null;
 }
 
 export interface MacroBundle {


### PR DESCRIPTION
## Summary
- Add `overall` field (`"sufficient"` / `"insufficient"`) to `MacroDataQuality` schema
- Compute overall sufficiency in `_compute_data_quality()`: **insufficient** when 2+ of 3 core KR sources (FX, futures, flow) are missing or stale
- Show amber warning banner in the macro page gauge hero section when data is insufficient
- Add i18n keys (en/ko/zh) for the banner message
- Add 7 unit tests covering all edge cases (0/1/2/3 bad sources, mixed stale+missing, US mode)

## Test plan
- [x] `pytest tests/test_macro_data_quality.py` — 7/7 pass
- [x] `npm run build` — frontend builds clean
- [x] Backend tests: 2341 passed (2 pre-existing failures unrelated)
- [ ] Verify banner appears when 2+ sources are stale/missing on live macro page
- [ ] Verify banner does not appear when data is fresh

Closes #1270

🤖 Generated with [Claude Code](https://claude.com/claude-code)