### PR TITLE
fix: resolve duplicate universes kwarg in strategy run endpoint

### DIFF
--- a/api/routers/strategy.py
+++ b/api/routers/strategy.py
@@ -570,7 +570,8 @@ async def run_strategy(request: StrategyExecuteRequest) -> StrategyExecuteRespon
             ranking_config=request.ranking_config,
         )
         response_universes = result.get("universes") or request.universe_overrides or [result["universe"]]
-        return StrategyExecuteResponse(**result, universes=response_universes)
+        payload = {**result, "universes": response_universes}
+        return StrategyExecuteResponse(**payload)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:


### PR DESCRIPTION
## Summary
- `StrategyExecuteResponse(**result, universes=response_universes)` raised `got multiple values for keyword argument 'universes'` because `result` dict already contains `universes` key
- Changed to dict merge pattern: `{**result, "universes": response_universes}` — latter value wins

## Codex review
- LGTM — consistent with `/run/stream` path which already uses this pattern

## Test plan
- [ ] POST `/api/strategy/run` with a valid graph → returns results without 500 error
- [ ] `universes` field in response matches expected value

Closes #1334

🤖 Generated with [Claude Code](https://claude.com/claude-code)