### PR TITLE
fix(web): fix CandleChart i18n crash and OHLC zero-value rendering

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -3451,6 +3451,7 @@
     "ma20Label": "20D Mid-term",
     "ma60Label": "60D Long-term",
     "ma120Label": "120D Very long-term",
+    "ma240Label": "240D Indicators",
     "rsiScaleOversold": "0 (Oversold)",
     "rsiScaleMid": "50",
     "rsiScaleOverbought": "100 (Overbought)",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -3451,6 +3451,7 @@
     "ma20Label": "20일 중기",
     "ma60Label": "60일 장기",
     "ma120Label": "120일 초장기",
+    "ma240Label": "240일 보조지표",
     "rsiScaleOversold": "0 (과매도)",
     "rsiScaleMid": "50",
     "rsiScaleOverbought": "100 (과매수)",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -3451,6 +3451,7 @@
     "ma20Label": "20日 中期",
     "ma60Label": "60日 长期",
     "ma120Label": "120日 超长期",
+    "ma240Label": "240日 指标",
     "rsiScaleOversold": "0 (超卖)",
     "rsiScaleMid": "50",
     "rsiScaleOverbought": "100 (超买)",

--- a/web/src/components/charts/CandleChart.tsx
+++ b/web/src/components/charts/CandleChart.tsx
@@ -13,7 +13,7 @@ import { useTranslations } from 'next-intl';
 import type { OHLCVData } from '@/lib/types';
 
 /** MA legend label keys mapped to each config index */
-const MA_LABEL_KEYS = ['ma5Label', 'ma20Label', 'ma60Label', 'ma120Label'] as const;
+const MA_LABEL_KEYS = ['ma5Label', 'ma20Label', 'ma60Label', 'ma120Label', 'ma240Label'] as const;
 
 interface CandleChartProps {
   /** OHLCV data array */
@@ -213,14 +213,15 @@ export default function CandleChart({
   useEffect(() => {
     if (!candleSeriesRef.current || data.length === 0) return;
 
-    // Convert OHLCV data to chart format
-    const candleData: CandlestickData<Time>[] = data.map((item) => ({
-      time: item.time as Time,
-      open: item.open,
-      high: item.high,
-      low: item.low,
-      close: item.close,
-    }));
+    // Convert OHLCV data to chart format, fixing zero OHLC values
+    // Ensures candle invariant: low <= open,close <= high
+    const candleData: CandlestickData<Time>[] = data.map((item) => {
+      const close = item.close;
+      const open = item.open || close;
+      const high = item.high || Math.max(open, close);
+      const low = item.low || Math.min(open, close);
+      return { time: item.time as Time, open, high, low, close };
+    });
 
     candleSeriesRef.current.setData(candleData);
 
@@ -229,7 +230,7 @@ export default function CandleChart({
       const volumeData: HistogramData<Time>[] = data.map((item) => ({
         time: item.time as Time,
         value: item.volume || 0,
-        color: item.close >= item.open ? '#22c55e80' : '#ef444480',
+        color: item.close >= (item.open || item.close) ? '#22c55e80' : '#ef444480',
       }));
 
       volumeSeriesRef.current.setData(volumeData);


### PR DESCRIPTION
## Summary
- CandleChart MA 범례 라벨 i18n 크래시 수정 (#1357)
- OHLC 0값 데이터의 캔들 렌더링 수정 (#1358)

## Changes

### i18n Crash Fix (#1357)
- `MA_CONFIGS`는 5개(5/20/60/120/240일)인데 `MA_LABEL_KEYS`는 4개만 → idx=4에서 `tInd(undefined)` → `split` 에러
- `MA_LABEL_KEYS`에 `ma240Label` 추가
- en/ko/zh 3개 언어에 번역 추가

### OHLC Zero-Value Fix (#1358)
- yfinance/pykrx가 일부 한국 주식에서 open/high/low=0 반환
- 캔들 불변식 보장하며 0값을 close 기반으로 정규화:
  - `open = item.open || close`
  - `high = item.high || Math.max(open, close)`
  - `low = item.low || Math.min(open, close)`
- 볼륨 바 색상도 정규화된 open 기준으로 수정

## Codex Review
- LGTM after addressing: OHLC candle invariant enforcement, volume color consistency, correct ma240Label translations

## Test plan
- [ ] DH오토넥스 (000300.KS) 분석 페이지에서 차트 정상 렌더링 확인
- [ ] 콘솔 에러 없음 확인
- [ ] MA 범례에 5개 라벨 모두 표시 확인
- [ ] 정상 데이터 주식 (AAPL 등)에서 회귀 없음 확인
- [ ] 다크모드 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1357
Closes #1358