### PR TITLE
fix: show Telegram API error details in test response

### DIFF
--- a/api/routers/settings.py
+++ b/api/routers/settings.py
@@ -265,12 +265,11 @@ def test_telegram_notification() -> TelegramTestResponse:
 
     try:
         ok = _settings_service.send_telegram_message(view.chat_id, encrypted_token)
-    except RuntimeError:
-        # Decryption failure — encryption key changed since the token was saved.
-        return TelegramTestResponse(
-            success=False,
-            message="Encryption key mismatch. Please re-save your bot token.",
-        )
+    except RuntimeError as exc:
+        msg = str(exc)
+        if "decrypt" in msg.lower():
+            msg = "Encryption key mismatch. Please re-save your bot token."
+        return TelegramTestResponse(success=False, message=msg)
     if ok:
         return TelegramTestResponse(success=True, message="Test message sent successfully")
     return TelegramTestResponse(

--- a/api/services/broker_settings_service.py
+++ b/api/services/broker_settings_service.py
@@ -429,6 +429,17 @@ class BrokerSettingsService:
             with urllib.request.urlopen(req, timeout=10) as resp:
                 body = json.loads(resp.read().decode("utf-8"))
                 return bool(body.get("ok"))
+        except urllib.error.HTTPError as exc:
+            detail = ""
+            try:
+                body = json.loads(exc.read().decode("utf-8"))
+                detail = body.get("description", "")
+            except Exception:
+                pass
+            logger.warning("Telegram sendMessage failed: %s %s", exc.code, detail)
+            raise RuntimeError(
+                detail or f"Telegram API error {exc.code}"
+            ) from exc
         except Exception:
             logger.warning("Telegram sendMessage failed", exc_info=True)
             return False


### PR DESCRIPTION
## Summary
- Parse error description from Telegram API HTTP error responses (e.g. "Forbidden: bots can't send messages to bots")
- Surface the actual Telegram error message to the user instead of generic "Failed to send test message"
- Distinguish between decryption errors (key mismatch) and Telegram API errors

## Test plan
- [x] `pytest tests/test_telegram_settings.py` — 14 passed
- [x] Manual: 403 error now shows "Forbidden: bots can't send messages to bots"

🤖 Generated with [Claude Code](https://claude.com/claude-code)