### PR TITLE
fix(web): show stock names in portfolio treemap

### DIFF
--- a/web/src/components/portfolio/AllocationCharts.tsx
+++ b/web/src/components/portfolio/AllocationCharts.tsx
@@ -186,8 +186,11 @@ function HeatmapContent({ x, y, width, height, name, ticker, pnl_pct }: HeatmapC
   const bgColor = getPnlColor(pnl_pct ?? null);
   const textColor = getPnlTextColor(pnl_pct ?? null);
   const fontSize = Math.floor(Math.min(width / 7, height / 3.5, 14));
-  const displayTicker = ((ticker || '').split('.')[0] || name || '').trim();
-  const showTicker = width > 35 && height > 20 && fontSize >= 8 && displayTicker.length > 0;
+  const tickerCode = ((ticker || '').split('.')[0] || '').trim();
+  const stockName = (name || '').trim();
+  // Show name if available and different from ticker code, otherwise show ticker code
+  const displayLabel = stockName && stockName !== tickerCode ? stockName : tickerCode;
+  const showLabel = width > 35 && height > 20 && fontSize >= 8 && displayLabel.length > 0;
   const showPnl = width > 50 && height > 35 && fontSize >= 8;
 
   const displayPnl = pnl_pct != null && Number.isFinite(pnl_pct)
@@ -206,7 +209,7 @@ function HeatmapContent({ x, y, width, height, name, ticker, pnl_pct }: HeatmapC
         strokeWidth={1.5}
         rx={2}
       />
-      {showTicker && (
+      {showLabel && (
         <text
           x={x + width / 2}
           y={y + height / 2 - (showPnl ? fontSize * 0.6 : 0)}
@@ -216,7 +219,7 @@ function HeatmapContent({ x, y, width, height, name, ticker, pnl_pct }: HeatmapC
           fontSize={fontSize}
           fontWeight={700}
         >
-          {displayTicker}
+          {displayLabel}
         </text>
       )}
       {showPnl && (


### PR DESCRIPTION
## Summary
- Treemap `HeatmapContent` was displaying raw ticker codes (e.g., `006400`) instead of stock names
- Changed display logic to show `stockName` when available and different from ticker code
- Falls back to ticker code when name is not available

## Test plan
- [ ] Open portfolio page → treemap shows stock names (e.g., "삼성SDI") instead of codes
- [ ] Stocks without names still show ticker code
- [ ] Build passes (`npm run build`)

Closes #1308

🤖 Generated with [Claude Code](https://claude.com/claude-code)