### PR TITLE
fix: prevent child node overlap inside GroupNode

### DIFF
--- a/web/src/app/[locale]/strategy/page.tsx
+++ b/web/src/app/[locale]/strategy/page.tsx
@@ -68,9 +68,17 @@ const GROUP_PADDING_TOP = 60;
 const GROUP_PADDING_BOTTOM = 28;
 const GROUP_PADDING_X = 24;
 const CHILD_SPACING = 16;
-const CHILD_HEIGHT = 80;
+const CHILD_HEIGHT_DEFAULT = 120;
 const GROUP_MIN_WIDTH = 380;
 const GROUP_MIN_HEIGHT = 220;
+
+/** Get the effective height of a child node inside a group, preferring measured height. */
+function getChildHeight(child: Node): number {
+  if (child.type === 'groupNode') {
+    return (child.style?.height as number) || GROUP_MIN_HEIGHT;
+  }
+  return (child.measured?.height as number) || CHILD_HEIGHT_DEFAULT;
+}
 
 type LayoutNodeData = {
   node_type: string;
@@ -723,10 +731,7 @@ function StrategyPageInner() {
           const relativePosition = {
             x: GROUP_PADDING_X,
             y: GROUP_PADDING_TOP + childrenInGroup.reduce((acc, child) => {
-              const h = child.type === 'groupNode'
-                ? ((child.style?.height as number) || GROUP_MIN_HEIGHT)
-                : CHILD_HEIGHT;
-              return acc + h + CHILD_SPACING;
+              return acc + getChildHeight(child) + CHILD_SPACING;
             }, 0),
           };
 
@@ -899,40 +904,64 @@ function StrategyPageInner() {
   useEffect(() => {
     setNodes((currentNodes) => {
       let changed = false;
+      // Collect child position/size fixes per group
+      const childFixes = new Map<string, { x: number; y: number }>();
+
       const updated = currentNodes.map((node) => {
         if (node.type !== 'groupNode') return node;
 
         const children = currentNodes.filter((n) => n.parentId === node.id);
         if (children.length === 0) return node;
 
-        const totalChildrenHeight = children.reduce((acc, child) => {
-          const h = child.type === 'groupNode'
-            ? ((child.style?.height as number) || GROUP_MIN_HEIGHT)
-            : CHILD_HEIGHT;
-          return acc + h + CHILD_SPACING;
-        }, 0);
+        // Calculate correct y-position for each child and total height
+        let yOffset = GROUP_PADDING_TOP;
+        for (const child of children) {
+          const expectedY = yOffset;
+          const expectedX = GROUP_PADDING_X;
+          if (
+            Math.abs((child.position?.y ?? 0) - expectedY) > 1 ||
+            Math.abs((child.position?.x ?? 0) - expectedX) > 1
+          ) {
+            childFixes.set(child.id, { x: expectedX, y: expectedY });
+          }
+          yOffset += getChildHeight(child) + CHILD_SPACING;
+        }
 
+        const totalChildrenHeight = yOffset - GROUP_PADDING_TOP;
         const newHeight = Math.max(
           GROUP_MIN_HEIGHT,
           GROUP_PADDING_TOP + totalChildrenHeight + GROUP_PADDING_BOTTOM
         );
-        const newWidth = Math.max(GROUP_MIN_WIDTH, GROUP_MIN_WIDTH);
         const curH = Number(node.style?.height || GROUP_MIN_HEIGHT);
         const curW = Number(node.style?.width || GROUP_MIN_WIDTH);
 
-        if (curH < newHeight || curW < newWidth) {
+        if (curH < newHeight || curW < GROUP_MIN_WIDTH) {
           changed = true;
           return {
             ...node,
             style: {
               ...node.style,
-              width: Math.max(curW, newWidth),
+              width: Math.max(curW, GROUP_MIN_WIDTH),
               height: Math.max(curH, newHeight),
             },
           };
         }
         return node;
       });
+
+      // Apply child position fixes
+      if (childFixes.size > 0) {
+        changed = true;
+        const final = updated.map((n) => {
+          const fix = childFixes.get(n.id);
+          if (fix) {
+            return { ...n, position: fix };
+          }
+          return n;
+        });
+        return final;
+      }
+
       return changed ? updated : currentNodes;
     });
   }, [childNodeCount, setNodes]);
@@ -1028,10 +1057,7 @@ function StrategyPageInner() {
                 // Calculate stacked position within group
                 const childrenInGroup = nds.filter((n) => n.parentId === group.id);
                 const relY = GROUP_PADDING_TOP + childrenInGroup.reduce((acc, child) => {
-                  const h = child.type === 'groupNode'
-                    ? ((child.style?.height as number) || GROUP_MIN_HEIGHT)
-                    : CHILD_HEIGHT;
-                  return acc + h + CHILD_SPACING;
+                  return acc + getChildHeight(child) + CHILD_SPACING;
                 }, 0);
 
                 // Update the node with parent relationship
@@ -1397,7 +1423,7 @@ function StrategyPageInner() {
               const childIndex = n.data.child_node_ids.indexOf(childId);
               childNode.position = {
                 x: GROUP_PADDING_X,
-                y: GROUP_PADDING_TOP + childIndex * (CHILD_HEIGHT + CHILD_SPACING),
+                y: GROUP_PADDING_TOP + childIndex * (CHILD_HEIGHT_DEFAULT + CHILD_SPACING),
               };
             }
           }

--- a/web/src/components/strategy/nodes/GroupNode.tsx
+++ b/web/src/components/strategy/nodes/GroupNode.tsx
@@ -96,7 +96,8 @@ function GroupNode({ id, data, selected }: NodeProps) {
 
   const dynamicMinHeight = useMemo(() => {
     if (childCount <= 1) return 220;
-    return 220 + (childCount - 1) * 120;
+    // Each child ~120px + 16px spacing, plus header (60px) and bottom padding (28px)
+    return 60 + childCount * 136 + 28;
   }, [childCount]);
 
   const handleOperatorChange = useCallback(


### PR DESCRIPTION
## Summary
- Child nodes inside AND/OR/NOT groups were overlapping because of hardcoded `CHILD_HEIGHT = 80px` which was smaller than actual rendered node height (~100-160px)
- Replaced with `getChildHeight()` that uses React Flow's `measured.height` with 120px fallback
- Auto-resize `useEffect` now also **repositions children** to correct stacking positions
- `GroupNode.tsx` `dynamicMinHeight` updated to match actual child sizes

## Changed files
- `web/src/app/[locale]/strategy/page.tsx` — `getChildHeight()` helper, child repositioning in useEffect, all 4 height calculation sites updated
- `web/src/components/strategy/nodes/GroupNode.tsx` — `dynamicMinHeight` formula updated

## Test plan
- [x] Drop 3 conditions inside OR group → no overlap, proper spacing
- [x] Group auto-resizes to fit all children
- [x] Horizontal auto-layout preserves correct child positions
- [x] No console errors
- [x] Frontend build passes

Closes #1302

🤖 Generated with [Claude Code](https://claude.com/claude-code)