### PR TITLE
fix: show company names in strategy stream results

### DIFF
--- a/api/services/strategy_service.py
+++ b/api/services/strategy_service.py
@@ -1312,6 +1312,7 @@ def execute_strategy(
         max_workers=5,
         use_full_universe=True,
         use_cache=True,
+        stock_names=symbols_dict,
     )
 
     eval_started_at = time.perf_counter()


### PR DESCRIPTION
## Summary
- `StockScreener` in `execute_strategy()` was created without `stock_names` parameter
- This forced per-stock `yf.Ticker().info` calls for US tickers, which are slow and often fail — returning ticker code as name
- `symbols_dict` from `_get_symbols_for_universes()` already contains `{ticker: company_name}` mapping
- Now passed to the screener as `stock_names=symbols_dict` (same pattern as `screening_service.py`)
- **Bonus**: eliminates N+1 yfinance API calls during strategy execution, improving speed

## Test plan
- [ ] Run strategy via streaming → stock names show correctly (not ticker codes)
- [ ] Run strategy via non-streaming → same result as before
- [ ] Both KR and US universes show proper names

Closes #1320

🤖 Generated with [Claude Code](https://claude.com/claude-code)