### PR TITLE
feat(notification): add Slack webhook + unified dispatcher

### DIFF
--- a/api/routers/settings.py
+++ b/api/routers/settings.py
@@ -20,6 +20,11 @@ from api.schemas.telegram import (
     TelegramSettingsResponse,
     TelegramTestResponse,
 )
+from api.schemas.slack import (
+    SlackSettingsRequest,
+    SlackSettingsResponse,
+    SlackTestResponse,
+)
 from api.services.broker_service import BrokerService
 from api.services.broker_settings_service import get_broker_settings_service
 
@@ -276,3 +281,52 @@ def test_telegram_notification() -> TelegramTestResponse:
         success=False,
         message="Failed to send test message. Check your bot token and chat ID.",
     )
+
+
+# ------------------------------------------------------------------
+# Slack notification settings
+# ------------------------------------------------------------------
+
+@router.get(
+    "/slack",
+    response_model=SlackSettingsResponse,
+    summary="Get Slack notification settings",
+)
+def get_slack_settings() -> SlackSettingsResponse:
+    view = _settings_service.get_slack_settings()
+    return SlackSettingsResponse(
+        has_webhook_url=view.has_webhook_url,
+        channel_name=view.channel_name,
+        enabled=view.enabled,
+        updated_at=view.updated_at,
+    )
+
+
+@router.put(
+    "/slack",
+    response_model=SlackSettingsResponse,
+    summary="Save Slack notification settings",
+)
+def save_slack_settings(request: SlackSettingsRequest) -> SlackSettingsResponse:
+    try:
+        view = _settings_service.save_slack_settings(request.model_dump())
+        return SlackSettingsResponse(
+            has_webhook_url=view.has_webhook_url,
+            channel_name=view.channel_name,
+            enabled=view.enabled,
+            updated_at=view.updated_at,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+
+@router.post(
+    "/slack/test",
+    response_model=SlackTestResponse,
+    summary="Send test Slack notification",
+)
+def test_slack_notification() -> SlackTestResponse:
+    ok = _settings_service.send_slack_test()
+    if ok:
+        return SlackTestResponse(success=True, message="Test message sent to Slack")
+    return SlackTestResponse(success=False, message="Failed to send. Check webhook URL.")

--- a/api/schemas/slack.py
+++ b/api/schemas/slack.py
@@ -1,0 +1,23 @@
+"""Slack notification settings schemas."""
+
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class SlackSettingsRequest(BaseModel):
+    webhook_url: Optional[str] = None
+    channel_name: Optional[str] = None
+    enabled: bool = False
+
+
+class SlackSettingsResponse(BaseModel):
+    has_webhook_url: bool = False
+    channel_name: Optional[str] = None
+    enabled: bool = False
+    updated_at: Optional[str] = None
+
+
+class SlackTestResponse(BaseModel):
+    success: bool
+    message: str = ""

--- a/api/schemas/strategy_alert.py
+++ b/api/schemas/strategy_alert.py
@@ -8,7 +8,7 @@ from typing import List, Optional
 
 from pydantic import BaseModel, Field, field_validator
 
-VALID_CHANNELS = {"webhook", "in_app", "telegram"}
+VALID_CHANNELS = {"webhook", "in_app", "telegram", "slack"}
 
 
 class AlertConfigUpsertRequest(BaseModel):

--- a/api/services/broker_settings_service.py
+++ b/api/services/broker_settings_service.py
@@ -54,6 +54,14 @@ class TelegramSettingsView:
     updated_at: str | None
 
 
+@dataclass
+class SlackSettingsView:
+    has_webhook_url: bool
+    channel_name: str | None
+    enabled: bool
+    updated_at: str | None
+
+
 class BrokerSettingsService:
     """Manage broker config persistence and dynamic adapter refresh."""
 
@@ -443,6 +451,74 @@ class BrokerSettingsService:
         except Exception:
             logger.warning("Telegram sendMessage failed", exc_info=True)
             return False
+
+
+    # ------------------------------------------------------------------
+    # Slack settings
+    # ------------------------------------------------------------------
+
+    _SLACK_WEBHOOK_PATTERN = re.compile(r"^https://hooks\.slack\.com/services/.+")
+
+    def get_slack_settings(self) -> SlackSettingsView:
+        db = SessionLocal()
+        try:
+            row = db.get(BrokerCredential, "slack")
+            if not row:
+                return SlackSettingsView(has_webhook_url=False, channel_name=None, enabled=False, updated_at=None)
+            data = json.loads(row.config_json)
+            return SlackSettingsView(
+                has_webhook_url=bool(data.get("webhook_url_encrypted")),
+                channel_name=data.get("channel_name"),
+                enabled=data.get("enabled", False),
+                updated_at=row.updated_at.isoformat() if row.updated_at else None,
+            )
+        finally:
+            db.close()
+
+    def save_slack_settings(self, payload: dict[str, Any]) -> SlackSettingsView:
+        webhook_url = (payload.get("webhook_url") or "").strip()
+        channel_name = (payload.get("channel_name") or "").strip()
+        enabled = bool(payload.get("enabled", False))
+
+        if webhook_url and not self._SLACK_WEBHOOK_PATTERN.match(webhook_url):
+            raise ValueError("Invalid Slack webhook URL. Must start with https://hooks.slack.com/services/")
+
+        db = SessionLocal()
+        try:
+            row = db.get(BrokerCredential, "slack")
+            if row:
+                data = json.loads(row.config_json)
+            else:
+                data = {}
+
+            if webhook_url:
+                data["webhook_url_encrypted"] = self._encrypt(webhook_url)
+            data["channel_name"] = channel_name
+            data["enabled"] = enabled
+
+            if row:
+                row.config_json = json.dumps(data)
+            else:
+                row = BrokerCredential(
+                    broker="slack",
+                    config_json=json.dumps(data),
+                )
+                db.add(row)
+            db.commit()
+            db.refresh(row)
+            return SlackSettingsView(
+                has_webhook_url=bool(data.get("webhook_url_encrypted")),
+                channel_name=data.get("channel_name"),
+                enabled=data.get("enabled", False),
+                updated_at=row.updated_at.isoformat() if row.updated_at else None,
+            )
+        finally:
+            db.close()
+
+    def send_slack_test(self, message: str = "Quant Investment test notification") -> bool:
+        """Send a test message via Slack webhook."""
+        from api.services.notification_dispatcher import _send_slack
+        return _send_slack(self, message)
 
 
 _broker_settings_service = BrokerSettingsService()

--- a/api/services/notification_dispatcher.py
+++ b/api/services/notification_dispatcher.py
@@ -1,0 +1,145 @@
+"""
+Unified notification dispatcher.
+
+Single entry point for dispatching messages to configured channels
+(Telegram, Slack). Eliminates duplicated send logic across
+portfolio_alert_service and strategy_alert_service.
+"""
+
+import json
+import logging
+import re
+import time
+import urllib.error
+import urllib.request
+from typing import Dict, Optional
+
+from api.database import SessionLocal
+
+logger = logging.getLogger(__name__)
+
+# Slack webhook URL must match this pattern (SSRF prevention)
+_SLACK_WEBHOOK_PATTERN = re.compile(r"^https://hooks\.slack\.com/services/.+")
+
+# Rate limit: minimum seconds between Slack messages
+_SLACK_RATE_LIMIT_SEC = 1.0
+_last_slack_send_time: float = 0.0
+
+
+def dispatch(message: str, channels: Optional[list[str]] = None) -> Dict[str, bool]:
+    """Dispatch a message to all enabled notification channels.
+
+    Args:
+        message: The message text to send.
+        channels: Optional explicit channel list. If None, sends to all
+                  enabled channels found in DB settings.
+
+    Returns:
+        Dict mapping channel name to success bool, e.g. {"telegram": True, "slack": False}
+    """
+    results: Dict[str, bool] = {}
+
+    try:
+        from api.services.broker_settings_service import get_broker_settings_service
+        svc = get_broker_settings_service()
+    except Exception:
+        logger.warning("Could not load broker settings service", exc_info=True)
+        return results
+
+    # Telegram
+    if channels is None or "telegram" in channels:
+        results["telegram"] = _send_telegram(svc, message)
+
+    # Slack
+    if channels is None or "slack" in channels:
+        results["slack"] = _send_slack(svc, message)
+
+    return results
+
+
+def _send_telegram(svc: object, message: str) -> bool:
+    """Send via Telegram using saved bot settings."""
+    try:
+        view = svc.get_telegram_settings()
+        if not (view.enabled and view.has_bot_token and view.chat_id):
+            logger.debug("Telegram not configured or disabled, skipping")
+            return False
+
+        from api.models.broker_credential import BrokerCredential
+
+        db = SessionLocal()
+        try:
+            row = db.get(BrokerCredential, "telegram")
+            if not row:
+                return False
+            data = json.loads(row.config_json)
+            encrypted_token = data.get("bot_token_encrypted", "")
+            svc.send_telegram_message(view.chat_id, encrypted_token, message)
+            logger.info("Notification sent via Telegram")
+            return True
+        finally:
+            db.close()
+    except Exception:
+        logger.warning("Failed to send via Telegram", exc_info=True)
+        return False
+
+
+def _send_slack(svc: object, message: str) -> bool:
+    """Send via Slack Incoming Webhook using saved settings."""
+    global _last_slack_send_time
+    try:
+        from api.models.broker_credential import BrokerCredential
+
+        db = SessionLocal()
+        try:
+            row = db.get(BrokerCredential, "slack")
+            if not row:
+                logger.debug("Slack not configured, skipping")
+                return False
+
+            data = json.loads(row.config_json)
+            if not data.get("enabled", False):
+                logger.debug("Slack disabled, skipping")
+                return False
+
+            encrypted_url = data.get("webhook_url_encrypted", "")
+            if not encrypted_url:
+                logger.debug("Slack webhook URL not set, skipping")
+                return False
+
+            webhook_url = svc._decrypt(encrypted_url)
+        finally:
+            db.close()
+
+        # SSRF prevention
+        if not _SLACK_WEBHOOK_PATTERN.match(webhook_url):
+            logger.warning("Slack webhook URL rejected (SSRF check): %s...", webhook_url[:40])
+            return False
+
+        # Rate limit
+        now = time.monotonic()
+        elapsed = now - _last_slack_send_time
+        if elapsed < _SLACK_RATE_LIMIT_SEC:
+            time.sleep(_SLACK_RATE_LIMIT_SEC - elapsed)
+
+        payload = json.dumps({"text": message}).encode("utf-8")
+        req = urllib.request.Request(
+            webhook_url,
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            _last_slack_send_time = time.monotonic()
+            logger.info("Notification sent via Slack")
+            return resp.status == 200
+
+    except urllib.error.HTTPError as exc:
+        if exc.code in (403, 410):
+            logger.warning("Slack webhook expired or revoked (HTTP %d)", exc.code)
+        else:
+            logger.warning("Slack API error: HTTP %d", exc.code)
+        return False
+    except Exception:
+        logger.warning("Failed to send via Slack", exc_info=True)
+        return False

--- a/api/services/portfolio_alert_scanner.py
+++ b/api/services/portfolio_alert_scanner.py
@@ -336,13 +336,13 @@ class PortfolioAlertScanner:
             # Stop loss
             if change_pct <= -settings.stop_loss_pct:
                 msg = _format_sell_message(holding, "stop_loss", price, change_pct)
-                if record_and_send(holding.ticker, "stop_loss", msg, price):
+                if record_and_send(holding.ticker, "stop_loss", msg, price, channels=settings.channels):
                     alerts_fired += 1
 
             # Take profit
             if change_pct >= settings.take_profit_pct:
                 msg = _format_sell_message(holding, "take_profit", price, change_pct)
-                if record_and_send(holding.ticker, "take_profit", msg, price):
+                if record_and_send(holding.ticker, "take_profit", msg, price, channels=settings.channels):
                     alerts_fired += 1
 
         if alerts_fired:

--- a/api/services/portfolio_alert_service.py
+++ b/api/services/portfolio_alert_service.py
@@ -51,8 +51,9 @@ def record_and_send(
     signal_type: str,
     message: str,
     price: Optional[float] = None,
+    channels: Optional[list[str]] = None,
 ) -> bool:
-    """Record alert and send via Telegram. Returns False if already sent today."""
+    """Record alert and send to configured channels. Returns False if already sent today."""
     today = date.today()
     now = datetime.utcnow()  # noqa: DTZ003
 
@@ -75,35 +76,10 @@ def record_and_send(
     finally:
         db.close()
 
-    # Dispatch to Telegram
-    _send_telegram(message)
+    # Dispatch to specified channels (or all enabled if not specified)
+    from api.services.notification_dispatcher import dispatch
+    dispatch(message, channels=channels)
     return True
-
-
-def _send_telegram(message: str) -> None:
-    """Send message via Telegram using saved bot settings."""
-    try:
-        from api.models.broker_credential import BrokerCredential
-        from api.services.broker_settings_service import get_broker_settings_service
-
-        svc = get_broker_settings_service()
-        view = svc.get_telegram_settings()
-        if not (view.enabled and view.has_bot_token and view.chat_id):
-            logger.debug("Telegram not configured or disabled, skipping")
-            return
-
-        db = SessionLocal()
-        try:
-            row = db.get(BrokerCredential, "telegram")
-            if row:
-                data = json.loads(row.config_json)
-                encrypted_token = data.get("bot_token_encrypted", "")
-                svc.send_telegram_message(view.chat_id, encrypted_token, message)
-                logger.info("Portfolio alert sent via Telegram")
-        finally:
-            db.close()
-    except Exception:
-        logger.warning("Failed to send portfolio alert via Telegram", exc_info=True)
 
 
 def get_history(limit: int = 50) -> PortfolioAlertHistoryResponse:

--- a/api/services/strategy_alert_service.py
+++ b/api/services/strategy_alert_service.py
@@ -172,38 +172,21 @@ def fire_alert(
     entry = record_alert(strategy_id, ticker, matched_conditions, price_at_signal)
     channels = channels or []
 
-    if "telegram" in channels:
+    if channels:
         try:
-            from api.models.broker_credential import BrokerCredential
-            from api.services.broker_settings_service import get_broker_settings_service
+            from api.services.notification_dispatcher import dispatch
 
-            import json as _json
-
-            svc = get_broker_settings_service()
-            view = svc.get_telegram_settings()
-            if view.enabled and view.has_bot_token and view.chat_id:
-                db = SessionLocal()
-                try:
-                    row = db.get(BrokerCredential, "telegram")
-                    if row:
-                        data = _json.loads(row.config_json)
-                        conditions_str = ", ".join(str(c) for c in matched_conditions)
-                        price_str = f"{price_at_signal}" if price_at_signal is not None else "N/A"
-                        msg = (
-                            f"Signal: {ticker}\n"
-                            f"Conditions: {conditions_str}\n"
-                            f"Price: {price_str}"
-                        )
-                        svc.send_telegram_message(
-                            view.chat_id,
-                            data.get("bot_token_encrypted", ""),
-                            msg,
-                        )
-                finally:
-                    db.close()
+            conditions_str = ", ".join(str(c) for c in matched_conditions)
+            price_str = f"{price_at_signal}" if price_at_signal is not None else "N/A"
+            msg = (
+                f"Signal: {ticker}\n"
+                f"Conditions: {conditions_str}\n"
+                f"Price: {price_str}"
+            )
+            dispatch(msg, channels=channels)
         except Exception:
             logger.warning(
-                "Failed to send Telegram alert for %s/%s",
+                "Failed to dispatch alert for %s/%s",
                 strategy_id,
                 ticker,
                 exc_info=True,

--- a/docs/works/20260322_slack_notification.md
+++ b/docs/works/20260322_slack_notification.md
@@ -1,0 +1,50 @@
+# Slack Notification Integration
+
+Issue: #1353
+
+## Decision Log
+
+### Round 1 — Planning Proposal
+- Slack Incoming Webhook으로 알림 채널 추가
+- 기존 `portfolio/notifiers/slack.py`의 SlackNotifier 활용
+- 텔레그램 패턴 복제
+
+### Round 2 — Dev Team Review
+- **수용**: 공통 dispatcher 레이어 필요 (텔레그램 코드 중복 해소)
+- **수용**: Webhook URL 암호화 + SSRF 방지 필수
+- **수용**: SlackNotifier rate limit 추가
+- **타협**: BrokerCredential 테이블 Phase 1 재사용, Phase 2 분리
+- **반론 수용**: portfolio.yaml vs DB 분리는 의도적 — 문서화로 충분
+
+### Round 3 — Final Agreement
+- notification_dispatcher.py 신설 (통합 발송 레이어)
+- 기존 텔레그램 코드도 dispatcher 경유로 리팩토링
+- 일정은 개발팀이 판단
+
+---
+
+## Execution Units
+
+### Unit 1: notification_dispatcher.py + telegram refactor
+- `api/services/notification_dispatcher.py` 신설
+- `portfolio/notifiers/MultiNotifier` 패턴 활용
+- `portfolio_alert_service._send_telegram()` → dispatcher 경유
+- `strategy_alert_service.fire_alert()` 내 telegram 블록 → dispatcher 경유
+- 기존 텔레그램 기능 회귀 없음 확인
+
+### Unit 2: SlackNotifier 보강
+- `portfolio/notifiers/slack.py`에 rate_limit 추가
+- HTTP 403/410 응답 → webhook 만료 로그
+- TelegramNotifier 패턴 참고
+
+### Unit 3: Slack settings API
+- `BrokerSettingsService`에 slack 메서드 추가
+- `GET/PUT /api/settings/slack`, `POST /api/settings/slack/test`
+- Webhook URL Fernet 암호화
+- SSRF: `https://hooks.slack.com/services/` 화이트리스트
+- `VALID_CHANNELS`에 `"slack"` 추가
+
+### Unit 4: Frontend — Slack 설정 UI
+- 설정 페이지에 Slack 탭 추가
+- Webhook URL 입력 (password type), 채널명, 활성화 토글, 테스트 버튼
+- i18n (en/ko/zh)

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -3383,7 +3383,13 @@
     "saveTelegram": "Save Telegram Settings",
     "testTelegram": "Send Test Message",
     "telegramSaved": "Telegram settings saved.",
-    "telegramTestSuccess": "Test message sent successfully."
+    "telegramTestSuccess": "Test message sent successfully.",
+    "slackWebhookUrl": "Slack Webhook URL",
+    "slackChannelName": "Channel Name (optional)",
+    "slackSaved": "Slack settings saved.",
+    "slackTestSuccess": "Test message sent to Slack.",
+    "testSlack": "Send Test Message",
+    "saveSlack": "Save Slack Settings"
   },
   "kiwoom": {
     "title": "Kiwoom",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -3383,7 +3383,13 @@
     "saveTelegram": "텔레그램 설정 저장",
     "testTelegram": "테스트 메시지 전송",
     "telegramSaved": "텔레그램 설정이 저장되었습니다.",
-    "telegramTestSuccess": "테스트 메시지가 전송되었습니다."
+    "telegramTestSuccess": "테스트 메시지가 전송되었습니다.",
+    "slackWebhookUrl": "Slack Webhook URL",
+    "slackChannelName": "채널명 (선택)",
+    "slackSaved": "Slack 설정이 저장되었습니다.",
+    "slackTestSuccess": "Slack으로 테스트 메시지가 전송되었습니다.",
+    "testSlack": "테스트 메시지 전송",
+    "saveSlack": "Slack 설정 저장"
   },
   "kiwoom": {
     "title": "키움",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -3383,7 +3383,13 @@
     "saveTelegram": "保存 Telegram 设置",
     "testTelegram": "发送测试消息",
     "telegramSaved": "Telegram 设置已保存。",
-    "telegramTestSuccess": "测试消息发送成功。"
+    "telegramTestSuccess": "测试消息发送成功。",
+    "slackWebhookUrl": "Slack Webhook URL",
+    "slackChannelName": "频道名称 (可选)",
+    "slackSaved": "Slack 设置已保存。",
+    "slackTestSuccess": "Slack 测试消息发送成功。",
+    "testSlack": "发送测试消息",
+    "saveSlack": "保存 Slack 设置"
   },
   "kiwoom": {
     "title": "Kiwoom",

--- a/web/src/app/[locale]/settings/page.tsx
+++ b/web/src/app/[locale]/settings/page.tsx
@@ -21,6 +21,10 @@ import {
   getTelegramSettings,
   saveTelegramSettings,
   testTelegramNotification,
+  getSlackSettings,
+  saveSlackSettings,
+  testSlackNotification,
+  type SlackSettingsUpsert,
 } from '@/lib/api';
 import type { BrokerConnectionStatus, BrokerConnectionState, TigerSettingsUpsert, IBKRSettingsUpsert, TelegramSettingsUpsert } from '@/lib/types';
 
@@ -71,6 +75,15 @@ export default function SettingsPage() {
   const [savingTelegram, setSavingTelegram] = useState(false);
   const [testingTelegram, setTestingTelegram] = useState(false);
   const [telegramMessage, setTelegramMessage] = useState<string | null>(null);
+  const [slackForm, setSlackForm] = useState<SlackSettingsUpsert>({
+    webhook_url: '',
+    channel_name: '',
+    enabled: true,
+  });
+  const [savingSlack, setSavingSlack] = useState(false);
+  const [testingSlack, setTestingSlack] = useState(false);
+  const [slackMessage, setSlackMessage] = useState<string | null>(null);
+  const [slackHasWebhookUrl, setSlackHasWebhookUrl] = useState(false);
 
   const statusTextKey: Record<BrokerConnectionState, string> = {
     connected: 'connected',
@@ -94,11 +107,12 @@ export default function SettingsPage() {
       setLoadingBrokers(true);
       setBrokerError(null);
       try {
-        const [brokerResult, tigerResult, ibkrResult, telegramResult] = await Promise.allSettled([
+        const [brokerResult, tigerResult, ibkrResult, telegramResult, slackResult] = await Promise.allSettled([
           getSettingsBrokerStatuses(),
           getTigerSettings(),
           getIbkrSettings(),
           getTelegramSettings(),
+          getSlackSettings(),
         ]);
         if (brokerResult.status === 'fulfilled') {
           setBrokers(brokerResult.value);
@@ -132,8 +146,18 @@ export default function SettingsPage() {
           }));
           setTelegramHasBotToken(tgSettings.has_bot_token);
         }
+        if (slackResult.status === 'fulfilled') {
+          const slackSettings = slackResult.value;
+          setSlackForm((prev) => ({
+            ...prev,
+            webhook_url: '',
+            channel_name: slackSettings.channel_name ?? '',
+            enabled: slackSettings.enabled,
+          }));
+          setSlackHasWebhookUrl(slackSettings.has_webhook_url);
+        }
         // Show error only if all requests failed
-        const allFailed = [brokerResult, tigerResult, ibkrResult, telegramResult].every(
+        const allFailed = [brokerResult, tigerResult, ibkrResult, telegramResult, slackResult].every(
           (r) => r.status === 'rejected'
         );
         if (allFailed) {
@@ -283,6 +307,44 @@ export default function SettingsPage() {
       setTelegramMessage(e instanceof Error ? e.message : t('testFailed'));
     } finally {
       setTestingTelegram(false);
+    }
+  };
+
+  const handleSaveSlack = async () => {
+    setSavingSlack(true);
+    setSlackMessage(null);
+    try {
+      const payload: SlackSettingsUpsert = {
+        webhook_url: slackForm.webhook_url?.trim() || undefined,
+        channel_name: slackForm.channel_name?.trim() || undefined,
+        enabled: slackForm.enabled,
+      };
+      const response = await saveSlackSettings(payload);
+      setSlackHasWebhookUrl(response.has_webhook_url);
+      setSlackForm((prev) => ({
+        ...prev,
+        webhook_url: '',
+        channel_name: response.channel_name ?? '',
+        enabled: response.enabled,
+      }));
+      setSlackMessage(t('slackSaved'));
+    } catch (e) {
+      setSlackMessage(e instanceof Error ? e.message : t('saveFailed'));
+    } finally {
+      setSavingSlack(false);
+    }
+  };
+
+  const handleTestSlack = async () => {
+    setTestingSlack(true);
+    setSlackMessage(null);
+    try {
+      const result = await testSlackNotification();
+      setSlackMessage(result.success ? t('slackTestSuccess') : result.message);
+    } catch (e) {
+      setSlackMessage(e instanceof Error ? e.message : t('testFailed'));
+    } finally {
+      setTestingSlack(false);
     }
   };
 
@@ -667,6 +729,75 @@ export default function SettingsPage() {
               className="rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm font-medium text-[var(--foreground)] hover:bg-[var(--background-secondary)] disabled:opacity-60"
             >
               {testingTelegram ? t('testing') : t('testTelegram')}
+            </button>
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-[var(--border)] bg-[var(--background-secondary)] p-4">
+          <div className="flex items-start gap-4">
+            <div className="rounded-xl bg-purple-50 p-3 text-purple-600 dark:bg-purple-900/20 dark:text-purple-400">
+              <Bell className="h-5 w-5" />
+            </div>
+            <div className="flex-1">
+              <h3 className="font-medium text-[var(--foreground)]">Slack</h3>
+              <p className="mt-1 text-sm text-[var(--foreground-muted)]">Configure Slack notification delivery.</p>
+            </div>
+          </div>
+
+          <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <label className="text-sm text-[var(--foreground-muted)]">
+              {t('slackWebhookUrl')}
+              <input
+                type="password"
+                value={slackForm.webhook_url ?? ''}
+                onChange={(e) => setSlackForm((prev) => ({ ...prev, webhook_url: e.target.value }))}
+                placeholder={slackHasWebhookUrl ? '••••••••••••••••••••••••••••••••' : 'https://hooks.slack.com/services/...'}
+                className="mt-1 w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)]"
+              />
+              <span className="mt-1 block text-xs text-[var(--foreground-muted)]">
+                {slackHasWebhookUrl ? t('telegramBotTokenStored') : t('telegramBotTokenMissing')}
+              </span>
+            </label>
+            <label className="text-sm text-[var(--foreground-muted)]">
+              {t('slackChannelName')}
+              <input
+                value={slackForm.channel_name ?? ''}
+                onChange={(e) => setSlackForm((prev) => ({ ...prev, channel_name: e.target.value }))}
+                placeholder="#alerts"
+                className="mt-1 w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)]"
+              />
+            </label>
+          </div>
+
+          <label className="mt-3 flex items-center gap-2 text-sm text-[var(--foreground)]">
+            <input
+              type="checkbox"
+              checked={slackForm.enabled}
+              onChange={(e) => setSlackForm((prev) => ({ ...prev, enabled: e.target.checked }))}
+            />
+            Enabled
+          </label>
+
+          {slackMessage && (
+            <p className="mt-3 text-sm text-[var(--foreground-muted)]">{slackMessage}</p>
+          )}
+
+          <div className="mt-4 flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={handleSaveSlack}
+              disabled={savingSlack}
+              className="rounded-lg bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-60"
+            >
+              {savingSlack ? t('saving') : t('saveSlack')}
+            </button>
+            <button
+              type="button"
+              onClick={handleTestSlack}
+              disabled={testingSlack}
+              className="rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm font-medium text-[var(--foreground)] hover:bg-[var(--background-secondary)] disabled:opacity-60"
+            >
+              {testingSlack ? t('testing') : t('testSlack')}
             </button>
           </div>
         </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -959,6 +959,43 @@ export async function testTelegramNotification(): Promise<TelegramTestResult> {
   });
 }
 
+// Slack notification settings
+
+export interface SlackSettings {
+  has_webhook_url: boolean;
+  channel_name: string | null;
+  enabled: boolean;
+  updated_at: string | null;
+}
+
+export interface SlackSettingsUpsert {
+  webhook_url?: string;
+  channel_name?: string;
+  enabled: boolean;
+}
+
+export interface SlackTestResult {
+  success: boolean;
+  message: string;
+}
+
+export async function getSlackSettings(): Promise<SlackSettings> {
+  return fetchApi<SlackSettings>('/api/settings/slack');
+}
+
+export async function saveSlackSettings(payload: SlackSettingsUpsert): Promise<SlackSettings> {
+  return fetchApi<SlackSettings>('/api/settings/slack', {
+    method: 'PUT',
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function testSlackNotification(): Promise<SlackTestResult> {
+  return fetchApi<SlackTestResult>('/api/settings/slack/test', {
+    method: 'POST',
+  });
+}
+
 export async function getBrokerConnectionStatus(
   broker: string
 ): Promise<BrokerConnectionStatus> {


### PR DESCRIPTION
## Summary

Adds Slack Incoming Webhook as a notification channel and introduces a unified dispatcher that eliminates duplicated telegram send logic.

### What changed

**New: `api/services/notification_dispatcher.py`**
- Single entry point: `dispatch(message, channels=None)`
- Telegram + Slack dispatch from one place
- SSRF prevention: only `hooks.slack.com` URLs accepted
- Rate limit: 1s minimum between Slack messages
- Webhook expiry detection (HTTP 403/410 → warning log)

**Refactored: portfolio_alert_service + strategy_alert_service**
- Removed duplicated `_send_telegram()` from both services
- Both now call `dispatcher.dispatch(message, channels)`
- Portfolio scanner passes `settings.channels` to respect user config

**New: Slack settings API**
- `GET/PUT /api/settings/slack` + `POST /api/settings/slack/test`
- Webhook URL encrypted with Fernet (same as telegram bot token)
- Stored in BrokerCredential table (`broker="slack"`)

**New: Slack settings UI**
- Settings page: Slack card with webhook URL, channel name, enable toggle, test button
- i18n keys for en/ko/zh

### Codex review feedback addressed
- Fixed: BrokerCredential `created_at` doesn't exist → removed from constructor
- Fixed: Portfolio alerts now pass `channels` from scanner settings to dispatcher
- Noted: `channel_name` is display-only (Slack webhooks are bound to a channel at creation time)

## Test plan
- [ ] Save Slack webhook URL → encrypted in DB
- [ ] Test button sends message to Slack channel
- [ ] Portfolio alert fires → goes to both telegram + slack (if both enabled)
- [ ] Disable slack → alerts only go to telegram
- [ ] Invalid webhook URL rejected (SSRF check)
- [ ] Existing telegram-only flow works unchanged

Closes #1353

🤖 Generated with [Claude Code](https://claude.com/claude-code)