### PR TITLE
fix: telegram encryption key persistence and mismatch handling

### DIFF
--- a/api/routers/settings.py
+++ b/api/routers/settings.py
@@ -263,7 +263,14 @@ def test_telegram_notification() -> TelegramTestResponse:
             detail="Bot token is missing. Please save your bot token first.",
         )
 
-    ok = _settings_service.send_telegram_message(view.chat_id, encrypted_token)
+    try:
+        ok = _settings_service.send_telegram_message(view.chat_id, encrypted_token)
+    except RuntimeError:
+        # Decryption failure — encryption key changed since the token was saved.
+        return TelegramTestResponse(
+            success=False,
+            message="Encryption key mismatch. Please re-save your bot token.",
+        )
     if ok:
         return TelegramTestResponse(success=True, message="Test message sent successfully")
     return TelegramTestResponse(

--- a/api/services/broker_settings_service.py
+++ b/api/services/broker_settings_service.py
@@ -64,11 +64,14 @@ class BrokerSettingsService:
             raise RuntimeError("cryptography package is required for encrypted broker settings")
         key = os.environ.get(self.ENCRYPTION_KEY_ENV)
         if not key:
+            # Try loading from .env file before generating a new one.
+            key = self._load_env_key()
+        if not key:
             # Auto-generate a key and persist it in .env for convenience.
             key = Fernet.generate_key().decode("utf-8")
-            os.environ[self.ENCRYPTION_KEY_ENV] = key
             self._persist_env_key(key)
             logger.info("Auto-generated %s and saved to .env", self.ENCRYPTION_KEY_ENV)
+        os.environ[self.ENCRYPTION_KEY_ENV] = key
         try:
             key_bytes = key.encode("utf-8")
             # Validate key format early.
@@ -76,6 +79,24 @@ class BrokerSettingsService:
             return Fernet(key_bytes)
         except Exception as exc:
             raise RuntimeError(f"Invalid {self.ENCRYPTION_KEY_ENV} format") from exc
+
+    def _load_env_key(self) -> str | None:
+        """Try to read the encryption key from the project .env file."""
+        import pathlib
+
+        env_path = pathlib.Path(__file__).resolve().parents[2] / ".env"
+        try:
+            if not env_path.exists():
+                return None
+            for line in env_path.read_text().splitlines():
+                if line.startswith(f"{self.ENCRYPTION_KEY_ENV}="):
+                    val = line.split("=", 1)[1].strip()
+                    if val:
+                        logger.info("Loaded %s from %s", self.ENCRYPTION_KEY_ENV, env_path)
+                        return val
+        except OSError:
+            pass
+        return None
 
     def _persist_env_key(self, key: str) -> None:
         """Append the encryption key to the project .env file."""
@@ -394,8 +415,9 @@ class BrokerSettingsService:
         bool
             True on success, False on failure.
         """
+        # Let decryption errors propagate so callers can distinguish key mismatch.
+        token = self._decrypt(bot_token_encrypted)
         try:
-            token = self._decrypt(bot_token_encrypted)
             url = f"https://api.telegram.org/bot{token}/sendMessage"
             payload = json.dumps({"chat_id": chat_id, "text": message}).encode("utf-8")
             req = urllib.request.Request(


### PR DESCRIPTION
## Summary
- Load `BROKER_CONFIG_ENCRYPTION_KEY` from `.env` file before auto-generating a new one, preventing key loss on server restart
- Add `_load_env_key()` method to `BrokerSettingsService`
- Let decryption errors propagate from `send_telegram_message()` so callers can distinguish key mismatch from Telegram API failure
- Return clear "re-save your bot token" message in test endpoint when encryption key doesn't match

## Test plan
- [x] `pytest tests/test_telegram_settings.py` — 14 passed
- [x] `npm run build` — success
- [x] Manual: POST `/api/settings/telegram/test` returns "Encryption key mismatch" message
- [ ] Manual: re-save bot token → test sends message successfully

Closes the telegram "Failed to send test message" issue after server restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)