### PR TITLE
fix(web): set lang on date input for locale-aware picker labels

### DIFF
--- a/web/src/components/screening/DateSelector.tsx
+++ b/web/src/components/screening/DateSelector.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useMemo } from 'react';
 import { RotateCcw } from 'lucide-react';
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 
 interface DateSelectorProps {
   /** null means "today" (latest available data) */
@@ -25,6 +25,7 @@ export default function DateSelector({
   disabled = false,
 }: DateSelectorProps) {
   const t = useTranslations('screening');
+  const locale = useLocale();
   const today = useMemo(() => getTodayString(), []);
   const isToday = value === null;
 
@@ -46,6 +47,7 @@ export default function DateSelector({
       <div className="flex items-center gap-2">
         <input
           type="date"
+          lang={locale}
           value={value ?? today}
           max={today}
           onChange={handleDateChange}


### PR DESCRIPTION
## Summary
- Native `<input type="date">` renders picker labels based on browser/OS locale
- Added `lang={locale}` attribute — works in Firefox, but **not Chrome** (Chrome follows OS locale)
- **This is a partial mitigation, not a full fix**

## Limitation
Chrome (majority browser) ignores `lang` on date inputs. Full fix requires a locale-aware custom date picker (e.g., react-day-picker).

**Note: This PR does NOT close #1331.** Issue remains open for a complete solution.

## Test plan
- [x] Build passes
- [ ] Firefox: date picker respects app locale
- [ ] Chrome: no regression (still uses OS locale as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)