### PR TITLE
feat(web): add 240-day MA line to analysis chart

### DIFF
--- a/web/src/components/charts/CandleChart.tsx
+++ b/web/src/components/charts/CandleChart.tsx
@@ -36,6 +36,7 @@ const MA_CONFIGS = [
   { period: 20, color: '#3b82f6', lineWidth: 1 as LineWidth },
   { period: 60, color: '#8b5cf6', lineWidth: 1 as LineWidth },
   { period: 120, color: '#ef4444', lineWidth: 1 as LineWidth },
+  { period: 240, color: '#10b981', lineWidth: 1 as LineWidth },
 ] as const;
 
 /** Calculate Simple Moving Average from OHLCV data */


### PR DESCRIPTION
## Summary
- Added SMA 240 (green `#10b981`) to `MA_CONFIGS` in `CandleChart.tsx`
- Line auto-hides when data is insufficient (e.g., period < 1y)
- Visible when user selects 1Y or 2Y period

## Test plan
- [x] `npm run build` passes
- [ ] Open `/analysis/AAPL` → select 1Y period → 240-day green MA line visible
- [ ] Select 6M period → 240-day line not shown (insufficient data)
- [ ] Legend shows all 5 MA periods with correct colors

Closes #1318

🤖 Generated with [Claude Code](https://claude.com/claude-code)