### PR TITLE
fix: conflicting entry signal and posture in macro monitor

### DIFF
--- a/api/services/macro_market_service.py
+++ b/api/services/macro_market_service.py
@@ -121,6 +121,9 @@ class MacroMarketService:
         )
         interpretation["posture"] = posture
         interpretation["posture_rationale"] = posture_rationale
+        # Demote entry_signal to match posture when they conflict
+        if posture == "wait" and interpretation.get("entry_signal") == "buy_favorable":
+            interpretation["entry_signal"] = "wait"
 
         breadth = self._get_breadth_snapshot()
         events = self._get_upcoming_events()

--- a/api/services/us_scoring_service.py
+++ b/api/services/us_scoring_service.py
@@ -342,6 +342,10 @@ class UsScoringService:
             entry,
         )
 
+        # Demote entry_signal to match posture when they conflict
+        if posture == "wait" and entry == "buy_favorable":
+            entry = "wait"
+
         return {
             "signal": signal,
             "interpretation": {


### PR DESCRIPTION
## Summary
- Fixed "매수 적기" (buy favorable) and "관망 유지" (wait) showing simultaneously
- When posture is "wait" (regime neutral), entry_signal is now demoted from "buy_favorable" to "wait"
- Applied to both KR (`macro_market_service.py`) and US (`us_scoring_service.py`) scoring

## Test plan
- [x] `pytest api/tests/test_us_scoring_service.py` — 15 passed
- [x] API: `GET /api/market/macro/bundle?mode=us` returns `entry: wait, posture: wait`
- [x] Visual: US tab now shows "관망" consistently with "관망 유지"

🤖 Generated with [Claude Code](https://claude.com/claude-code)