### PR TITLE
fix(engine): make MA crossover strategies long-only

### DIFF
--- a/engine/strategies/ma_cross.py
+++ b/engine/strategies/ma_cross.py
@@ -45,9 +45,10 @@ class SmaCross(Strategy):
         # 골든크로스: 매수
         if crossover(self.sma1, self.sma2):
             self.buy()
-        # 데드크로스: 매도
+        # 데드크로스: 청산 (long-only — self.sell() would open a short)
         elif crossover(self.sma2, self.sma1):
-            self.sell()
+            if self.position:
+                self.position.close()
 
 
 class EmaCross(Strategy):
@@ -73,9 +74,10 @@ class EmaCross(Strategy):
         # 골든크로스: 매수
         if crossover(self.ema1, self.ema2):
             self.buy()
-        # 데드크로스: 매도
+        # 데드크로스: 청산 (long-only — self.sell() would open a short)
         elif crossover(self.ema2, self.ema1):
-            self.sell()
+            if self.position:
+                self.position.close()
 
 
 class MaTouchStrategy(Strategy):
@@ -121,9 +123,9 @@ class MaTouchStrategy(Strategy):
 
                 # 익절
                 if pnl >= self.take_profit:
-                    self.sell()
+                    self.position.close()
                     self.entry_price = None
                 # 손절
                 elif pnl <= -self.stop_loss:
-                    self.sell()
+                    self.position.close()
                     self.entry_price = None


### PR DESCRIPTION
## Summary
- `self.sell()` in backtesting.py opens a short position, not just exits a long
- Replaced with `self.position.close()` in SmaCross, EmaCross, and MaTouchStrategy
- This makes all crossover strategies behave as long-only (buy on golden cross, close on death cross)
- No more spurious short positions in trade records

## Test plan
- [ ] Run EMA backtest: `POST /api/backtest/run` with `strategy: "ema"` and `include_trades: true`
- [ ] Verify no negative `size` values in returned trades
- [ ] Run SMA backtest: same check
- [ ] Run MA touch backtest: same check

Closes #1312

🤖 Generated with [Claude Code](https://claude.com/claude-code)