### PR TITLE
fix strategy run response universes payload

### DIFF
--- a/api/routers/strategy.py
+++ b/api/routers/strategy.py
@@ -570,7 +570,8 @@ async def run_strategy(request: StrategyExecuteRequest) -> StrategyExecuteRespon
             ranking_config=request.ranking_config,
         )
         response_universes = result.get("universes") or request.universe_overrides or [result["universe"]]
-        return StrategyExecuteResponse(**result, universes=response_universes)
+        payload = {**result, "universes": response_universes}
+        return StrategyExecuteResponse(**payload)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:


### PR DESCRIPTION
## Summary
- fix the normal `/api/strategy/run` response path so it no longer passes `universes` twice into `StrategyExecuteResponse`
- keep the existing universe fallback logic by building a single payload before model construction
- isolate the change in a dedicated worktree branch so it does not mix with unrelated local edits

## Test plan
- [x] `python -m py_compile /Users/miyoungjang/Repository/quant/quant-investment/.claude/worktrees/strategy-run-universes-fix/api/routers/strategy.py`
- [x] review `git diff main...HEAD -- api/routers/strategy.py`
- [x] manually reproduce the original failure on the running local API before the fix: `api.schemas.strategy.StrategyExecuteResponse() got multiple values for keyword argument 'universes'`

## Consolidated PR note
- direction: keep the fix minimal and scoped to response assembly only
- review findings: duplicate keyword expansion in the normal `/api/strategy/run` route caused the 500 response
- fixes applied: construct a merged payload dict and pass it once into `StrategyExecuteResponse`
- final validation: syntax compile passed and the PR diff is limited to one router hunk

🤖 Generated with [Claude Code](https://claude.com/claude-code)