### PR TITLE
fix: Pine Script export returns stub instead of 400 for unsupported conditions

### DIFF
--- a/api/services/pine_script_exporter.py
+++ b/api/services/pine_script_exporter.py
@@ -228,9 +228,18 @@ def export_pine_script(
             skipped.append(ct)
 
     if not conditions:
-        raise ValueError(
-            f"No exportable conditions found. Skipped: {skipped or 'none'}"
-        )
+        # Return a stub script with comments instead of raising an error,
+        # so the frontend can show a graceful warning.
+        stub_lines = [
+            "//@version=5",
+            f'strategy("{safe_name}", overlay=true)',
+            "",
+            "// No exportable conditions found.",
+        ]
+        if skipped:
+            stub_lines.append(f"// Skipped unsupported conditions: {', '.join(_sanitize_string(str(s)) for s in skipped)}")
+        stub_lines.append("")
+        return "\n".join(stub_lines)
 
     # Build script
     lines = [

--- a/tests/test_pine_script_exporter.py
+++ b/tests/test_pine_script_exporter.py
@@ -138,14 +138,20 @@ class TestExportPineScript:
         assert "loss=close * 0.02" in code
         assert "profit=" not in code
 
-    def test_no_exportable_conditions_raises(self):
+    def test_no_exportable_conditions_returns_stub(self):
         graph = _make_graph(("unknown_condition", {}))
-        with pytest.raises(ValueError, match="No exportable conditions"):
-            export_pine_script(graph)
+        code = export_pine_script(graph)
+        assert "//@version=5" in code
+        assert "No exportable conditions found" in code
+        assert "Skipped unsupported conditions: unknown_condition" in code
+        # Should NOT contain strategy.entry (no real conditions)
+        assert "strategy.entry" not in code
 
-    def test_empty_graph_raises(self):
-        with pytest.raises(ValueError, match="No exportable conditions"):
-            export_pine_script({"nodes": [], "edges": []})
+    def test_empty_graph_returns_stub(self):
+        code = export_pine_script({"nodes": [], "edges": []})
+        assert "//@version=5" in code
+        assert "No exportable conditions found" in code
+        assert "strategy.entry" not in code
 
     def test_skipped_conditions_in_comments(self):
         graph = _make_graph(

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1004,6 +1004,7 @@
     "pineExportSuccess": "Pine Script exported successfully",
     "pineExportSkipped": "Some conditions were skipped",
     "pineExportFailed": "Pine Script export failed",
+    "pineExportAllSkipped": "No conditions support Pine Script export. Try using MA, RSI, MACD, or Bollinger Band conditions.",
     "loadSelected": "Load",
     "deleteConfirm": "Delete this strategy?",
     "unsavedChanges": "You have unsaved changes",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -1004,6 +1004,7 @@
     "pineExportSuccess": "Pine Script 내보내기 완료",
     "pineExportSkipped": "일부 조건이 건너뛰어졌습니다",
     "pineExportFailed": "Pine Script 내보내기 실패",
+    "pineExportAllSkipped": "Pine Script으로 내보낼 수 있는 조건이 없습니다. MA, RSI, MACD, 볼린저 밴드 조건을 사용해 보세요.",
     "loadSelected": "불러오기",
     "deleteConfirm": "이 전략을 삭제할까요?",
     "unsavedChanges": "저장되지 않은 변경 사항이 있습니다",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -1004,6 +1004,7 @@
     "pineExportSuccess": "Pine Script 导出成功",
     "pineExportSkipped": "部分条件已跳过",
     "pineExportFailed": "Pine Script 导出失败",
+    "pineExportAllSkipped": "没有可导出为 Pine Script 的条件。请尝试使用 MA、RSI、MACD 或布林带条件。",
     "loadSelected": "加载",
     "deleteConfirm": "删除该策略？",
     "unsavedChanges": "您有未保存的更改",

--- a/web/src/app/[locale]/strategy/page.tsx
+++ b/web/src/app/[locale]/strategy/page.tsx
@@ -1179,6 +1179,7 @@ function StrategyPageInner() {
         graph,
         strategy_name: strategyName || 'QuantCanvas Strategy',
       });
+      const allSkipped = resp.conditions_used.length === 0;
       const blob = new Blob([resp.pine_script], { type: 'text/plain' });
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
@@ -1186,7 +1187,9 @@ function StrategyPageInner() {
       a.download = `${(strategyName || 'strategy').replace(/\s+/g, '_')}.pine`;
       a.click();
       URL.revokeObjectURL(url);
-      if (resp.conditions_skipped.length > 0) {
+      if (allSkipped) {
+        showToast(t('pineExportAllSkipped'), 'warning');
+      } else if (resp.conditions_skipped.length > 0) {
         showToast(`${t('pineExportSkipped')}: ${resp.conditions_skipped.join(', ')}`, 'warning');
       } else {
         showToast(t('pineExportSuccess'), 'success');


### PR DESCRIPTION
## Summary
- When all strategy conditions are unsupported for Pine Script export, the backend now returns a valid stub Pine Script with warning comments instead of raising `ValueError` (HTTP 400)
- Frontend downloads the stub file and shows a warning toast guiding users to use supported condition types (MA, RSI, MACD, Bollinger Bands)
- Updated 2 tests to match new behavior (stub return instead of ValueError)

## Changes
| File | Change |
|------|--------|
| `api/services/pine_script_exporter.py` | Return stub script instead of raising ValueError |
| `web/src/app/[locale]/strategy/page.tsx` | Download stub + show warning toast |
| `web/messages/{en,ko,zh}.json` | Added `pineExportAllSkipped` i18n key |
| `tests/test_pine_script_exporter.py` | Updated 2 tests for new behavior |

## Test plan
- [x] `pytest tests/test_pine_script_exporter.py` — 32 passed
- [x] `npm run build` — success
- [ ] Manual: create strategy with only unsupported conditions → export Pine Script → stub file downloaded + warning toast shown

Closes #1296

🤖 Generated with [Claude Code](https://claude.com/claude-code)