### PR TITLE
fix: portfolio alert scanner uses DB holdings, not static YAML

### DIFF
--- a/api/services/portfolio_alert_scanner.py
+++ b/api/services/portfolio_alert_scanner.py
@@ -48,33 +48,41 @@ class AlertSettings:
             self.channels = ["telegram"]
 
 
-def load_config() -> tuple[list[HoldingInfo], AlertSettings]:
-    """Load holdings and alert settings from portfolio.yaml."""
+def _load_holdings_from_db() -> list[HoldingInfo]:
+    """Load current holdings from the database (source of truth)."""
+    try:
+        from api.database import SessionLocal
+        from api.models.portfolio import Holding
+
+        db = SessionLocal()
+        try:
+            rows = db.query(Holding).filter(Holding.quantity > 0).all()
+            return [
+                HoldingInfo(
+                    ticker=row.ticker,
+                    name=row.name or row.ticker,
+                    buy_price=float(row.avg_price or 0),
+                    quantity=int(row.quantity),
+                )
+                for row in rows
+            ]
+        finally:
+            db.close()
+    except Exception:
+        logger.warning("Failed to load holdings from DB", exc_info=True)
+        return []
+
+
+def _load_alert_settings() -> AlertSettings:
+    """Load alert settings from portfolio.yaml."""
     if not _CONFIG_PATH.exists():
-        logger.warning("portfolio.yaml not found at %s", _CONFIG_PATH)
-        return [], AlertSettings(enabled=False)
+        return AlertSettings(enabled=False)
 
     with open(_CONFIG_PATH, "r", encoding="utf-8") as f:
         data = yaml.safe_load(f) or {}
 
-    # Holdings
-    holdings_raw = data.get("holdings", {})
-    holdings: list[HoldingInfo] = []
-    for ticker, info in holdings_raw.items():
-        if not isinstance(info, dict):
-            continue
-        holdings.append(
-            HoldingInfo(
-                ticker=ticker,
-                name=info.get("name", ticker),
-                buy_price=float(info.get("buy_price", 0)),
-                quantity=int(info.get("quantity", 0)),
-            )
-        )
-
-    # Alert settings
     alert_raw = data.get("alert_settings", {})
-    settings = AlertSettings(
+    return AlertSettings(
         enabled=alert_raw.get("enabled", True),
         scan_interval_seconds=alert_raw.get("scan_interval_seconds", 60),
         stop_loss_pct=alert_raw.get("stop_loss_pct", 0.20),
@@ -85,6 +93,11 @@ def load_config() -> tuple[list[HoldingInfo], AlertSettings]:
         channels=alert_raw.get("channels", ["telegram"]),
     )
 
+
+def load_config() -> tuple[list[HoldingInfo], AlertSettings]:
+    """Load holdings from DB and alert settings from YAML."""
+    holdings = _load_holdings_from_db()
+    settings = _load_alert_settings()
     return holdings, settings
 
 

--- a/tests/test_portfolio_alerts.py
+++ b/tests/test_portfolio_alerts.py
@@ -17,7 +17,9 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 os.environ["DATABASE_URL"] = "sqlite:///test_portfolio_alerts.db"
 
 from api.database import Base, SessionLocal, engine
+import api.models.portfolio  # noqa: F401
 import api.models.portfolio_alert  # noqa: F401
+from api.models.portfolio import Holding
 from api.models.portfolio_alert import PortfolioAlertHistory
 
 
@@ -26,10 +28,11 @@ def _fresh_tables():
     """Create tables before each test, truncate after."""
     Base.metadata.create_all(bind=engine)
     yield
-    # Truncate alert history between tests
+    # Truncate between tests
     db = SessionLocal()
     try:
         db.query(PortfolioAlertHistory).delete()
+        db.query(Holding).delete()
         db.commit()
     finally:
         db.close()
@@ -94,6 +97,54 @@ class TestDedupLogic:
         history = get_history(limit=10)
         assert history.total_count == 2
         assert len(history.alerts) == 2
+
+
+# ---------------------------------------------------------------------------
+# Tests — DB holdings loading
+# ---------------------------------------------------------------------------
+
+
+class TestDBHoldings:
+    def test_load_holdings_from_db(self):
+        from api.services.portfolio_alert_scanner import _load_holdings_from_db
+
+        # Insert a holding into DB
+        db = SessionLocal()
+        db.add(Holding(ticker="005930.KS", name="삼성전자", quantity=10, avg_price=70000, currency="KRW"))
+        db.commit()
+        db.close()
+
+        holdings = _load_holdings_from_db()
+        assert len(holdings) == 1
+        assert holdings[0].ticker == "005930.KS"
+        assert holdings[0].name == "삼성전자"
+        assert holdings[0].buy_price == 70000
+        assert holdings[0].quantity == 10
+
+    def test_zero_quantity_excluded(self):
+        from api.services.portfolio_alert_scanner import _load_holdings_from_db
+
+        db = SessionLocal()
+        db.add(Holding(ticker="AAPL", name="Apple", quantity=10, avg_price=150, currency="USD"))
+        db.add(Holding(ticker="SOLD", name="Sold Stock", quantity=0, avg_price=100, currency="USD"))
+        db.commit()
+        db.close()
+
+        holdings = _load_holdings_from_db()
+        assert len(holdings) == 1
+        assert holdings[0].ticker == "AAPL"
+
+    def test_load_config_uses_db(self):
+        from api.services.portfolio_alert_scanner import load_config
+
+        db = SessionLocal()
+        db.add(Holding(ticker="MSFT", name="Microsoft", quantity=5, avg_price=400, currency="USD"))
+        db.commit()
+        db.close()
+
+        holdings, settings = load_config()
+        assert len(holdings) == 1
+        assert holdings[0].ticker == "MSFT"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Scanner was reading holdings from `config/portfolio.yaml` (static file), causing false alerts for sold stocks
- Now queries `Holding` table (where `quantity > 0`) as source of truth
- Alert settings still loaded from YAML (intentional — config, not state)
- Added 3 new tests for DB holdings loading (including zero-quantity exclusion)

## Test plan
- [x] `pytest tests/test_portfolio_alerts.py` — 14/14 pass
- [ ] Sell a stock → scanner no longer sends alerts for it
- [ ] Add new holding via UI → scanner picks it up automatically

Closes #1316

🤖 Generated with [Claude Code](https://claude.com/claude-code)