### PR TITLE
feat(api): portfolio alert scanner with Telegram dedup

### DIFF
--- a/api/database.py
+++ b/api/database.py
@@ -56,6 +56,7 @@ def init_db() -> None:
     import api.models.screening_result  # noqa: F401 — register model with Base
     import api.models.strategy  # noqa: F401 — register model with Base
     import api.models.strategy_backtest_result  # noqa: F401 — register model with Base
+    import api.models.portfolio_alert  # noqa: F401 — register model with Base
     import api.models.strategy_alert  # noqa: F401 — register model with Base
     import api.models.strategy_webhook  # noqa: F401 — register model with Base
     import api.models.watchlist  # noqa: F401 — register model with Base

--- a/api/main.py
+++ b/api/main.py
@@ -22,6 +22,7 @@ from api.routers.search import router as search_router
 from api.routers.agent_task import router as agent_task_router
 from api.routers.kiwoom import router as kiwoom_router
 from api.routers.strategy import router as strategy_router
+from api.routers.portfolio_alerts import router as portfolio_alerts_router
 from api.routers.watchlist import router as watchlist_router
 
 
@@ -192,6 +193,12 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             get_broker_settings_service().apply_ibkr_settings_to_runtime()
         except Exception as e:
             print(f"WARNING: IBKR settings runtime apply failed: {e}")
+
+        try:
+            from api.services.portfolio_alert_scanner import get_portfolio_alert_scanner
+            get_portfolio_alert_scanner().start()
+        except Exception as e:
+            print(f"WARNING: Portfolio alert scanner failed to start: {e}")
     except Exception as e:
         print(f"WARNING: Database initialization failed: {e}")
         print("Strategy persistence will be unavailable until DB is reachable.")
@@ -256,6 +263,7 @@ def create_app() -> FastAPI:
     app.include_router(broker_router)
     app.include_router(execution_history_router)
     app.include_router(watchlist_router)
+    app.include_router(portfolio_alerts_router)
 
     # Future routers (추후 추가될 라우터)
     # app.include_router(news_router, prefix="/api/v1")

--- a/api/models/portfolio_alert.py
+++ b/api/models/portfolio_alert.py
@@ -1,0 +1,26 @@
+"""
+SQLAlchemy model for portfolio alert history with daily dedup.
+"""
+
+from datetime import date, datetime
+
+from sqlalchemy import Column, Date, DateTime, Float, Integer, String, Text, UniqueConstraint
+
+from api.database import Base
+
+
+class PortfolioAlertHistory(Base):
+    """Record of a fired portfolio alert with daily dedup."""
+
+    __tablename__ = "portfolio_alert_history"
+    __table_args__ = (
+        UniqueConstraint("ticker", "signal_type", "dedup_date", name="uq_portfolio_alert_dedup"),
+    )
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    ticker = Column(String(32), nullable=False, index=True)
+    signal_type = Column(String(32), nullable=False)
+    message = Column(Text, nullable=False)
+    price_at_signal = Column(Float, nullable=True)
+    fired_at = Column(DateTime, default=datetime.utcnow, index=True)
+    dedup_date = Column(Date, default=date.today, nullable=False, index=True)

--- a/api/routers/portfolio_alerts.py
+++ b/api/routers/portfolio_alerts.py
@@ -1,0 +1,90 @@
+"""
+Portfolio alert endpoints — history, config, manual scan trigger.
+"""
+
+from fastapi import APIRouter, Query
+
+from api.schemas.portfolio_alert import (
+    PortfolioAlertConfigResponse,
+    PortfolioAlertConfigUpdate,
+    PortfolioAlertHistoryResponse,
+    PortfolioAlertScanResult,
+)
+
+router = APIRouter(prefix="/api/portfolio/alerts", tags=["portfolio-alerts"])
+
+
+@router.get("/history", response_model=PortfolioAlertHistoryResponse)
+async def get_alert_history(limit: int = Query(50, ge=1, le=200)):
+    """Get recent portfolio alert history."""
+    from api.services.portfolio_alert_service import get_history
+
+    return get_history(limit=limit)
+
+
+@router.get("/config", response_model=PortfolioAlertConfigResponse)
+async def get_alert_config():
+    """Get current alert settings from portfolio.yaml."""
+    from api.services.portfolio_alert_scanner import load_config
+
+    _, settings = load_config()
+    return PortfolioAlertConfigResponse(
+        enabled=settings.enabled,
+        scan_interval_seconds=settings.scan_interval_seconds,
+        stop_loss_pct=settings.stop_loss_pct,
+        take_profit_pct=settings.take_profit_pct,
+        trailing_stop_pct=settings.trailing_stop_pct,
+        technical_signals=settings.technical_signals,
+        market_hours_only=settings.market_hours_only,
+        channels=settings.channels or ["telegram"],
+    )
+
+
+@router.put("/config", response_model=PortfolioAlertConfigResponse)
+async def update_alert_config(body: PortfolioAlertConfigUpdate):
+    """Update alert settings in portfolio.yaml."""
+    import yaml
+    from api.services.portfolio_alert_scanner import _CONFIG_PATH
+
+    if not _CONFIG_PATH.exists():
+        return PortfolioAlertConfigResponse()
+
+    with open(_CONFIG_PATH, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+
+    alert_raw = data.setdefault("alert_settings", {})
+
+    for field in (
+        "enabled",
+        "scan_interval_seconds",
+        "stop_loss_pct",
+        "take_profit_pct",
+        "trailing_stop_pct",
+        "technical_signals",
+        "market_hours_only",
+        "channels",
+    ):
+        val = getattr(body, field, None)
+        if val is not None:
+            alert_raw[field] = val
+
+    with open(_CONFIG_PATH, "w", encoding="utf-8") as f:
+        yaml.dump(data, f, allow_unicode=True, default_flow_style=False)
+
+    return PortfolioAlertConfigResponse(**alert_raw)
+
+
+@router.post("/scan", response_model=PortfolioAlertScanResult)
+async def trigger_scan():
+    """Manually trigger a portfolio alert scan."""
+    from api.services.portfolio_alert_scanner import get_portfolio_alert_scanner, load_config
+
+    holdings, _ = load_config()
+    scanner = get_portfolio_alert_scanner()
+    alerts_fired = scanner.scan_once()
+
+    return PortfolioAlertScanResult(
+        scanned_count=len(holdings),
+        alerts_fired=alerts_fired,
+        message=f"Scanned {len(holdings)} holdings, fired {alerts_fired} alerts",
+    )

--- a/api/schemas/portfolio_alert.py
+++ b/api/schemas/portfolio_alert.py
@@ -1,0 +1,49 @@
+"""
+Pydantic schemas for portfolio alerts.
+"""
+
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class PortfolioAlertHistoryEntry(BaseModel):
+    id: int
+    ticker: str
+    signal_type: str
+    message: str
+    price_at_signal: Optional[float] = None
+    fired_at: Optional[str] = None
+
+
+class PortfolioAlertHistoryResponse(BaseModel):
+    alerts: List[PortfolioAlertHistoryEntry]
+    total_count: int
+
+
+class PortfolioAlertConfigResponse(BaseModel):
+    enabled: bool = False
+    scan_interval_seconds: int = 60
+    stop_loss_pct: float = 0.20
+    take_profit_pct: float = 0.30
+    trailing_stop_pct: float = 0.10
+    technical_signals: bool = True
+    market_hours_only: bool = True
+    channels: List[str] = Field(default_factory=lambda: ["telegram"])
+
+
+class PortfolioAlertConfigUpdate(BaseModel):
+    enabled: Optional[bool] = None
+    scan_interval_seconds: Optional[int] = None
+    stop_loss_pct: Optional[float] = None
+    take_profit_pct: Optional[float] = None
+    trailing_stop_pct: Optional[float] = None
+    technical_signals: Optional[bool] = None
+    market_hours_only: Optional[bool] = None
+    channels: Optional[List[str]] = None
+
+
+class PortfolioAlertScanResult(BaseModel):
+    scanned_count: int
+    alerts_fired: int
+    message: str

--- a/api/services/portfolio_alert_scanner.py
+++ b/api/services/portfolio_alert_scanner.py
@@ -1,0 +1,293 @@
+"""
+Portfolio Alert Scanner — background thread that periodically checks holdings
+against sell/buy conditions and fires dedup-aware Telegram alerts.
+
+Uses yfinance for price data (free, 1-minute polling acceptable).
+"""
+
+import logging
+import threading
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Config loader
+# ---------------------------------------------------------------------------
+
+_CONFIG_PATH = Path(__file__).resolve().parents[2] / "config" / "portfolio.yaml"
+
+
+@dataclass
+class HoldingInfo:
+    ticker: str
+    name: str
+    buy_price: float
+    quantity: int
+
+
+@dataclass
+class AlertSettings:
+    enabled: bool = True
+    scan_interval_seconds: int = 60
+    stop_loss_pct: float = 0.20
+    take_profit_pct: float = 0.30
+    trailing_stop_pct: float = 0.10
+    technical_signals: bool = True
+    market_hours_only: bool = True
+    channels: list = None
+
+    def __post_init__(self):
+        if self.channels is None:
+            self.channels = ["telegram"]
+
+
+def load_config() -> tuple[list[HoldingInfo], AlertSettings]:
+    """Load holdings and alert settings from portfolio.yaml."""
+    if not _CONFIG_PATH.exists():
+        logger.warning("portfolio.yaml not found at %s", _CONFIG_PATH)
+        return [], AlertSettings(enabled=False)
+
+    with open(_CONFIG_PATH, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+
+    # Holdings
+    holdings_raw = data.get("holdings", {})
+    holdings: list[HoldingInfo] = []
+    for ticker, info in holdings_raw.items():
+        if not isinstance(info, dict):
+            continue
+        holdings.append(
+            HoldingInfo(
+                ticker=ticker,
+                name=info.get("name", ticker),
+                buy_price=float(info.get("buy_price", 0)),
+                quantity=int(info.get("quantity", 0)),
+            )
+        )
+
+    # Alert settings
+    alert_raw = data.get("alert_settings", {})
+    settings = AlertSettings(
+        enabled=alert_raw.get("enabled", True),
+        scan_interval_seconds=alert_raw.get("scan_interval_seconds", 60),
+        stop_loss_pct=alert_raw.get("stop_loss_pct", 0.20),
+        take_profit_pct=alert_raw.get("take_profit_pct", 0.30),
+        trailing_stop_pct=alert_raw.get("trailing_stop_pct", 0.10),
+        technical_signals=alert_raw.get("technical_signals", True),
+        market_hours_only=alert_raw.get("market_hours_only", True),
+        channels=alert_raw.get("channels", ["telegram"]),
+    )
+
+    return holdings, settings
+
+
+# ---------------------------------------------------------------------------
+# Market hours check
+# ---------------------------------------------------------------------------
+
+
+def _is_market_hours() -> bool:
+    """Simple check: skip weekends. For more precision, use market_calendar."""
+    now = datetime.utcnow()
+    # Skip Saturday (5) and Sunday (6)
+    if now.weekday() in (5, 6):
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Price fetcher
+# ---------------------------------------------------------------------------
+
+
+def _fetch_prices(tickers: list[str]) -> Dict[str, float]:
+    """Fetch latest prices for a batch of tickers via yfinance."""
+    try:
+        import yfinance as yf
+
+        prices: Dict[str, float] = {}
+        # Batch download — single HTTP request for all tickers
+        data = yf.download(tickers, period="1d", interval="1m", progress=False, threads=True)
+        if data.empty:
+            return prices
+
+        close = data.get("Close")
+        if close is None:
+            return prices
+
+        if len(tickers) == 1:
+            # Single ticker: close is a Series
+            last_val = close.dropna().iloc[-1] if not close.dropna().empty else None
+            if last_val is not None:
+                prices[tickers[0]] = float(last_val)
+        else:
+            # Multiple tickers: close is a DataFrame
+            for t in tickers:
+                if t in close.columns:
+                    col = close[t].dropna()
+                    if not col.empty:
+                        prices[t] = float(col.iloc[-1])
+
+        return prices
+    except Exception:
+        logger.warning("yfinance price fetch failed", exc_info=True)
+        return {}
+
+
+# ---------------------------------------------------------------------------
+# Message formatters
+# ---------------------------------------------------------------------------
+
+
+def _format_sell_message(
+    holding: HoldingInfo,
+    signal_type: str,
+    price: float,
+    change_pct: float,
+) -> str:
+    """Format a sell signal alert message."""
+    labels = {
+        "stop_loss": "손절",
+        "take_profit": "익절",
+        "trailing_stop": "트레일링 스톱",
+    }
+    label = labels.get(signal_type, signal_type)
+    emoji = "🔴" if signal_type == "stop_loss" else "🟢" if signal_type == "take_profit" else "🟡"
+    sign = "+" if change_pct >= 0 else ""
+
+    # Currency formatting
+    ticker = holding.ticker
+    if ticker.endswith(".KS") or ticker.endswith(".KQ"):
+        price_str = f"₩{price:,.0f}"
+        buy_str = f"₩{holding.buy_price:,.0f}"
+    else:
+        price_str = f"${price:,.2f}"
+        buy_str = f"${holding.buy_price:,.2f}"
+
+    return (
+        f"{emoji} 매도 시그널 — {label}\n"
+        f"종목: {holding.name} ({ticker.split('.')[0]})\n"
+        f"사유: {label} {sign}{change_pct:.1%} 도달\n"
+        f"현재가: {price_str}\n"
+        f"매수가: {buy_str}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scanner
+# ---------------------------------------------------------------------------
+
+
+class PortfolioAlertScanner:
+    """Background scanner that checks portfolio holdings and fires alerts."""
+
+    def __init__(self):
+        self._running = False
+        self._consecutive_failures = 0
+        self._max_consecutive_failures = 3
+
+    def start(self) -> None:
+        """Launch as daemon thread."""
+        self._running = True
+        threading.Thread(
+            target=self._run_loop, daemon=True, name="portfolio-alert-scanner"
+        ).start()
+        logger.info("Portfolio alert scanner started")
+
+    def stop(self) -> None:
+        self._running = False
+
+    def _run_loop(self) -> None:
+        while self._running:
+            holdings, settings = load_config()
+            if not settings.enabled:
+                time.sleep(60)
+                continue
+
+            interval = max(settings.scan_interval_seconds, 30)
+
+            try:
+                self._scan(holdings, settings)
+                self._consecutive_failures = 0
+            except Exception:
+                self._consecutive_failures += 1
+                logger.exception("Portfolio alert scan failed (attempt %d)", self._consecutive_failures)
+                if self._consecutive_failures >= self._max_consecutive_failures:
+                    interval = max(interval, 300)  # Back off to 5 minutes
+                    logger.warning("Too many consecutive failures, backing off to %ds", interval)
+
+            time.sleep(interval)
+
+    def _scan(self, holdings: list[HoldingInfo], settings: AlertSettings) -> int:
+        """Run a single scan cycle. Returns number of alerts fired."""
+        if not holdings:
+            return 0
+
+        if settings.market_hours_only and not _is_market_hours():
+            logger.debug("Market closed, skipping scan")
+            return 0
+
+        tickers = [h.ticker for h in holdings]
+        prices = _fetch_prices(tickers)
+        if not prices:
+            logger.debug("No prices fetched, skipping")
+            return 0
+
+        from api.services.portfolio_alert_service import record_and_send
+
+        alerts_fired = 0
+        for holding in holdings:
+            price = prices.get(holding.ticker)
+            if price is None or holding.buy_price <= 0:
+                continue
+
+            change_pct = (price - holding.buy_price) / holding.buy_price
+
+            # Stop loss
+            if change_pct <= -settings.stop_loss_pct:
+                msg = _format_sell_message(holding, "stop_loss", price, change_pct)
+                if record_and_send(holding.ticker, "stop_loss", msg, price):
+                    alerts_fired += 1
+
+            # Take profit
+            if change_pct >= settings.take_profit_pct:
+                msg = _format_sell_message(holding, "take_profit", price, change_pct)
+                if record_and_send(holding.ticker, "take_profit", msg, price):
+                    alerts_fired += 1
+
+        if alerts_fired:
+            logger.info("Portfolio scan fired %d alerts", alerts_fired)
+
+        return alerts_fired
+
+    def scan_once(self) -> int:
+        """Manual trigger for a single scan. Returns alerts fired count."""
+        holdings, settings = load_config()
+        # Override market hours check for manual scans
+        original = settings.market_hours_only
+        settings.market_hours_only = False
+        try:
+            return self._scan(holdings, settings)
+        finally:
+            settings.market_hours_only = original
+
+
+# ---------------------------------------------------------------------------
+# Singleton
+# ---------------------------------------------------------------------------
+
+_scanner: Optional[PortfolioAlertScanner] = None
+
+
+def get_portfolio_alert_scanner() -> PortfolioAlertScanner:
+    global _scanner
+    if _scanner is None:
+        _scanner = PortfolioAlertScanner()
+    return _scanner

--- a/api/services/portfolio_alert_service.py
+++ b/api/services/portfolio_alert_service.py
@@ -1,0 +1,126 @@
+"""
+Portfolio alert service — dedup-aware alert recording and Telegram dispatch.
+"""
+
+import json
+import logging
+from datetime import date, datetime
+from typing import Optional
+
+from sqlalchemy.exc import IntegrityError
+
+from api.database import SessionLocal
+from api.models.portfolio_alert import PortfolioAlertHistory
+from api.schemas.portfolio_alert import PortfolioAlertHistoryEntry, PortfolioAlertHistoryResponse
+
+logger = logging.getLogger(__name__)
+
+
+def _entry_from_row(row: PortfolioAlertHistory) -> PortfolioAlertHistoryEntry:
+    return PortfolioAlertHistoryEntry(
+        id=row.id,
+        ticker=row.ticker,
+        signal_type=row.signal_type,
+        message=row.message,
+        price_at_signal=row.price_at_signal,
+        fired_at=row.fired_at.isoformat() if row.fired_at else None,
+    )
+
+
+def is_already_sent_today(ticker: str, signal_type: str) -> bool:
+    """Check if the same (ticker, signal_type) alert was already sent today."""
+    today = date.today()
+    db = SessionLocal()
+    try:
+        exists = (
+            db.query(PortfolioAlertHistory)
+            .filter(
+                PortfolioAlertHistory.ticker == ticker,
+                PortfolioAlertHistory.signal_type == signal_type,
+                PortfolioAlertHistory.dedup_date == today,
+            )
+            .first()
+        )
+        return exists is not None
+    finally:
+        db.close()
+
+
+def record_and_send(
+    ticker: str,
+    signal_type: str,
+    message: str,
+    price: Optional[float] = None,
+) -> bool:
+    """Record alert and send via Telegram. Returns False if already sent today."""
+    today = date.today()
+    now = datetime.utcnow()  # noqa: DTZ003
+
+    db = SessionLocal()
+    try:
+        row = PortfolioAlertHistory(
+            ticker=ticker,
+            signal_type=signal_type,
+            message=message,
+            price_at_signal=price,
+            fired_at=now,
+            dedup_date=today,
+        )
+        db.add(row)
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        logger.debug("Alert already sent today: %s/%s", ticker, signal_type)
+        return False
+    finally:
+        db.close()
+
+    # Dispatch to Telegram
+    _send_telegram(message)
+    return True
+
+
+def _send_telegram(message: str) -> None:
+    """Send message via Telegram using saved bot settings."""
+    try:
+        from api.models.broker_credential import BrokerCredential
+        from api.services.broker_settings_service import get_broker_settings_service
+
+        svc = get_broker_settings_service()
+        view = svc.get_telegram_settings()
+        if not (view.enabled and view.has_bot_token and view.chat_id):
+            logger.debug("Telegram not configured or disabled, skipping")
+            return
+
+        db = SessionLocal()
+        try:
+            row = db.get(BrokerCredential, "telegram")
+            if row:
+                data = json.loads(row.config_json)
+                encrypted_token = data.get("bot_token_encrypted", "")
+                svc.send_telegram_message(view.chat_id, encrypted_token, message)
+                logger.info("Portfolio alert sent via Telegram")
+        finally:
+            db.close()
+    except Exception:
+        logger.warning("Failed to send portfolio alert via Telegram", exc_info=True)
+
+
+def get_history(limit: int = 50) -> PortfolioAlertHistoryResponse:
+    """Get recent alert history."""
+    limit = max(1, min(limit, 200))
+    db = SessionLocal()
+    try:
+        total = db.query(PortfolioAlertHistory).count()
+        rows = (
+            db.query(PortfolioAlertHistory)
+            .order_by(PortfolioAlertHistory.fired_at.desc())
+            .limit(limit)
+            .all()
+        )
+        return PortfolioAlertHistoryResponse(
+            alerts=[_entry_from_row(r) for r in rows],
+            total_count=total,
+        )
+    finally:
+        db.close()

--- a/tests/test_portfolio_alerts.py
+++ b/tests/test_portfolio_alerts.py
@@ -1,0 +1,210 @@
+"""Tests for portfolio alert dedup logic and scanner."""
+
+import os
+import sys
+from datetime import date, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Ensure project root is on path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+# ---------------------------------------------------------------------------
+# Setup: configure in-memory SQLite BEFORE importing any api modules
+# ---------------------------------------------------------------------------
+
+os.environ["DATABASE_URL"] = "sqlite:///test_portfolio_alerts.db"
+
+from api.database import Base, SessionLocal, engine
+import api.models.portfolio_alert  # noqa: F401
+from api.models.portfolio_alert import PortfolioAlertHistory
+
+
+@pytest.fixture(autouse=True)
+def _fresh_tables():
+    """Create tables before each test, truncate after."""
+    Base.metadata.create_all(bind=engine)
+    yield
+    # Truncate alert history between tests
+    db = SessionLocal()
+    try:
+        db.query(PortfolioAlertHistory).delete()
+        db.commit()
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests — dedup logic
+# ---------------------------------------------------------------------------
+
+
+class TestDedupLogic:
+    def test_first_alert_succeeds(self):
+        from api.services.portfolio_alert_service import record_and_send
+
+        with patch("api.services.portfolio_alert_service._send_telegram") as mock_tg:
+            result = record_and_send("005930.KS", "stop_loss", "Test message", 50000.0)
+            assert result is True
+            mock_tg.assert_called_once()
+
+    def test_duplicate_alert_blocked(self):
+        from api.services.portfolio_alert_service import record_and_send
+
+        with patch("api.services.portfolio_alert_service._send_telegram"):
+            record_and_send("005930.KS", "stop_loss", "First", 50000.0)
+            result = record_and_send("005930.KS", "stop_loss", "Duplicate", 49000.0)
+            assert result is False
+
+    def test_different_signal_type_allowed(self):
+        from api.services.portfolio_alert_service import record_and_send
+
+        with patch("api.services.portfolio_alert_service._send_telegram"):
+            r1 = record_and_send("005930.KS", "stop_loss", "SL", 50000.0)
+            r2 = record_and_send("005930.KS", "take_profit", "TP", 80000.0)
+            assert r1 is True
+            assert r2 is True
+
+    def test_different_ticker_allowed(self):
+        from api.services.portfolio_alert_service import record_and_send
+
+        with patch("api.services.portfolio_alert_service._send_telegram"):
+            r1 = record_and_send("005930.KS", "stop_loss", "A", 50000.0)
+            r2 = record_and_send("035420.KS", "stop_loss", "B", 180000.0)
+            assert r1 is True
+            assert r2 is True
+
+    def test_is_already_sent_today(self):
+        from api.services.portfolio_alert_service import is_already_sent_today, record_and_send
+
+        with patch("api.services.portfolio_alert_service._send_telegram"):
+            assert is_already_sent_today("AAPL", "stop_loss") is False
+            record_and_send("AAPL", "stop_loss", "msg", 150.0)
+            assert is_already_sent_today("AAPL", "stop_loss") is True
+            assert is_already_sent_today("AAPL", "take_profit") is False
+
+    def test_get_history(self):
+        from api.services.portfolio_alert_service import get_history, record_and_send
+
+        with patch("api.services.portfolio_alert_service._send_telegram"):
+            record_and_send("AAPL", "stop_loss", "msg1", 150.0)
+            record_and_send("MSFT", "take_profit", "msg2", 400.0)
+
+        history = get_history(limit=10)
+        assert history.total_count == 2
+        assert len(history.alerts) == 2
+
+
+# ---------------------------------------------------------------------------
+# Tests — scanner
+# ---------------------------------------------------------------------------
+
+
+class TestScanner:
+    def test_scan_fires_stop_loss(self):
+        from api.services.portfolio_alert_scanner import (
+            AlertSettings,
+            HoldingInfo,
+            PortfolioAlertScanner,
+        )
+
+        scanner = PortfolioAlertScanner()
+
+        holdings = [
+            HoldingInfo(ticker="005930.KS", name="Samsung", buy_price=80000, quantity=10),
+        ]
+        settings = AlertSettings(
+            enabled=True,
+            stop_loss_pct=0.20,
+            take_profit_pct=0.30,
+            market_hours_only=False,
+        )
+
+        # Price at 60000 = -25% from buy price → triggers stop loss
+        with (
+            patch("api.services.portfolio_alert_scanner._fetch_prices", return_value={"005930.KS": 60000.0}),
+            patch("api.services.portfolio_alert_service._send_telegram"),
+        ):
+            alerts = scanner._scan(holdings, settings)
+            assert alerts == 1
+
+    def test_scan_fires_take_profit(self):
+        from api.services.portfolio_alert_scanner import (
+            AlertSettings,
+            HoldingInfo,
+            PortfolioAlertScanner,
+        )
+
+        scanner = PortfolioAlertScanner()
+
+        holdings = [
+            HoldingInfo(ticker="AAPL", name="Apple", buy_price=100, quantity=10),
+        ]
+        settings = AlertSettings(
+            enabled=True,
+            stop_loss_pct=0.20,
+            take_profit_pct=0.30,
+            market_hours_only=False,
+        )
+
+        # Price at 135 = +35% → triggers take profit
+        with (
+            patch("api.services.portfolio_alert_scanner._fetch_prices", return_value={"AAPL": 135.0}),
+            patch("api.services.portfolio_alert_service._send_telegram"),
+        ):
+            alerts = scanner._scan(holdings, settings)
+            assert alerts == 1
+
+    def test_scan_no_alert_in_safe_zone(self):
+        from api.services.portfolio_alert_scanner import (
+            AlertSettings,
+            HoldingInfo,
+            PortfolioAlertScanner,
+        )
+
+        scanner = PortfolioAlertScanner()
+
+        holdings = [
+            HoldingInfo(ticker="AAPL", name="Apple", buy_price=100, quantity=10),
+        ]
+        settings = AlertSettings(
+            enabled=True,
+            stop_loss_pct=0.20,
+            take_profit_pct=0.30,
+            market_hours_only=False,
+        )
+
+        # Price at 105 = +5% → no alert
+        with (
+            patch("api.services.portfolio_alert_scanner._fetch_prices", return_value={"AAPL": 105.0}),
+            patch("api.services.portfolio_alert_service._send_telegram"),
+        ):
+            alerts = scanner._scan(holdings, settings)
+            assert alerts == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests — message formatting
+# ---------------------------------------------------------------------------
+
+
+class TestMessageFormat:
+    def test_kr_format(self):
+        from api.services.portfolio_alert_scanner import HoldingInfo, _format_sell_message
+
+        h = HoldingInfo(ticker="005930.KS", name="삼성전자", buy_price=80000, quantity=10)
+        msg = _format_sell_message(h, "stop_loss", 60000, -0.25)
+        assert "삼성전자" in msg
+        assert "₩60,000" in msg
+        assert "₩80,000" in msg
+        assert "손절" in msg
+
+    def test_us_format(self):
+        from api.services.portfolio_alert_scanner import HoldingInfo, _format_sell_message
+
+        h = HoldingInfo(ticker="AAPL", name="Apple", buy_price=200, quantity=5)
+        msg = _format_sell_message(h, "take_profit", 270, 0.35)
+        assert "Apple" in msg
+        assert "$270.00" in msg
+        assert "익절" in msg


### PR DESCRIPTION
## Summary
- **Background scanner**: Polls yfinance every 60s for portfolio holdings prices
- **Daily dedup**: Same (ticker, signal_type) alert sent at most once per day via DB unique constraint
- **Telegram dispatch**: Reuses existing Telegram bot settings for alert delivery
- **REST API**: History, config, and manual scan trigger endpoints
- **Message formatting**: KR (₩) / US ($) currency-aware, emoji-tagged sell signals

## New files
| File | Description |
|------|-------------|
| `api/models/portfolio_alert.py` | `PortfolioAlertHistory` model with dedup constraint |
| `api/services/portfolio_alert_service.py` | Dedup logic + Telegram dispatch |
| `api/services/portfolio_alert_scanner.py` | Background scanner (yfinance polling) |
| `api/routers/portfolio_alerts.py` | REST endpoints |
| `api/schemas/portfolio_alert.py` | Pydantic schemas |
| `tests/test_portfolio_alerts.py` | 11 tests |

## Modified files
| File | Change |
|------|--------|
| `api/database.py` | Register `PortfolioAlertHistory` model |
| `api/main.py` | Start scanner in lifespan, register router |

## Test plan
- [x] `pytest tests/test_portfolio_alerts.py` — 11/11 pass
- [ ] Manual: Add holding with large loss → trigger scan → Telegram received
- [ ] Manual: Trigger scan again → no duplicate message
- [ ] `GET /api/portfolio/alerts/history` returns alert records
- [ ] `POST /api/portfolio/alerts/scan` triggers manual scan

Closes #1309

🤖 Generated with [Claude Code](https://claude.com/claude-code)