### PR TITLE
feat(portfolio): archive, bulk ops, price fix, AI chatbot

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -5,7 +5,7 @@ Manages environment variables and application settings.
 """
 
 from functools import lru_cache
-from typing import List
+from typing import List, Optional
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -42,6 +42,9 @@ class Settings(BaseSettings):
     # Application metadata (애플리케이션 메타데이터)
     app_name: str = "Quant Investment API"
     app_version: str = "0.1.0"
+
+    # Anthropic API key for portfolio chatbot (포트폴리오 챗봇용 Anthropic API 키)
+    anthropic_api_key: Optional[str] = None
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/api/main.py
+++ b/api/main.py
@@ -24,6 +24,7 @@ from api.routers.kiwoom import router as kiwoom_router
 from api.routers.strategy import router as strategy_router
 from api.routers.portfolio_alerts import router as portfolio_alerts_router
 from api.routers.watchlist import router as watchlist_router
+from api.routers.chat import router as chat_router
 
 
 def _backfill_metadata():
@@ -264,6 +265,7 @@ def create_app() -> FastAPI:
     app.include_router(execution_history_router)
     app.include_router(watchlist_router)
     app.include_router(portfolio_alerts_router)
+    app.include_router(chat_router)
 
     # Future routers (추후 추가될 라우터)
     # app.include_router(news_router, prefix="/api/v1")

--- a/api/models/portfolio.py
+++ b/api/models/portfolio.py
@@ -116,3 +116,43 @@ class SellRule(Base):
 
     holding = relationship("Holding", back_populates="sell_rules")
     preset = relationship("SellRulePreset", back_populates="linked_sell_rules")
+
+
+class PortfolioArchive(Base):
+    __tablename__ = "portfolio_archives"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(String(255), nullable=False)
+    description = Column(Text, nullable=True)
+    archived_at = Column(DateTime, default=datetime.utcnow)
+    total_holdings = Column(Integer, nullable=False, default=0)
+
+    items = relationship(
+        "PortfolioArchiveItem",
+        back_populates="archive",
+        cascade="all, delete-orphan",
+    )
+
+
+class PortfolioArchiveItem(Base):
+    __tablename__ = "portfolio_archive_items"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    archive_id = Column(
+        Integer,
+        ForeignKey("portfolio_archives.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    ticker = Column(String(32), nullable=False)
+    name = Column(String(255), nullable=True)
+    quantity = Column(Integer, nullable=False)
+    avg_price = Column(Float, nullable=False)
+    currency = Column(String(8), nullable=False, default="KRW")
+    bought_at = Column(Date, nullable=True)
+    sector = Column(String(128), nullable=True)
+    industry = Column(String(128), nullable=True)
+    country = Column(String(64), nullable=True)
+    exchange = Column(String(32), nullable=True)
+
+    archive = relationship("PortfolioArchive", back_populates="items")

--- a/api/routers/chat.py
+++ b/api/routers/chat.py
@@ -1,0 +1,82 @@
+"""
+Portfolio AI Chatbot router.
+
+Exposes POST /api/chat/portfolio as a Server-Sent Events (SSE) streaming endpoint.
+The endpoint streams Claude's analysis of the user's portfolio in real-time.
+"""
+
+import json
+import logging
+
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import StreamingResponse
+
+from api.config import get_settings
+from api.schemas.chat import ChatRequest
+from api.services.chat_service import stream_chat
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/chat", tags=["Chat"])
+
+
+@router.post(
+    "/portfolio",
+    summary="Portfolio AI Chatbot",
+    description=(
+        "Stream an AI-powered portfolio analysis response via SSE. "
+        "Requires ANTHROPIC_API_KEY to be set. "
+        "Each SSE event is a JSON object with a 'type' field: "
+        "'text' | 'tool_start' | 'tool_end' | 'done' | 'error'."
+    ),
+)
+async def portfolio_chat(request: ChatRequest) -> StreamingResponse:
+    """
+    Portfolio AI chatbot endpoint (SSE streaming).
+
+    Returns a StreamingResponse with Content-Type text/event-stream.
+    Each event is a JSON payload:
+      - {"type": "text",       "content": "..."}
+      - {"type": "tool_start", "name": "get_indicators", "input": {...}}
+      - {"type": "tool_end",   "name": "get_indicators"}
+      - {"type": "done"}
+      - {"type": "error",      "message": "..."}
+
+    Args:
+        request: ChatRequest with messages and portfolio context flag.
+
+    Returns:
+        StreamingResponse with SSE content.
+
+    Raises:
+        HTTPException 503: When ANTHROPIC_API_KEY is not configured.
+    """
+    settings = get_settings()
+    if not settings.anthropic_api_key:
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "ANTHROPIC_API_KEY가 설정되지 않아 챗봇 서비스를 사용할 수 없습니다. "
+                "서버 환경 변수 ANTHROPIC_API_KEY를 설정해 주세요."
+            ),
+        )
+
+    async def event_generator():
+        try:
+            async for chunk in stream_chat(
+                messages=request.messages,
+                include_portfolio=request.include_portfolio,
+            ):
+                yield chunk
+        except Exception as exc:
+            logger.error("Chat stream generator error: %s", exc, exc_info=True)
+            yield f"data: {json.dumps({'type': 'error', 'message': str(exc)})}\n\n"
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        },
+    )

--- a/api/routers/portfolio.py
+++ b/api/routers/portfolio.py
@@ -17,6 +17,9 @@ from fastapi.responses import StreamingResponse
 from api.schemas.portfolio import (
     AdditionalPurchaseRequest,
     ApplyPresetToHolding,
+    ArchiveCreate,
+    ArchiveDetailResponse,
+    ArchiveSummary,
     BulkApplyPresetRequest,
     BulkApplyPresetResponse,
     CsvImportResponse,
@@ -842,3 +845,115 @@ async def get_trade_history(
     except Exception as e:
         logger.error(f"Failed to get trade history: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Failed to get trade history: {str(e)}")
+
+
+# ── Bulk delete ───────────────────────────────────────────────────
+
+
+@router.delete(
+    "/holdings",
+    status_code=204,
+    summary="Delete All Holdings",
+    description="Remove all holdings and their sell rules.",
+)
+async def delete_all_holdings() -> None:
+    service = get_portfolio_service()
+    try:
+        service.delete_all_holdings()
+    except Exception as e:
+        logger.error(f"Failed to delete all holdings: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to delete all holdings: {str(e)}")
+
+
+# ── Cache ─────────────────────────────────────────────────────────
+
+
+@router.post(
+    "/cache/clear",
+    status_code=204,
+    summary="Clear Price Cache",
+    description="Evict all in-memory price cache entries so the next request fetches fresh data.",
+)
+async def clear_price_cache() -> None:
+    service = get_portfolio_service()
+    service._price_cache.clear()
+    service._change_cache.clear()
+
+
+# ── Portfolio Archives ─────────────────────────────────────────────
+
+
+@router.post(
+    "/archives",
+    response_model=ArchiveDetailResponse,
+    status_code=201,
+    summary="Create Portfolio Archive",
+    description="Snapshot current holdings into a named archive for later comparison.",
+)
+async def create_archive(data: ArchiveCreate) -> ArchiveDetailResponse:
+    service = get_portfolio_service()
+    try:
+        return service.create_archive(data)
+    except Exception as e:
+        logger.error(f"Failed to create archive: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to create archive: {str(e)}")
+
+
+@router.get(
+    "/archives",
+    response_model=List[ArchiveSummary],
+    summary="List Portfolio Archives",
+    description="Return all portfolio archives ordered by most recent first.",
+)
+async def list_archives() -> List[ArchiveSummary]:
+    service = get_portfolio_service()
+    try:
+        return service.list_archives()
+    except Exception as e:
+        logger.error(f"Failed to list archives: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to list archives: {str(e)}")
+
+
+@router.get(
+    "/archives/{archive_id}",
+    response_model=ArchiveDetailResponse,
+    summary="Get Portfolio Archive",
+    description="Return a single archive with all holdings. Pass with_prices=true to include current prices and P&L.",
+)
+async def get_archive(
+    archive_id: int,
+    with_prices: bool = Query(
+        default=False,
+        description="Fetch live prices and compute pnl_pct for each item",
+    ),
+) -> ArchiveDetailResponse:
+    service = get_portfolio_service()
+    try:
+        result = service.get_archive(archive_id, with_prices=with_prices)
+        if result is None:
+            raise HTTPException(status_code=404, detail=f"Archive not found: {archive_id}")
+        return result
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Failed to get archive {archive_id}: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to get archive: {str(e)}")
+
+
+@router.delete(
+    "/archives/{archive_id}",
+    status_code=204,
+    summary="Delete Portfolio Archive",
+    description="Delete an archive and all its items.",
+)
+async def delete_archive(archive_id: int) -> None:
+    service = get_portfolio_service()
+    try:
+        success = service.delete_archive(archive_id)
+        if not success:
+            raise HTTPException(status_code=404, detail=f"Archive not found: {archive_id}")
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Failed to delete archive {archive_id}: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to delete archive: {str(e)}")

--- a/api/routers/portfolio.py
+++ b/api/routers/portfolio.py
@@ -871,13 +871,17 @@ async def delete_all_holdings() -> None:
 @router.post(
     "/cache/clear",
     status_code=204,
-    summary="Clear Price Cache",
-    description="Evict all in-memory price cache entries so the next request fetches fresh data.",
+    summary="Force Refresh Prices",
+    description=(
+        "Force-fetch fresh prices from yfinance/pykrx for all held tickers, "
+        "bypassing both the in-memory TTL cache and the on-disk parquet cache."
+    ),
 )
 async def clear_price_cache() -> None:
     service = get_portfolio_service()
-    service._price_cache.clear()
-    service._change_cache.clear()
+    holdings = service.get_all_holdings(with_prices=False)
+    tickers = [h.ticker for h in holdings]
+    await asyncio.to_thread(service.force_refresh_prices, tickers)
 
 
 # ── Portfolio Archives ─────────────────────────────────────────────

--- a/api/schemas/chat.py
+++ b/api/schemas/chat.py
@@ -1,0 +1,26 @@
+"""
+Chat schemas for portfolio AI chatbot.
+
+Defines request/response models for the portfolio analysis chatbot endpoint.
+"""
+
+from typing import List, Literal
+
+from pydantic import BaseModel, Field
+
+
+class ChatMessage(BaseModel):
+    """A single chat message with role and content."""
+
+    role: Literal["user", "assistant"]
+    content: str = Field(..., min_length=1)
+
+
+class ChatRequest(BaseModel):
+    """Request body for the portfolio chatbot endpoint."""
+
+    messages: List[ChatMessage]
+    # When True, the service automatically injects current holdings
+    # into the system prompt so Claude can reference them without
+    # an explicit tool call.
+    include_portfolio: bool = True

--- a/api/schemas/portfolio.py
+++ b/api/schemas/portfolio.py
@@ -8,7 +8,7 @@ import math
 from datetime import datetime, date
 from typing import Any, Dict, List, Optional, Self
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 SELL_RULE_TYPES = {"stop_loss", "take_profit", "trailing_stop", "holding_period"}
 
@@ -495,3 +495,40 @@ class SellSignalsResponse(BaseModel):
         default_factory=datetime.now,
         description="Check timestamp"
     )
+
+
+# ── Portfolio Archive schemas ──────────────────────────────────────
+
+
+class ArchiveCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=255)
+    description: Optional[str] = None
+    clear_after: bool = Field(default=False, description="Delete all current holdings after archiving")
+
+
+class ArchiveItemResponse(BaseModel):
+    ticker: str
+    name: Optional[str] = None
+    quantity: int
+    avg_price: float
+    currency: str
+    bought_at: Optional[date] = None
+    sector: Optional[str] = None
+    current_price: Optional[float] = None
+    pnl_pct: Optional[float] = None  # ((current_price - avg_price) / avg_price) * 100, with_prices=True only
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ArchiveSummary(BaseModel):
+    id: int
+    name: str
+    description: Optional[str] = None
+    archived_at: datetime
+    total_holdings: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ArchiveDetailResponse(ArchiveSummary):
+    items: List[ArchiveItemResponse] = Field(default_factory=list)

--- a/api/services/chat_service.py
+++ b/api/services/chat_service.py
@@ -1,0 +1,579 @@
+"""
+Portfolio AI Chatbot Service.
+
+Implements a streaming Claude-powered chatbot that analyzes the user's portfolio
+using tool_use to pull live holdings, price history, technical indicators,
+news, and macro data.
+
+Streaming protocol: SSE with JSON payloads.
+  {"type": "text",       "content": "..."}
+  {"type": "tool_start", "name": "get_indicators", "input": {...}}
+  {"type": "tool_end",   "name": "get_indicators"}
+  {"type": "done"}
+  {"type": "error",      "message": "..."}
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+from typing import Any, AsyncIterator, Dict, List, Optional
+
+import asyncio
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+# Maximum conversation turns forwarded to Claude (sliding window, prevents context overflow)
+_MAX_HISTORY_MESSAGES = 20
+
+# ── System prompt ──────────────────────────────────────────────────────────────
+
+_SYSTEM_PROMPT = """당신은 퀀트 투자 전문 AI 어시스턴트입니다. \
+사용자의 포트폴리오를 분석하고 매수/매도 타이밍, 기술적 분석, 리스크 관리에 대해 \
+구체적이고 실용적인 조언을 제공합니다.
+
+원칙:
+- 한국어로 답변합니다.
+- 수치 기반 근거를 반드시 제시합니다.
+- 투자 결정은 최종적으로 사용자의 책임임을 명시합니다.
+- 제공된 도구를 적극 활용해 실제 데이터 기반으로 분석합니다.
+- 불확실한 내용은 명확히 불확실하다고 밝힙니다."""
+
+# ── Tool definitions (sent to Claude) ─────────────────────────────────────────
+
+_TOOLS: List[Dict[str, Any]] = [
+    {
+        "name": "get_holdings",
+        "description": (
+            "현재 포트폴리오의 보유 종목 전체를 조회합니다. "
+            "각 종목의 평균 단가, 현재가, 손익률 등을 반환합니다."
+        ),
+        "input_schema": {"type": "object", "properties": {}, "required": []},
+    },
+    {
+        "name": "get_price_history",
+        "description": (
+            "특정 종목의 OHLCV (시가/고가/저가/종가/거래량) 일별 데이터를 조회합니다. "
+            "최근 N일치 데이터를 반환합니다 (최대 60행)."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "ticker": {"type": "string", "description": "종목 코드 (예: AAPL, 005930.KS)"},
+                "days": {"type": "integer", "description": "조회 기간 (일수, 기본 60)", "default": 60},
+            },
+            "required": ["ticker"],
+        },
+    },
+    {
+        "name": "get_indicators",
+        "description": (
+            "특정 종목의 기술적 지표를 계산하여 반환합니다. "
+            "RSI, MACD, 볼린저 밴드, 이동평균선, OBV 트렌드, 스토캐스틱 등을 포함합니다."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "ticker": {"type": "string", "description": "종목 코드 (예: AAPL, 005930.KS)"},
+                "days": {"type": "integer", "description": "계산에 사용할 데이터 기간 (일수, 기본 120)", "default": 120},
+            },
+            "required": ["ticker"],
+        },
+    },
+    {
+        "name": "get_news",
+        "description": (
+            "특정 종목의 최근 뉴스를 조회합니다. "
+            "제목, 요약, 날짜, 출처를 반환합니다."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "ticker": {"type": "string", "description": "종목 코드 (예: AAPL, 005930.KS)"},
+                "limit": {"type": "integer", "description": "최대 뉴스 건수 (기본 5)", "default": 5},
+            },
+            "required": ["ticker"],
+        },
+    },
+    {
+        "name": "get_macro_context",
+        "description": (
+            "현재 거시경제 환경 데이터를 조회합니다. "
+            "VIX, 매크로 점수, 시장 레짐, 환율(USD/KRW), 주요 지수 방향을 반환합니다."
+        ),
+        "input_schema": {"type": "object", "properties": {}, "required": []},
+    },
+]
+
+# ── Tool implementations ───────────────────────────────────────────────────────
+
+
+def _run_get_holdings() -> Dict[str, Any]:
+    from api.services.portfolio_service import get_portfolio_service
+
+    service = get_portfolio_service()
+    holdings = service.get_all_holdings(with_prices=True)
+    rows = [
+        {
+            "ticker": h.ticker,
+            "name": h.name,
+            "quantity": h.quantity,
+            "avg_price": h.avg_price,
+            "current_price": h.current_price,
+            "pnl_pct": h.pnl_pct,
+            "currency": h.currency,
+            "sector": h.sector,
+        }
+        for h in holdings
+    ]
+    return {"holdings": rows, "count": len(rows)}
+
+
+def _run_get_price_history(ticker: str, days: int = 60) -> Dict[str, Any]:
+    from utils.data_cache import OHLCVCache
+
+    cache = OHLCVCache()
+    data = cache.get(ticker, days=days)
+    if data is None or data.empty:
+        return {"ticker": ticker, "rows": [], "note": "데이터 없음"}
+
+    tail = data.tail(60)
+    rows = []
+    for idx, row in tail.iterrows():
+        date_str = idx.strftime("%Y-%m-%d") if hasattr(idx, "strftime") else str(idx)
+        rows.append(
+            {
+                "date": date_str,
+                "open": _safe_float(row.get("open")),
+                "high": _safe_float(row.get("high")),
+                "low": _safe_float(row.get("low")),
+                "close": _safe_float(row.get("close")),
+                "volume": _safe_float(row.get("volume")),
+            }
+        )
+    return {"ticker": ticker, "rows": rows, "count": len(rows)}
+
+
+def _run_get_indicators(ticker: str, days: int = 120) -> Dict[str, Any]:
+    from utils.data_cache import OHLCVCache
+    from discovery.indicators import calculate_indicators, calculate_stochastic, get_ma_distances
+
+    cache = OHLCVCache()
+    data = cache.get(ticker, days=days)
+    if data is None or data.empty:
+        return {"ticker": ticker, "error": "데이터 없음"}
+
+    try:
+        base = calculate_indicators(ticker, period=days, data=data)
+    except Exception as exc:
+        logger.warning("calculate_indicators failed for %s: %s", ticker, exc)
+        base = {}
+
+    stoch_k = stoch_d = None
+    try:
+        k_series, d_series = calculate_stochastic(data["high"], data["low"], data["close"])
+        stoch_k = _safe_last_series(k_series)
+        stoch_d = _safe_last_series(d_series)
+    except Exception as exc:
+        logger.warning("calculate_stochastic failed for %s: %s", ticker, exc)
+
+    ma_distances: Dict[str, Any] = {}
+    try:
+        ma_distances = get_ma_distances(ticker, periods=[20, 60, 120, 240], data=data)
+    except Exception as exc:
+        logger.warning("get_ma_distances failed for %s: %s", ticker, exc)
+
+    obv_trend = None
+    try:
+        close = data["close"]
+        volume = data["volume"]
+        obv = (volume * close.diff().apply(lambda x: 1 if x > 0 else (-1 if x < 0 else 0))).cumsum()
+        if len(obv) >= 20:
+            recent_obv = obv.iloc[-20:]
+            slope = (recent_obv.iloc[-1] - recent_obv.iloc[0]) / 20
+            obv_trend = "상승" if slope > 0 else "하락"
+    except Exception as exc:
+        logger.warning("OBV trend failed for %s: %s", ticker, exc)
+
+    return {
+        "ticker": ticker,
+        "current_price": base.get("current_price"),
+        "rsi": base.get("rsi"),
+        "macd": {
+            "value": base.get("macd"),
+            "signal": base.get("macd_signal"),
+            "histogram": base.get("macd_histogram"),
+        },
+        "bollinger_bands": {
+            "upper": base.get("bb_upper"),
+            "middle": base.get("bb_middle"),
+            "lower": base.get("bb_lower"),
+            "width": base.get("bb_width"),
+        },
+        "moving_averages": {
+            "ma_20": base.get("ma_20"),
+            "ma_60": base.get("ma_60"),
+            "ma_120": base.get("ma_120"),
+            "ma_240": base.get("ma_240"),
+        },
+        "ma_distances_pct": {
+            str(period): info.get("distance_pct")
+            for period, info in ma_distances.items()
+        },
+        "stochastic": {"k": stoch_k, "d": stoch_d},
+        "obv_trend": obv_trend,
+        "volume_ratio": base.get("volume_ratio"),
+        "high_52w": base.get("high_52w"),
+        "low_52w": base.get("low_52w"),
+    }
+
+
+def _run_get_news(ticker: str, limit: int = 5) -> Dict[str, Any]:
+    try:
+        from news.aggregator import get_news as _get_news
+
+        items = _get_news(ticker, limit=limit)
+        rows = [
+            {
+                "title": item.title,
+                "summary": getattr(item, "summary", None),
+                "published_at": (
+                    item.published_at.strftime("%Y-%m-%d %H:%M") if item.published_at else None
+                ),
+                "source": getattr(item, "source", None),
+                "url": getattr(item, "url", None),
+            }
+            for item in items
+        ]
+        return {"ticker": ticker, "news": rows, "count": len(rows)}
+    except Exception as exc:
+        logger.warning("News service unavailable: %s", exc)
+        return {"ticker": ticker, "news": [], "note": "뉴스 서비스 사용 불가"}
+
+
+def _run_get_macro_context() -> Dict[str, Any]:
+    try:
+        from api.services.macro_market_service import get_macro_market_service
+
+        bundle = get_macro_market_service().get_bundle()
+        signal = bundle.get("signal", {})
+        fx = bundle.get("fx", {})
+        interpretation = bundle.get("interpretation", {})
+        futures = bundle.get("futures", {})
+        return {
+            "macro_score": signal.get("score"),
+            "regime": signal.get("regime"),
+            "confidence_band": signal.get("confidence_band"),
+            "entry_signal": interpretation.get("entry_signal"),
+            "posture": interpretation.get("posture"),
+            "usd_krw": fx.get("rate"),
+            "usd_krw_change_pct": fx.get("change_pct"),
+            "futures_change_pct": futures.get("change_pct"),
+            "is_market_hours": bundle.get("is_market_hours"),
+            "generated_at": bundle.get("generated_at"),
+        }
+    except Exception as exc:
+        logger.warning("Macro service unavailable: %s", exc)
+        return {"note": "매크로 데이터 사용 불가", "error": str(exc)}
+
+
+# ── Tool dispatcher ────────────────────────────────────────────────────────────
+
+_TOOL_MAP = {
+    "get_holdings": lambda inp: _run_get_holdings(),
+    "get_price_history": lambda inp: _run_get_price_history(inp["ticker"], inp.get("days", 60)),
+    "get_indicators": lambda inp: _run_get_indicators(inp["ticker"], inp.get("days", 120)),
+    "get_news": lambda inp: _run_get_news(inp["ticker"], inp.get("limit", 5)),
+    "get_macro_context": lambda inp: _run_get_macro_context(),
+}
+
+
+def _execute_tool(name: str, tool_input: Dict[str, Any]) -> str:
+    fn = _TOOL_MAP.get(name)
+    if fn is None:
+        return json.dumps({"error": f"Unknown tool: {name}"})
+    try:
+        result = fn(tool_input)
+        return json.dumps(result, ensure_ascii=False, default=str)
+    except Exception as exc:
+        logger.error("Tool %s failed: %s", name, exc, exc_info=True)
+        return json.dumps({"error": str(exc)})
+
+
+# ── Helper utilities ───────────────────────────────────────────────────────────
+
+
+def _safe_float(val: Any) -> Optional[float]:
+    if val is None:
+        return None
+    try:
+        f = float(val)
+        return None if math.isnan(f) or math.isinf(f) else f
+    except (TypeError, ValueError):
+        return None
+
+
+def _safe_last_series(series: Any) -> Optional[float]:
+    try:
+        if series is None or series.empty:
+            return None
+        val = series.iloc[-1]
+        if pd.isna(val):
+            return None
+        f = float(val)
+        return None if math.isnan(f) else f
+    except Exception:
+        return None
+
+
+def _sse(payload: dict) -> str:
+    return f"data: {json.dumps(payload, ensure_ascii=False)}\n\n"
+
+
+def _build_holdings_context(holdings_json: str) -> str:
+    return f"\n\n[현재 포트폴리오 현황]\n{holdings_json}"
+
+
+# ── Core streaming round (runs in thread) ─────────────────────────────────────
+
+_QUEUE_DONE = object()
+_PUT_TIMEOUT = 30  # seconds
+_MODEL = "claude-sonnet-4-6"
+
+
+def _run_stream_round(
+    client: Any,
+    system: str,
+    anthropic_messages: list,
+    queue: "asyncio.Queue[Any]",
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    """
+    Execute one synchronous Claude streaming round in a background thread.
+
+    Routes content_block_delta and content_block_stop events by block index
+    so that multi-tool responses are correctly handled.
+
+    Puts SSE payload dicts, a result tuple, then _QUEUE_DONE into *queue*.
+    Always guarantees _QUEUE_DONE is enqueued — even on unexpected exceptions.
+    """
+    import anthropic as _anthropic
+
+    def _put(item: Any) -> None:
+        asyncio.run_coroutine_threadsafe(queue.put(item), loop).result(timeout=_PUT_TIMEOUT)
+
+    # Map block_index → tool_use entry for correct multi-tool routing
+    tool_uses: list[dict] = []
+    index_to_tool: dict[int, dict] = {}
+    final_message = None
+
+    try:
+        with client.messages.stream(
+            model=_MODEL,
+            max_tokens=4096,
+            system=system,
+            tools=_TOOLS,
+            messages=anthropic_messages,
+        ) as stream:
+            for event in stream:
+                event_type = getattr(event, "type", None)
+                block_index = getattr(event, "index", None)
+
+                if event_type == "content_block_start":
+                    block = getattr(event, "content_block", None)
+                    if block and block.type == "tool_use":
+                        entry = {
+                            "id": block.id,
+                            "name": block.name,
+                            "input_json": "",
+                            "_block_index": block_index,
+                        }
+                        tool_uses.append(entry)
+                        if block_index is not None:
+                            index_to_tool[block_index] = entry
+                        _put({"type": "tool_start", "name": block.name, "input": {}})
+
+                elif event_type == "content_block_delta":
+                    delta = getattr(event, "delta", None)
+                    if delta is None:
+                        continue
+                    delta_type = getattr(delta, "type", None)
+
+                    if delta_type == "text_delta":
+                        text = getattr(delta, "text", "")
+                        if text:
+                            _put({"type": "text", "content": text})
+
+                    elif delta_type == "input_json_delta":
+                        # Route by block index to avoid corrupting multi-tool inputs
+                        target = index_to_tool.get(block_index) if block_index is not None else (tool_uses[-1] if tool_uses else None)
+                        if target is not None:
+                            target["input_json"] += getattr(delta, "partial_json", "")
+
+                elif event_type == "content_block_stop":
+                    # Only emit tool_end for tool_use blocks; text block stops are ignored.
+                    # Using block_index lookup ensures we never fire tool_end for a text block.
+                    if block_index is not None and block_index in index_to_tool:
+                        target = index_to_tool[block_index]
+                        try:
+                            target["input"] = json.loads(target["input_json"] or "{}")
+                        except json.JSONDecodeError:
+                            target["input"] = {}
+                        _put({"type": "tool_end", "name": target["name"]})
+
+            final_message = stream.get_final_message()
+
+    except _anthropic.APIError as exc:
+        logger.error("Anthropic API error: %s", exc)
+        _put({"type": "error", "message": f"API 오류: {str(exc)}"})
+    except Exception as exc:
+        # Catch all unexpected errors (network, SSL, etc.) so _QUEUE_DONE is always sent
+        logger.error("Unexpected error in stream round: %s", exc, exc_info=True)
+        _put({"type": "error", "message": f"스트림 오류: {str(exc)}"})
+
+    _put((tool_uses, final_message))
+    _put(_QUEUE_DONE)
+
+
+# ── Main streaming generator ───────────────────────────────────────────────────
+
+_TOOL_TIMEOUT = 30.0   # seconds per tool call
+_QUEUE_TIMEOUT = 60.0  # seconds to wait for next queue item
+_MAX_TOOL_ROUNDS = 8
+
+
+async def stream_chat(messages: list, include_portfolio: bool = True) -> AsyncIterator[str]:
+    """
+    Stream a chat response using Claude with tool_use.
+
+    Yields SSE-formatted strings: data: <json>\\n\\n
+    """
+    try:
+        import anthropic
+        from api.config import get_settings
+
+        settings = get_settings()
+        api_key = settings.anthropic_api_key
+        if not api_key:
+            yield _sse({"type": "error", "message": "ANTHROPIC_API_KEY가 설정되지 않았습니다."})
+            return
+
+        client = anthropic.Anthropic(api_key=api_key)
+
+        # Build system prompt with optional portfolio context
+        system = _SYSTEM_PROMPT
+        if include_portfolio:
+            try:
+                holdings_data = await asyncio.to_thread(_run_get_holdings)
+                holdings_str = json.dumps(holdings_data, ensure_ascii=False, default=str)
+                system += _build_holdings_context(holdings_str)
+            except Exception as exc:
+                logger.warning("Failed to inject portfolio context: %s", exc)
+
+        # Sliding window: cap the *initial* history sent to Claude.
+        # Note: tool-round turns appended inside the loop below are NOT capped —
+        # they grow with each tool call (bounded by _MAX_TOOL_ROUNDS).
+        windowed = messages[-_MAX_HISTORY_MESSAGES:] if len(messages) > _MAX_HISTORY_MESSAGES else messages
+        anthropic_messages = [{"role": m.role, "content": m.content} for m in windowed]
+
+        loop = asyncio.get_running_loop()
+
+        for _round in range(_MAX_TOOL_ROUNDS):
+            queue: asyncio.Queue = asyncio.Queue()
+
+            future = loop.run_in_executor(
+                None,
+                _run_stream_round,
+                client,
+                system,
+                anthropic_messages,
+                queue,
+                loop,
+            )
+
+            tool_uses: list[dict] = []
+            final_message = None
+
+            while True:
+                try:
+                    item = await asyncio.wait_for(queue.get(), timeout=_QUEUE_TIMEOUT)
+                except asyncio.TimeoutError:
+                    # Check if the thread crashed without putting _QUEUE_DONE
+                    if future.done() and future.exception():
+                        raise future.exception()  # type: ignore[misc]
+                    yield _sse({"type": "error", "message": "응답 시간이 초과되었습니다."})
+                    return
+
+                if item is _QUEUE_DONE:
+                    break
+                if isinstance(item, tuple):
+                    tool_uses, final_message = item
+                elif isinstance(item, dict):
+                    yield _sse(item)
+                    if item.get("type") == "error":
+                        return
+
+            if final_message is None:
+                return
+
+            if not tool_uses:
+                break
+
+            stop_reason = getattr(final_message, "stop_reason", None)
+            if stop_reason != "tool_use":
+                break
+
+            # Build assistant turn
+            assistant_content = []
+            for block in final_message.content:
+                if block.type == "text":
+                    assistant_content.append({"type": "text", "text": block.text})
+                elif block.type == "tool_use":
+                    matching = next((t for t in tool_uses if t.get("id") == block.id), None)
+                    assistant_content.append(
+                        {
+                            "type": "tool_use",
+                            "id": block.id,
+                            "name": block.name,
+                            "input": matching.get("input", {}) if matching else {},
+                        }
+                    )
+
+            anthropic_messages.append({"role": "assistant", "content": assistant_content})
+
+            # Execute tools with per-tool timeout
+            tool_results = []
+            for tool_use_block in final_message.content:
+                if tool_use_block.type != "tool_use":
+                    continue
+                matching = next((t for t in tool_uses if t.get("id") == tool_use_block.id), None)
+                tool_input = matching.get("input", {}) if matching else {}
+                try:
+                    result_json = await asyncio.wait_for(
+                        asyncio.to_thread(_execute_tool, tool_use_block.name, tool_input),
+                        timeout=_TOOL_TIMEOUT,
+                    )
+                except asyncio.TimeoutError:
+                    result_json = json.dumps({"error": f"{tool_use_block.name} 조회 시간 초과"})
+                tool_results.append(
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": tool_use_block.id,
+                        "content": result_json,
+                    }
+                )
+
+            anthropic_messages.append({"role": "user", "content": tool_results})
+
+        else:
+            # Exhausted MAX_TOOL_ROUNDS
+            yield _sse({"type": "error", "message": "도구 호출이 최대 횟수에 도달했습니다. 질문을 더 간단하게 나눠서 시도해주세요."})
+            return
+
+        yield _sse({"type": "done"})
+
+    except Exception as exc:
+        logger.error("stream_chat unexpected error: %s", exc, exc_info=True)
+        yield _sse({"type": "error", "message": str(exc)})

--- a/api/services/portfolio_service.py
+++ b/api/services/portfolio_service.py
@@ -2103,6 +2103,37 @@ class PortfolioService:
             db.close()
 
 
+    def force_refresh_prices(self, tickers: List[str]) -> None:
+        """
+        Force-fetch fresh prices from source (yfinance/pykrx), bypassing all caches.
+
+        Clears the in-memory TTL caches and also invalidates the OHLCVCache
+        in-memory metadata so that the next get() call re-fetches parquet from
+        the network even if the parquet file was written today.
+        """
+        if not tickers:
+            return
+
+        self._price_cache.clear()
+        self._change_cache.clear()
+
+        # Invalidate OHLCVCache in-memory metadata so _is_cache_fresh() re-reads
+        # from disk and force_refresh=True actually hits the network.
+        with self._cache._meta_lock:
+            self._cache._latest_date_cache.clear()
+
+        # Parallel force-refresh: writes fresh data to parquet for each ticker
+        futures = {
+            self._executor.submit(self._cache.get, ticker, 5, True): ticker
+            for ticker in tickers
+        }
+        for future in as_completed(futures):
+            ticker = futures[future]
+            try:
+                future.result()
+            except Exception as e:
+                logger.warning(f"Force refresh failed for {ticker}: {e}")
+
     def delete_all_holdings(self) -> None:
         """Remove all holdings and their associated sell rules."""
         db = SessionLocal()

--- a/api/services/portfolio_service.py
+++ b/api/services/portfolio_service.py
@@ -9,15 +9,20 @@ import csv
 import io
 import logging
 import math
+import re
 import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, date
 from typing import List, Dict, Any, Optional, Set
 
 from api.database import SessionLocal
-from api.models.portfolio import Holding, SellRule, SellRulePreset, Trade
+from api.models.portfolio import Holding, SellRule, SellRulePreset, Trade, PortfolioArchive, PortfolioArchiveItem
 from api.schemas.portfolio import (
     AdditionalPurchaseRequest,
+    ArchiveCreate,
+    ArchiveItemResponse,
+    ArchiveSummary,
+    ArchiveDetailResponse,
     HoldingCreate,
     HoldingUpdate,
     HoldingResponse,
@@ -85,6 +90,29 @@ class PortfolioService:
     EXECUTOR_MAX_WORKERS = 8
     _shared_executor: Optional[ThreadPoolExecutor] = None
     _executor_lock = threading.Lock()
+
+    _KR_CODE_PATTERN = re.compile(r'^[0-9A-Z]{6}$')
+
+
+    @classmethod
+    def _validate_ticker(cls, ticker: str) -> str | None:
+        """Return an error message if ticker format is invalid, else None.
+
+        Korean stock codes (6 alphanumeric chars) must include .KS or .KQ suffix.
+        US tickers (letters only) are accepted as-is.
+        """
+        if "." in ticker:
+            suffix = ticker.rsplit(".", 1)[-1].upper()
+            if suffix not in ("KS", "KQ", "KL"):
+                return f"알 수 없는 거래소 suffix: .{suffix} (한국: .KS / .KQ, 미국: suffix 없음)"
+            return None
+
+        if cls._KR_CODE_PATTERN.match(ticker):
+            return (
+                f"한국 종목은 거래소 suffix가 필요합니다: {ticker}.KS (KOSPI) 또는 {ticker}.KQ (KOSDAQ)"
+            )
+
+        return None  # US ticker (letters), leave as-is
 
     def __init__(self):
         self._cache = get_cache()
@@ -948,6 +976,12 @@ class PortfolioService:
 
             if not ticker_val:
                 errors.append({"row": row_num, "ticker": None, "reason": "Empty ticker"})
+                continue
+
+            ticker_val = ticker_val.upper()
+            ticker_error = self._validate_ticker(ticker_val)
+            if ticker_error:
+                errors.append({"row": row_num, "ticker": ticker_val, "reason": ticker_error})
                 continue
 
             try:
@@ -1864,6 +1898,223 @@ class PortfolioService:
         if rule.rule_type == "trailing_stop" and high_watermark:
             return high_watermark * (1 - abs(params.get("pct", 0)) / 100)
         return None
+
+
+    # ── Portfolio Archive ──────────────────────────────────────────────
+
+    def create_archive(self, data: ArchiveCreate) -> ArchiveDetailResponse:
+        """Snapshot current holdings into a new portfolio archive.
+
+        Reads all rows from the holdings table and persists them as
+        PortfolioArchiveItem records linked to a new PortfolioArchive row.
+        Current prices are not fetched here; items are stored with
+        avg_price only (current_price=None, pnl_pct=None).
+
+        Args:
+            data: Archive name and optional description.
+
+        Returns:
+            ArchiveDetailResponse with the newly created archive and its items.
+        """
+        db = SessionLocal()
+        try:
+            holdings: List[Holding] = db.query(Holding).all()
+
+            archive = PortfolioArchive(
+                name=data.name,
+                description=data.description,
+                total_holdings=len(holdings),
+            )
+            db.add(archive)
+            db.flush()  # obtain archive.id before inserting items
+
+            for h in holdings:
+                item = PortfolioArchiveItem(
+                    archive_id=archive.id,
+                    ticker=h.ticker,
+                    name=h.name,
+                    quantity=h.quantity,
+                    avg_price=h.avg_price,
+                    currency=h.currency,
+                    bought_at=h.bought_at,
+                    sector=h.sector,
+                    industry=h.industry,
+                    country=h.country,
+                    exchange=h.exchange,
+                )
+                db.add(item)
+
+            if data.clear_after:
+                db.query(SellRule).delete(synchronize_session=False)
+                db.query(Holding).delete(synchronize_session=False)
+
+            db.commit()
+            db.refresh(archive)
+
+            item_responses = [
+                ArchiveItemResponse(
+                    ticker=item.ticker,
+                    name=item.name,
+                    quantity=item.quantity,
+                    avg_price=item.avg_price,
+                    currency=item.currency,
+                    bought_at=item.bought_at,
+                    sector=item.sector,
+                    current_price=None,
+                    pnl_pct=None,
+                )
+                for item in archive.items
+            ]
+
+            return ArchiveDetailResponse(
+                id=archive.id,
+                name=archive.name,
+                description=archive.description,
+                archived_at=archive.archived_at,
+                total_holdings=archive.total_holdings,
+                items=item_responses,
+            )
+        except Exception:
+            db.rollback()
+            raise
+        finally:
+            db.close()
+
+    def list_archives(self) -> List[ArchiveSummary]:
+        """Return all archives ordered by most recent first.
+
+        Returns:
+            List of ArchiveSummary (no items included).
+        """
+        db = SessionLocal()
+        try:
+            archives: List[PortfolioArchive] = (
+                db.query(PortfolioArchive)
+                .order_by(PortfolioArchive.archived_at.desc())
+                .all()
+            )
+            return [
+                ArchiveSummary(
+                    id=a.id,
+                    name=a.name,
+                    description=a.description,
+                    archived_at=a.archived_at,
+                    total_holdings=a.total_holdings,
+                )
+                for a in archives
+            ]
+        finally:
+            db.close()
+
+    def get_archive(
+        self, archive_id: int, with_prices: bool = False
+    ) -> Optional[ArchiveDetailResponse]:
+        """Return a single archive with all its items.
+
+        When with_prices is True, fetches the current price for each item
+        and computes pnl_pct = ((current_price - avg_price) / avg_price) * 100.
+
+        Args:
+            archive_id: Primary key of the archive.
+            with_prices: Whether to enrich items with live prices.
+
+        Returns:
+            ArchiveDetailResponse, or None if not found.
+        """
+        db = SessionLocal()
+        try:
+            archive: Optional[PortfolioArchive] = (
+                db.query(PortfolioArchive)
+                .filter(PortfolioArchive.id == archive_id)
+                .first()
+            )
+            if archive is None:
+                return None
+
+            prices: Dict[str, float] = {}
+            if with_prices:
+                tickers = [item.ticker for item in archive.items]
+                if tickers:
+                    prices = self._get_current_prices(tickers)
+
+            item_responses = []
+            for item in archive.items:
+                current_price: Optional[float] = prices.get(item.ticker) if with_prices else None
+                pnl_pct: Optional[float] = None
+                if (
+                    with_prices
+                    and current_price is not None
+                    and item.avg_price
+                    and not math.isnan(current_price)
+                    and not math.isinf(current_price)
+                ):
+                    pnl_pct = ((current_price - item.avg_price) / item.avg_price) * 100
+
+                item_responses.append(
+                    ArchiveItemResponse(
+                        ticker=item.ticker,
+                        name=item.name,
+                        quantity=item.quantity,
+                        avg_price=item.avg_price,
+                        currency=item.currency,
+                        bought_at=item.bought_at,
+                        sector=item.sector,
+                        current_price=current_price,
+                        pnl_pct=pnl_pct,
+                    )
+                )
+
+            return ArchiveDetailResponse(
+                id=archive.id,
+                name=archive.name,
+                description=archive.description,
+                archived_at=archive.archived_at,
+                total_holdings=archive.total_holdings,
+                items=item_responses,
+            )
+        finally:
+            db.close()
+
+    def delete_archive(self, archive_id: int) -> bool:
+        """Delete an archive and all its items (CASCADE).
+
+        Args:
+            archive_id: Primary key of the archive to delete.
+
+        Returns:
+            True if deleted, False if not found.
+        """
+        db = SessionLocal()
+        try:
+            archive: Optional[PortfolioArchive] = (
+                db.query(PortfolioArchive)
+                .filter(PortfolioArchive.id == archive_id)
+                .first()
+            )
+            if archive is None:
+                return False
+            db.delete(archive)
+            db.commit()
+            return True
+        except Exception:
+            db.rollback()
+            raise
+        finally:
+            db.close()
+
+
+    def delete_all_holdings(self) -> None:
+        """Remove all holdings and their associated sell rules."""
+        db = SessionLocal()
+        try:
+            db.query(SellRule).delete(synchronize_session=False)
+            db.query(Holding).delete(synchronize_session=False)
+            db.commit()
+        except Exception:
+            db.rollback()
+            raise
+        finally:
+            db.close()
 
 
 # Singleton instance

--- a/api/services/portfolio_service.py
+++ b/api/services/portfolio_service.py
@@ -600,13 +600,13 @@ class PortfolioService:
         if with_prices and holdings_dicts:
             tickers = [h["ticker"] for h in holdings_dicts]
 
-            # Run price and change enrichment in parallel (sector is now in DB).
-            f_prices = self._executor.submit(self._get_current_prices, tickers)
-            f_changes = self._executor.submit(self._get_daily_changes, tickers)
-
-            prices = f_prices.result(timeout=ENRICHMENT_TIMEOUT_SECONDS)
+            # Prices first (warms the OHLCV parquet cache), then changes.
+            # Running them in parallel caused a race: _get_daily_changes would
+            # read the cache before _get_current_prices had finished writing it,
+            # resulting in null change_pct for most holdings.
+            prices = self._get_current_prices(tickers)
             try:
-                changes = f_changes.result(timeout=ENRICHMENT_TIMEOUT_SECONDS)
+                changes = self._get_daily_changes(tickers)
             except Exception as e:
                 logger.warning(f"Daily change enrichment failed: {e}")
 

--- a/utils/data_cache.py
+++ b/utils/data_cache.py
@@ -219,7 +219,7 @@ class OHLCVCache:
             return None
         try:
             stock = yf.Ticker(ticker)
-            data = stock.history(period=f"{days}d")
+            data = stock.history(period=f"{days}d", auto_adjust=False)
 
             if data.empty:
                 return None

--- a/web/src/app/[locale]/portfolio/page.tsx
+++ b/web/src/app/[locale]/portfolio/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useTranslations, useLocale } from 'next-intl';
-import { Plus, RefreshCw, TrendingUp, TrendingDown, DollarSign, PieChart, Upload, Download, Search, History, CheckSquare, X } from 'lucide-react';
+import { Plus, RefreshCw, TrendingUp, TrendingDown, DollarSign, PieChart, Upload, Download, Search, History, CheckSquare, X, Archive, Trash2, MessageCircle } from 'lucide-react';
 import { Button, Card } from '@/components/ui';
 import {
   HoldingsTable,
@@ -17,6 +17,8 @@ import {
   SellRuleModal,
   TradeHistory,
   AllocationCharts,
+  ArchiveModal,
+  ChatPanel,
 } from '@/components/portfolio';
 import { normalizeSector, classifyMarket } from '@/components/portfolio/AllocationCharts';
 import {
@@ -30,6 +32,8 @@ import {
   exportHoldingsCsv,
   getSellRulePresets,
   bulkApplyPreset,
+  clearPortfolioCache,
+  deleteAllHoldings,
 } from '@/lib/api';
 import type { Holding, HoldingCreate, HoldingUpdate, AdditionalPurchaseRequest, PortfolioSummary, SellSignal, SellRulePreset } from '@/lib/types';
 import { formatCurrency as formatCurrencyUtil, formatPercent as formatPercentUtil } from '@/lib/format';
@@ -114,6 +118,9 @@ export default function PortfolioPage() {
   // Loading state
   const [isLoading, setIsLoading] = useState(true);
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const [isCacheClearing, setIsCacheClearing] = useState(false);
+  const [showDeleteAllConfirm, setShowDeleteAllConfirm] = useState(false);
+  const [isDeletingAll, setIsDeletingAll] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   // Modal state
@@ -133,6 +140,12 @@ export default function PortfolioPage() {
 
   // Trade history section state
   const [isTradeHistoryOpen, setIsTradeHistoryOpen] = useState(false);
+
+  // Archive modal state
+  const [showArchiveModal, setShowArchiveModal] = useState(false);
+
+  // AI Chat panel state
+  const [showChatPanel, setShowChatPanel] = useState(false);
 
   // Bulk mode state
   const [bulkMode, setBulkMode] = useState(false);
@@ -354,6 +367,27 @@ export default function PortfolioPage() {
       setIsRefreshing(false);
     }
   }, [settings.baseCurrency]);
+
+  const handleDeleteAll = useCallback(async () => {
+    setIsDeletingAll(true);
+    try {
+      await deleteAllHoldings();
+      await fetchData(false);
+      setShowDeleteAllConfirm(false);
+    } finally {
+      setIsDeletingAll(false);
+    }
+  }, [fetchData]);
+
+  const handleForceRefresh = useCallback(async () => {
+    setIsCacheClearing(true);
+    try {
+      await clearPortfolioCache();
+      await fetchData(false);
+    } finally {
+      setIsCacheClearing(false);
+    }
+  }, [fetchData]);
 
   // Initial data fetch
   useEffect(() => {
@@ -647,7 +681,9 @@ export default function PortfolioPage() {
   ];
 
   return (
-    <div className="space-y-6">
+    <div className="flex min-h-0 items-start gap-4">
+    {/* Main portfolio content */}
+    <div className="flex-1 min-w-0 space-y-6">
       {/* Page Header */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
@@ -709,10 +745,29 @@ export default function PortfolioPage() {
           <Button
             variant="outline"
             onClick={() => fetchData(false)}
-            disabled={isRefreshing}
+            disabled={isRefreshing || isCacheClearing}
           >
             <RefreshCw className={`h-4 w-4 mr-2 ${isRefreshing ? 'animate-spin' : ''}`} />
             {t('refresh')}
+          </Button>
+          <Button
+            variant="outline"
+            onClick={handleForceRefresh}
+            disabled={isRefreshing || isCacheClearing}
+            title="캐시를 초기화하고 최신 시세를 새로 받아옵니다"
+          >
+            <RefreshCw className={`h-4 w-4 mr-2 ${isCacheClearing ? 'animate-spin' : ''}`} />
+            강제 새로고침
+          </Button>
+          <Button
+            variant="outline"
+            onClick={() => setShowDeleteAllConfirm(true)}
+            disabled={isDeletingAll}
+            className="text-red-600 hover:text-red-700 hover:border-red-400 dark:text-red-400"
+            title="전체 보유 종목 삭제"
+          >
+            <Trash2 className="h-4 w-4 mr-2" />
+            전체 삭제
           </Button>
           <Button
             variant="outline"
@@ -736,6 +791,10 @@ export default function PortfolioPage() {
             <Download className="h-4 w-4 mr-2" />
             {t('exportCsv')}
           </Button>
+          <Button variant="outline" onClick={() => setShowArchiveModal(true)}>
+            <Archive className="h-4 w-4 mr-2" />
+            아카이브
+          </Button>
           {!bulkMode ? (
             <Button variant="outline" onClick={handleEnterBulkMode} disabled={holdings.length === 0}>
               <CheckSquare className="h-4 w-4 mr-2" />
@@ -747,6 +806,15 @@ export default function PortfolioPage() {
               {t('bulkExitSelectMode')}
             </Button>
           )}
+          <Button
+            variant="outline"
+            onClick={() => setShowChatPanel((prev) => !prev)}
+            aria-pressed={showChatPanel}
+            title="AI 어시스턴트 열기"
+          >
+            <MessageCircle className="h-4 w-4 mr-2" />
+            AI 어시스턴트
+          </Button>
           <Button variant="primary" onClick={() => setIsAddModalOpen(true)}>
             <Plus className="h-4 w-4 mr-2" />
             {t('addHolding')}
@@ -1043,6 +1111,54 @@ export default function PortfolioPage() {
         />
       )}
 
+      {/* Archive Modal */}
+      <ArchiveModal
+        open={showArchiveModal}
+        onClose={() => setShowArchiveModal(false)}
+        onHoldingsCleared={() => fetchData(false)}
+      />
+
+      {/* Delete All Confirm Dialog */}
+      {showDeleteAllConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="rounded-xl border border-[var(--border)] bg-[var(--background)] p-6 shadow-xl w-full max-w-sm mx-4">
+            <div className="flex items-center gap-3 mb-3">
+              <Trash2 className="h-5 w-5 text-red-500 shrink-0" />
+              <h2 className="text-base font-semibold text-[var(--foreground)]">전체 종목 삭제</h2>
+            </div>
+            <p className="text-sm text-[var(--foreground-muted)] mb-5">
+              보유 중인 종목 전체와 매도 규칙이 삭제됩니다. 이 작업은 되돌릴 수 없습니다.
+            </p>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                onClick={() => setShowDeleteAllConfirm(false)}
+                disabled={isDeletingAll}
+                className="flex-1"
+              >
+                취소
+              </Button>
+              <Button
+                variant="primary"
+                onClick={handleDeleteAll}
+                isLoading={isDeletingAll}
+                className="flex-1 bg-red-600 hover:bg-red-700 text-white border-red-600"
+              >
+                삭제
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+
+    </div>{/* end main content */}
+
+      {/* AI Chat Panel */}
+      {showChatPanel && (
+        <div className="sticky top-4 self-start">
+          <ChatPanel open={showChatPanel} onClose={() => setShowChatPanel(false)} />
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/components/portfolio/ArchiveModal.tsx
+++ b/web/src/components/portfolio/ArchiveModal.tsx
@@ -1,0 +1,504 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { Archive, ArrowLeft, X, Trash2, RefreshCw, DollarSign } from 'lucide-react';
+import { Button } from '@/components/ui';
+import {
+  listPortfolioArchives,
+  createPortfolioArchive,
+  getPortfolioArchive,
+  deletePortfolioArchive,
+} from '@/lib/api';
+import type { ArchiveSummary, ArchiveDetailResponse, ArchiveItemResponse } from '@/lib/types';
+
+interface ArchiveModalProps {
+  /** Whether the modal is open */
+  open: boolean;
+  /** Callback to close the modal */
+  onClose: () => void;
+  /** Called after a successful archive-and-clear so the parent can refresh holdings */
+  onHoldingsCleared?: () => void;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString('ko-KR', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function formatPrice(value: number, currency: string): string {
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency, maximumFractionDigits: 2 }).format(value);
+}
+
+function PnlBadge({ pnl }: { pnl: number | null | undefined }) {
+  if (pnl == null) return <span className="text-[var(--foreground-muted)]">-</span>;
+  const isPositive = pnl >= 0;
+  return (
+    <span
+      className={`font-mono font-semibold ${
+        isPositive ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
+      }`}
+    >
+      {isPositive ? '+' : ''}
+      {pnl.toFixed(2)}%
+    </span>
+  );
+}
+
+// ── List View ───────────────────────────────────────────────────────────────
+
+interface ListViewProps {
+  archives: ArchiveSummary[];
+  isLoading: boolean;
+  error: string | null;
+  onCreate: (name: string, description?: string, clearAfter?: boolean) => Promise<void>;
+  onSelect: (id: number) => void;
+  onDelete: (id: number) => Promise<void>;
+}
+
+function ListView({ archives, isLoading, error, onCreate, onSelect, onDelete }: ListViewProps) {
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [newDesc, setNewDesc] = useState('');
+  const [clearAfter, setClearAfter] = useState(false);
+  const [isCreating, setIsCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<number | null>(null);
+
+  const handleCreate = async () => {
+    if (!newName.trim()) return;
+    setIsCreating(true);
+    setCreateError(null);
+    try {
+      await onCreate(newName.trim(), newDesc.trim() || undefined, clearAfter);
+      setNewName('');
+      setNewDesc('');
+      setClearAfter(false);
+      setShowCreateForm(false);
+    } catch (e) {
+      setCreateError(e instanceof Error ? e.message : '생성에 실패했습니다.');
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    setDeletingId(id);
+    try {
+      await onDelete(id);
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Create button / form */}
+      {!showCreateForm ? (
+        <Button variant="primary" onClick={() => setShowCreateForm(true)} className="self-start">
+          <Archive className="h-4 w-4 mr-2" />
+          아카이브 생성
+        </Button>
+      ) : (
+        <div className="rounded-lg border border-[var(--border)] bg-[var(--background)] p-4 flex flex-col gap-3">
+          <p className="text-sm font-medium text-[var(--foreground)]">새 아카이브</p>
+          {createError && (
+            <p className="text-sm text-red-600 dark:text-red-400">{createError}</p>
+          )}
+          <div className="flex flex-col gap-2">
+            <input
+              type="text"
+              placeholder="아카이브 이름 (필수)"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              className="w-full rounded-md border border-[var(--border)] bg-[var(--background-secondary)] px-3 py-2 text-sm text-[var(--foreground)] placeholder:text-[var(--foreground-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]"
+            />
+            <input
+              type="text"
+              placeholder="설명 (선택)"
+              value={newDesc}
+              onChange={(e) => setNewDesc(e.target.value)}
+              className="w-full rounded-md border border-[var(--border)] bg-[var(--background-secondary)] px-3 py-2 text-sm text-[var(--foreground)] placeholder:text-[var(--foreground-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]"
+            />
+          </div>
+          <label className="flex items-center gap-2 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={clearAfter}
+              onChange={(e) => setClearAfter(e.target.checked)}
+              className="h-4 w-4 rounded border-[var(--border)] accent-[var(--color-primary)]"
+            />
+            <span className="text-sm text-[var(--foreground-muted)]">아카이브 후 현재 포트폴리오 비우기</span>
+          </label>
+          <div className="flex gap-2">
+            <Button
+              variant="primary"
+              onClick={handleCreate}
+              isLoading={isCreating}
+              disabled={!newName.trim()}
+              className="flex-1"
+            >
+              저장
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setShowCreateForm(false);
+                setCreateError(null);
+                setNewName('');
+                setNewDesc('');
+                setClearAfter(false);
+              }}
+              disabled={isCreating}
+              className="flex-1"
+            >
+              취소
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* Error */}
+      {error && (
+        <div className="rounded-lg border border-red-300 bg-red-50 p-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-950/50 dark:text-red-300">
+          {error}
+        </div>
+      )}
+
+      {/* Loading */}
+      {isLoading && (
+        <div className="flex items-center justify-center py-12">
+          <RefreshCw className="h-6 w-6 animate-spin text-[var(--foreground-muted)]" />
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!isLoading && archives.length === 0 && (
+        <div className="flex flex-col items-center justify-center py-12 gap-2 text-[var(--foreground-muted)]">
+          <Archive className="h-10 w-10 opacity-30" />
+          <p className="text-sm">저장된 아카이브가 없습니다.</p>
+        </div>
+      )}
+
+      {/* List */}
+      {!isLoading && archives.length > 0 && (
+        <ul className="flex flex-col gap-2">
+          {archives.map((a) => (
+            <li
+              key={a.id}
+              className="flex items-center justify-between rounded-lg border border-[var(--border)] bg-[var(--background)] px-4 py-3 hover:bg-[var(--background-secondary)] transition-colors"
+            >
+              <button
+                type="button"
+                className="flex-1 text-left"
+                onClick={() => onSelect(a.id)}
+              >
+                <p className="font-medium text-[var(--foreground)]">{a.name}</p>
+                {a.description && (
+                  <p className="mt-0.5 text-xs text-[var(--foreground-muted)] truncate max-w-xs">{a.description}</p>
+                )}
+                <p className="mt-1 text-xs text-[var(--foreground-muted)]">
+                  {formatDate(a.archived_at)} &middot; {a.total_holdings}개 종목
+                </p>
+              </button>
+              <button
+                type="button"
+                aria-label="아카이브 삭제"
+                onClick={() => handleDelete(a.id)}
+                disabled={deletingId === a.id}
+                className="ml-3 rounded p-1.5 text-[var(--foreground-muted)] hover:bg-red-100 hover:text-red-600 dark:hover:bg-red-900/40 dark:hover:text-red-400 transition-colors disabled:opacity-40"
+              >
+                {deletingId === a.id ? (
+                  <RefreshCw className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Trash2 className="h-4 w-4" />
+                )}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+// ── Detail View ─────────────────────────────────────────────────────────────
+
+interface DetailViewProps {
+  detail: ArchiveDetailResponse;
+  onBack: () => void;
+  onRefreshWithPrices: (withPrices: boolean) => Promise<void>;
+}
+
+function DetailView({ detail, onBack, onRefreshWithPrices }: DetailViewProps) {
+  const [withPrices, setWithPrices] = useState(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const hasPriceData = detail.items.some((item) => item.current_price != null);
+
+  const handleTogglePrices = async () => {
+    const next = !withPrices;
+    setWithPrices(next);
+    setIsRefreshing(true);
+    try {
+      await onRefreshWithPrices(next);
+    } finally {
+      setIsRefreshing(false);
+    }
+  };
+
+  const showPriceColumns = withPrices && hasPriceData;
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Back + toggle */}
+      <div className="flex items-center justify-between gap-2">
+        <button
+          type="button"
+          onClick={onBack}
+          className="flex items-center gap-1.5 text-sm text-[var(--foreground-muted)] hover:text-[var(--foreground)] transition-colors"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          목록으로
+        </button>
+        <button
+          type="button"
+          onClick={handleTogglePrices}
+          disabled={isRefreshing}
+          className={`flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium transition-colors disabled:opacity-50 ${
+            withPrices
+              ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-400'
+              : 'border border-[var(--border)] text-[var(--foreground-muted)] hover:bg-[var(--border)]'
+          }`}
+        >
+          {isRefreshing ? (
+            <RefreshCw className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <DollarSign className="h-3.5 w-3.5" />
+          )}
+          현재가로 조회
+        </button>
+      </div>
+
+      {/* Archive meta */}
+      <div>
+        <h3 className="text-base font-semibold text-[var(--foreground)]">{detail.name}</h3>
+        {detail.description && (
+          <p className="mt-0.5 text-sm text-[var(--foreground-muted)]">{detail.description}</p>
+        )}
+        <p className="mt-1 text-xs text-[var(--foreground-muted)]">
+          {formatDate(detail.archived_at)} &middot; {detail.total_holdings}개 종목
+        </p>
+      </div>
+
+      {/* Items table */}
+      <div className="overflow-x-auto rounded-lg border border-[var(--border)]">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-[var(--border)] bg-[var(--background)]">
+              <th className="px-3 py-2.5 text-left text-xs font-medium text-[var(--foreground-muted)]">티커</th>
+              <th className="px-3 py-2.5 text-left text-xs font-medium text-[var(--foreground-muted)]">종목명</th>
+              <th className="px-3 py-2.5 text-right text-xs font-medium text-[var(--foreground-muted)]">수량</th>
+              <th className="px-3 py-2.5 text-right text-xs font-medium text-[var(--foreground-muted)]">매수가</th>
+              {showPriceColumns && (
+                <>
+                  <th className="px-3 py-2.5 text-right text-xs font-medium text-[var(--foreground-muted)]">현재가</th>
+                  <th className="px-3 py-2.5 text-right text-xs font-medium text-[var(--foreground-muted)]">수익률</th>
+                </>
+              )}
+            </tr>
+          </thead>
+          <tbody>
+            {detail.items.length === 0 && (
+              <tr>
+                <td
+                  colSpan={showPriceColumns ? 6 : 4}
+                  className="px-3 py-8 text-center text-[var(--foreground-muted)]"
+                >
+                  종목이 없습니다.
+                </td>
+              </tr>
+            )}
+            {detail.items.map((item: ArchiveItemResponse, idx: number) => (
+              <tr
+                key={`${item.ticker}-${idx}`}
+                className="border-b border-[var(--border)] last:border-0 hover:bg-[var(--background)] transition-colors"
+              >
+                <td className="px-3 py-2.5 font-mono font-medium text-[var(--foreground)]">
+                  {item.ticker}
+                </td>
+                <td className="px-3 py-2.5 text-[var(--foreground-muted)] max-w-[160px] truncate">
+                  {item.name ?? '-'}
+                </td>
+                <td className="px-3 py-2.5 text-right font-mono text-[var(--foreground)]">
+                  {item.quantity.toLocaleString()}
+                </td>
+                <td className="px-3 py-2.5 text-right font-mono text-[var(--foreground)]">
+                  {formatPrice(item.avg_price, item.currency)}
+                </td>
+                {showPriceColumns && (
+                  <>
+                    <td className="px-3 py-2.5 text-right font-mono text-[var(--foreground)]">
+                      {item.current_price != null
+                        ? formatPrice(item.current_price, item.currency)
+                        : '-'}
+                    </td>
+                    <td className="px-3 py-2.5 text-right">
+                      <PnlBadge pnl={item.pnl_pct} />
+                    </td>
+                  </>
+                )}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+// ── ArchiveModal ────────────────────────────────────────────────────────────
+
+/**
+ * Modal for creating, listing, and inspecting portfolio archives (snapshots).
+ */
+export default function ArchiveModal({ open, onClose, onHoldingsCleared }: ArchiveModalProps) {
+  const [archives, setArchives] = useState<ArchiveSummary[]>([]);
+  const [detail, setDetail] = useState<ArchiveDetailResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [listError, setListError] = useState<string | null>(null);
+
+  // Load list when opening
+  const loadList = useCallback(async () => {
+    setIsLoading(true);
+    setListError(null);
+    try {
+      const data = await listPortfolioArchives();
+      setArchives(data);
+    } catch (e) {
+      setListError(e instanceof Error ? e.message : '목록을 불러오지 못했습니다.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (open) {
+      setDetail(null);
+      loadList();
+    }
+  }, [open, loadList]);
+
+  // Escape key
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && open) onClose();
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [open, onClose]);
+
+  const handleCreate = useCallback(
+    async (name: string, description?: string, clearAfter?: boolean) => {
+      await createPortfolioArchive({ name, description, clear_after: clearAfter ?? false });
+      await loadList();
+      if (clearAfter) {
+        onHoldingsCleared?.();
+      }
+    },
+    [loadList],
+  );
+
+  const handleDelete = useCallback(
+    async (id: number) => {
+      await deletePortfolioArchive(id);
+      setArchives((prev) => prev.filter((a) => a.id !== id));
+    },
+    [],
+  );
+
+  const handleSelect = useCallback(async (id: number) => {
+    try {
+      const data = await getPortfolioArchive(id, false);
+      setDetail(data);
+    } catch (e) {
+      setListError(e instanceof Error ? e.message : '상세 정보를 불러오지 못했습니다.');
+    }
+  }, []);
+
+  const handleRefreshWithPrices = useCallback(
+    async (withPrices: boolean) => {
+      if (!detail) return;
+      const data = await getPortfolioArchive(detail.id, withPrices);
+      setDetail(data);
+    },
+    [detail],
+  );
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="archive-modal-title"
+    >
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Panel */}
+      <div className="relative flex flex-col w-full max-w-2xl max-h-[85vh] rounded-lg border border-[var(--border)] bg-[var(--background-secondary)] shadow-xl">
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-[var(--border)] px-6 py-4 shrink-0">
+          <div className="flex items-center gap-3">
+            <div className="rounded-full bg-blue-100 p-2 dark:bg-blue-900/50">
+              <Archive className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+            </div>
+            <h2 id="archive-modal-title" className="text-lg font-semibold text-[var(--foreground)]">
+              포트폴리오 아카이브
+            </h2>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded p-1 text-[var(--foreground-muted)] hover:bg-[var(--border)] hover:text-[var(--foreground)] transition-colors"
+            aria-label="닫기"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="overflow-y-auto flex-1 p-6">
+          {detail ? (
+            <DetailView
+              detail={detail}
+              onBack={() => setDetail(null)}
+              onRefreshWithPrices={handleRefreshWithPrices}
+            />
+          ) : (
+            <ListView
+              archives={archives}
+              isLoading={isLoading}
+              error={listError}
+              onCreate={handleCreate}
+              onSelect={handleSelect}
+              onDelete={handleDelete}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/portfolio/ChatPanel.tsx
+++ b/web/src/components/portfolio/ChatPanel.tsx
@@ -39,12 +39,14 @@ function renderMarkdown(text: string): React.ReactNode[] {
   const lines = text.split('\n');
   const result: React.ReactNode[] = [];
   let listItems: React.ReactNode[] = [];
+  let tableRows: string[][] = [];
+  let tableHeader: string[] | null = null;
   let nodeKey = 0;
 
   const flushList = () => {
     if (listItems.length > 0) {
       result.push(
-        <ul key={`ul-${nodeKey++}`} className="my-1 ml-4 list-disc space-y-0.5">
+        <ul key={`ul-${nodeKey++}`} className="my-1.5 ml-4 list-disc space-y-0.5 text-sm">
           {listItems}
         </ul>
       );
@@ -52,9 +54,40 @@ function renderMarkdown(text: string): React.ReactNode[] {
     }
   };
 
+  const flushTable = () => {
+    if (tableHeader && tableRows.length > 0) {
+      result.push(
+        <div key={`tbl-${nodeKey++}`} className="my-2 overflow-x-auto rounded-lg border border-[var(--border)]">
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="border-b border-[var(--border)] bg-[var(--background)]">
+                {tableHeader.map((cell, i) => (
+                  <th key={i} className="px-3 py-1.5 text-left font-semibold text-[var(--foreground-muted)]">
+                    {parseInline(cell.trim(), nodeKey * 100 + i)}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {tableRows.map((row, ri) => (
+                <tr key={ri} className={ri % 2 === 0 ? '' : 'bg-[var(--background)]'}>
+                  {row.map((cell, ci) => (
+                    <td key={ci} className="px-3 py-1.5 text-[var(--foreground)]">
+                      {parseInline(cell.trim(), nodeKey * 100 + ri * 10 + ci)}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      );
+    }
+    tableHeader = null;
+    tableRows = [];
+  };
+
   const parseInline = (raw: string, key: number): React.ReactNode => {
-    // Bold: **text** or __text__
-    // Italic: *text* or _text_
     const parts: React.ReactNode[] = [];
     const regex = /(\*\*|__)(.+?)\1|(\*|_)(.+?)\3/g;
     let last = 0;
@@ -65,7 +98,7 @@ function renderMarkdown(text: string): React.ReactNode[] {
         parts.push(<span key={`${key}-t${idx++}`}>{raw.slice(last, m.index)}</span>);
       }
       if (m[1]) {
-        parts.push(<strong key={`${key}-b${idx++}`}>{m[2]}</strong>);
+        parts.push(<strong key={`${key}-b${idx++}`} className="font-semibold">{m[2]}</strong>);
       } else {
         parts.push(<em key={`${key}-i${idx++}`}>{m[4]}</em>);
       }
@@ -77,25 +110,94 @@ function renderMarkdown(text: string): React.ReactNode[] {
     return parts.length === 1 ? parts[0] : <>{parts}</>;
   };
 
-  for (const line of lines) {
-    const listMatch = line.match(/^[-*]\s+(.*)/);
+  const parseTableCells = (line: string) =>
+    line.replace(/^\||\|$/g, '').split('|');
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const trimmed = line.trim();
+
+    // Heading: ## or ###
+    const headingMatch = trimmed.match(/^(#{1,3})\s+(.*)/);
+    if (headingMatch) {
+      flushList(); flushTable();
+      const level = headingMatch[1].length;
+      const content = headingMatch[2];
+      const cls = level === 1
+        ? 'mt-3 mb-1 text-base font-bold text-[var(--foreground)] border-b border-[var(--border)] pb-1'
+        : level === 2
+        ? 'mt-2.5 mb-1 text-sm font-bold text-[var(--foreground)]'
+        : 'mt-2 mb-0.5 text-xs font-semibold text-[var(--foreground-muted)] uppercase tracking-wide';
+      result.push(
+        <p key={`h${level}-${nodeKey}`} className={cls}>
+          {parseInline(content, nodeKey)}
+        </p>
+      );
+      nodeKey++;
+      continue;
+    }
+
+    // Horizontal rule: --- or ***
+    if (/^[-*]{3,}$/.test(trimmed)) {
+      flushList(); flushTable();
+      result.push(<hr key={`hr-${nodeKey++}`} className="my-2 border-[var(--border)]" />);
+      continue;
+    }
+
+    // Blockquote: > text
+    const bqMatch = trimmed.match(/^>\s*(.*)/);
+    if (bqMatch) {
+      flushList(); flushTable();
+      result.push(
+        <blockquote key={`bq-${nodeKey}`} className="my-1 border-l-2 border-[var(--color-primary)] pl-3 text-sm text-[var(--foreground-muted)] italic">
+          {parseInline(bqMatch[1], nodeKey)}
+        </blockquote>
+      );
+      nodeKey++;
+      continue;
+    }
+
+    // Table row: | ... |
+    if (trimmed.startsWith('|') && trimmed.endsWith('|')) {
+      flushList();
+      // Separator row: |---|---|
+      if (/^\|[-| :]+\|$/.test(trimmed)) continue;
+      const cells = parseTableCells(trimmed);
+      if (tableHeader === null) {
+        tableHeader = cells;
+      } else {
+        tableRows.push(cells);
+      }
+      continue;
+    } else {
+      flushTable();
+    }
+
+    // List item: - or *
+    const listMatch = trimmed.match(/^[-*]\s+(.*)/);
     if (listMatch) {
       listItems.push(
         <li key={`li-${nodeKey}`}>{parseInline(listMatch[1], nodeKey)}</li>
       );
       nodeKey++;
+      continue;
+    }
+
+    flushList();
+    if (trimmed === '') {
+      result.push(<div key={`sp-${nodeKey++}`} className="h-1" />);
     } else {
-      flushList();
-      if (line.trim() === '') {
-        result.push(<br key={`br-${nodeKey++}`} />);
-      } else {
-        result.push(<p key={`p-${nodeKey}`}>{parseInline(line, nodeKey)}</p>);
-        nodeKey++;
-      }
+      result.push(
+        <p key={`p-${nodeKey}`} className="leading-relaxed">
+          {parseInline(trimmed, nodeKey)}
+        </p>
+      );
+      nodeKey++;
     }
   }
-  flushList();
 
+  flushList();
+  flushTable();
   return result;
 }
 

--- a/web/src/components/portfolio/ChatPanel.tsx
+++ b/web/src/components/portfolio/ChatPanel.tsx
@@ -149,7 +149,7 @@ function renderMarkdown(text: string): React.ReactNode[] {
     if (bqMatch) {
       flushList(); flushTable();
       result.push(
-        <blockquote key={`bq-${nodeKey}`} className="my-1 border-l-2 border-[var(--color-primary)] pl-3 text-sm text-[var(--foreground-muted)] italic">
+        <blockquote key={`bq-${nodeKey}`} className="my-1 border-l-2 border-[var(--color-primary)] pl-3 text-xs text-[var(--foreground-muted)] italic">
           {parseInline(bqMatch[1], nodeKey)}
         </blockquote>
       );
@@ -188,7 +188,7 @@ function renderMarkdown(text: string): React.ReactNode[] {
       result.push(<div key={`sp-${nodeKey++}`} className="h-1" />);
     } else {
       result.push(
-        <p key={`p-${nodeKey}`} className="leading-relaxed">
+        <p key={`p-${nodeKey}`} className="text-xs leading-relaxed text-[var(--foreground)]">
           {parseInline(trimmed, nodeKey)}
         </p>
       );

--- a/web/src/components/portfolio/ChatPanel.tsx
+++ b/web/src/components/portfolio/ChatPanel.tsx
@@ -1,0 +1,357 @@
+'use client';
+
+import { useState, useRef, useEffect, useCallback, KeyboardEvent } from 'react';
+import { X, MessageCircle, Send, Loader2, Settings2 } from 'lucide-react';
+import { streamPortfolioChat } from '@/lib/api';
+import type { ChatMessage } from '@/lib/api';
+
+interface ChatPanelProps {
+  /** Whether the chat panel is visible */
+  open: boolean;
+  /** Callback to close the panel */
+  onClose: () => void;
+}
+
+interface DisplayMessage {
+  role: 'user' | 'assistant';
+  content: string;
+  /** Unique key for React list rendering */
+  id: number;
+}
+
+interface ToolActivity {
+  name: string;
+}
+
+const INITIAL_MESSAGE: DisplayMessage = {
+  id: 0,
+  role: 'assistant',
+  content:
+    '안녕하세요! 포트폴리오 분석을 도와드릴게요. 궁금한 종목이나 매매 타이밍을 물어보세요.',
+};
+
+/**
+ * Minimal inline markdown renderer.
+ * Supports **bold**, *italic*, and unordered lists (- or *).
+ * No external dependencies.
+ */
+function renderMarkdown(text: string): React.ReactNode[] {
+  const lines = text.split('\n');
+  const result: React.ReactNode[] = [];
+  let listItems: React.ReactNode[] = [];
+  let nodeKey = 0;
+
+  const flushList = () => {
+    if (listItems.length > 0) {
+      result.push(
+        <ul key={`ul-${nodeKey++}`} className="my-1 ml-4 list-disc space-y-0.5">
+          {listItems}
+        </ul>
+      );
+      listItems = [];
+    }
+  };
+
+  const parseInline = (raw: string, key: number): React.ReactNode => {
+    // Bold: **text** or __text__
+    // Italic: *text* or _text_
+    const parts: React.ReactNode[] = [];
+    const regex = /(\*\*|__)(.+?)\1|(\*|_)(.+?)\3/g;
+    let last = 0;
+    let m: RegExpExecArray | null;
+    let idx = 0;
+    while ((m = regex.exec(raw)) !== null) {
+      if (m.index > last) {
+        parts.push(<span key={`${key}-t${idx++}`}>{raw.slice(last, m.index)}</span>);
+      }
+      if (m[1]) {
+        parts.push(<strong key={`${key}-b${idx++}`}>{m[2]}</strong>);
+      } else {
+        parts.push(<em key={`${key}-i${idx++}`}>{m[4]}</em>);
+      }
+      last = m.index + m[0].length;
+    }
+    if (last < raw.length) {
+      parts.push(<span key={`${key}-t${idx++}`}>{raw.slice(last)}</span>);
+    }
+    return parts.length === 1 ? parts[0] : <>{parts}</>;
+  };
+
+  for (const line of lines) {
+    const listMatch = line.match(/^[-*]\s+(.*)/);
+    if (listMatch) {
+      listItems.push(
+        <li key={`li-${nodeKey}`}>{parseInline(listMatch[1], nodeKey)}</li>
+      );
+      nodeKey++;
+    } else {
+      flushList();
+      if (line.trim() === '') {
+        result.push(<br key={`br-${nodeKey++}`} />);
+      } else {
+        result.push(<p key={`p-${nodeKey}`}>{parseInline(line, nodeKey)}</p>);
+        nodeKey++;
+      }
+    }
+  }
+  flushList();
+
+  return result;
+}
+
+/**
+ * Single message bubble in the chat.
+ */
+function MessageBubble({ msg }: { msg: DisplayMessage }) {
+  const isUser = msg.role === 'user';
+  return (
+    <div className={`flex ${isUser ? 'justify-end' : 'justify-start'}`}>
+      <div
+        className={`max-w-[85%] rounded-2xl px-4 py-2.5 text-sm leading-relaxed ${
+          isUser
+            ? 'rounded-br-sm bg-[var(--color-primary)] text-white'
+            : 'rounded-bl-sm bg-[var(--background-secondary)] text-[var(--foreground)]'
+        }`}
+      >
+        {isUser ? (
+          <span className="whitespace-pre-wrap">{msg.content}</span>
+        ) : (
+          <div className="prose-sm">{renderMarkdown(msg.content)}</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Animated tool-use indicator shown while the AI calls a tool.
+ */
+function ToolIndicator({ tool }: { tool: ToolActivity }) {
+  return (
+    <div className="flex justify-start">
+      <div className="flex items-center gap-2 rounded-full border border-[var(--border)] bg-[var(--background)] px-3 py-1.5 text-xs text-[var(--foreground-muted)]">
+        <Settings2 className="h-3.5 w-3.5 animate-spin" />
+        <span>{tool.name} 조회 중...</span>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * AI 어시스턴트 사이드 패널 for portfolio page.
+ * Streams responses from POST /api/chat/portfolio.
+ */
+export default function ChatPanel({ open, onClose }: ChatPanelProps) {
+  const [messages, setMessages] = useState<DisplayMessage[]>([INITIAL_MESSAGE]);
+  const [input, setInput] = useState('');
+  const [isSending, setIsSending] = useState(false);
+  const [activeTool, setActiveTool] = useState<ToolActivity | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const nextId = useRef(1);
+  /** Holds the active AbortController so we can cancel the stream on close/unmount */
+  const abortRef = useRef<AbortController | null>(null);
+
+  /** Scroll to the bottom of the message list */
+  const scrollToBottom = useCallback(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, []);
+
+  useEffect(() => {
+    scrollToBottom();
+  }, [messages, activeTool, scrollToBottom]);
+
+  /** Focus input when panel opens; abort any running stream when it closes */
+  useEffect(() => {
+    if (open) {
+      // 100 ms delay: allows CSS display transition to complete before focusing
+      setTimeout(() => textareaRef.current?.focus(), 100);
+    } else {
+      abortRef.current?.abort();
+    }
+  }, [open]);
+
+  /** Cancel any in-flight stream on unmount */
+  useEffect(() => {
+    return () => { abortRef.current?.abort(); };
+  }, []);
+
+  /** Auto-resize textarea */
+  const resizeTextarea = useCallback(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = 'auto';
+    el.style.height = `${Math.min(el.scrollHeight, 120)}px`;
+  }, []);
+
+  /** Build history for API from display messages (skip initial greeting) */
+  const buildHistory = useCallback((displayMsgs: DisplayMessage[]): ChatMessage[] => {
+    return displayMsgs
+      .filter((m) => m.id !== 0)
+      .map((m) => ({ role: m.role, content: m.content }));
+  }, []);
+
+  const sendMessage = useCallback(async () => {
+    const text = input.trim();
+    if (!text || isSending) return;
+
+    setInput('');
+    setError(null);
+    if (textareaRef.current) {
+      textareaRef.current.style.height = 'auto';
+    }
+
+    const userMsg: DisplayMessage = {
+      id: nextId.current++,
+      role: 'user',
+      content: text,
+    };
+
+    const assistantMsg: DisplayMessage = {
+      id: nextId.current++,
+      role: 'assistant',
+      content: '',
+    };
+
+    setMessages((prev) => [...prev, userMsg, assistantMsg]);
+    setIsSending(true);
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    try {
+      const history = buildHistory([...messages, userMsg]);
+
+      const gen = streamPortfolioChat(history, true, controller.signal);
+      for await (const event of gen) {
+        if (event.type === 'text' && event.content) {
+          setMessages((prev) =>
+            prev.map((m) =>
+              m.id === assistantMsg.id
+                ? { ...m, content: m.content + event.content }
+                : m
+            )
+          );
+        } else if (event.type === 'tool_start' && event.name) {
+          setActiveTool({ name: event.name });
+        } else if (event.type === 'tool_end') {
+          setActiveTool(null);
+        } else if (event.type === 'error' && event.message) {
+          setError(event.message);
+          setActiveTool(null);
+        } else if (event.type === 'done') {
+          setActiveTool(null);
+        }
+      }
+    } catch (err) {
+      // AbortError is intentional (panel closed) — don't show an error
+      if (err instanceof Error && err.name === 'AbortError') {
+        setActiveTool(null);
+        return;
+      }
+      setError(err instanceof Error ? err.message : '응답을 불러오지 못했습니다.');
+      setActiveTool(null);
+      // Remove empty assistant bubble on failure
+      setMessages((prev) =>
+        prev.filter((m) => !(m.id === assistantMsg.id && m.content === ''))
+      );
+    } finally {
+      setIsSending(false);
+    }
+  }, [input, isSending, messages, buildHistory]);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        sendMessage();
+      }
+    },
+    [sendMessage]
+  );
+
+  // CSS-hide instead of unmount so message history is preserved across open/close
+  return (
+    <aside
+      className={`flex h-full w-[400px] flex-shrink-0 flex-col rounded-xl border border-[var(--border)] bg-[var(--background-secondary)] shadow-xl${!open ? ' hidden' : ''}`}
+      aria-label="AI 어시스턴트"
+      role="complementary"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3">
+        <div className="flex items-center gap-2">
+          <div className="rounded-full bg-blue-100 p-1.5 dark:bg-blue-900/40">
+            <MessageCircle className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+          </div>
+          <span className="text-sm font-semibold text-[var(--foreground)]">AI 어시스턴트</span>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded p-1 text-[var(--foreground-muted)] transition-colors hover:bg-[var(--border)] hover:text-[var(--foreground)]"
+          aria-label="닫기"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      {/* Message list */}
+      <div
+        className="flex flex-1 flex-col gap-3 overflow-y-auto px-4 py-4"
+        role="log"
+        aria-live="polite"
+        aria-label="대화 내용"
+      >
+        {messages.map((msg) => (
+          <MessageBubble key={msg.id} msg={msg} />
+        ))}
+        {activeTool && <ToolIndicator tool={activeTool} />}
+        {error && (
+          <div className="rounded-lg border border-red-300 bg-red-50 px-3 py-2 text-xs text-red-700 dark:border-red-800 dark:bg-red-950/50 dark:text-red-300">
+            {error}
+          </div>
+        )}
+        <div ref={bottomRef} />
+      </div>
+
+      {/* Input area */}
+      <div className="border-t border-[var(--border)] px-3 py-3">
+        <div className="flex items-end gap-2">
+          <textarea
+            ref={textareaRef}
+            value={input}
+            onChange={(e) => {
+              setInput(e.target.value);
+              resizeTextarea();
+            }}
+            onKeyDown={handleKeyDown}
+            disabled={isSending}
+            rows={1}
+            placeholder="메시지를 입력하세요..."
+            aria-label="메시지 입력"
+            className="flex-1 resize-none rounded-xl border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)] placeholder:text-[var(--foreground-muted)] focus:outline-none focus:ring-2 focus:ring-blue-500/30 disabled:opacity-50"
+            style={{ minHeight: '40px', maxHeight: '120px' }}
+          />
+          <button
+            type="button"
+            onClick={sendMessage}
+            disabled={isSending || !input.trim()}
+            aria-label="전송"
+            className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl bg-[var(--color-primary)] text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            {isSending ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Send className="h-4 w-4" />
+            )}
+          </button>
+        </div>
+        <p className="mt-1.5 text-center text-[10px] text-[var(--foreground-muted)]">
+          Enter로 전송 · Shift+Enter 줄바꿈
+        </p>
+      </div>
+    </aside>
+  );
+}

--- a/web/src/components/portfolio/ChatPanel.tsx
+++ b/web/src/components/portfolio/ChatPanel.tsx
@@ -186,10 +186,10 @@ export default function ChatPanel({ open, onClose }: ChatPanelProps) {
     el.style.height = `${Math.min(el.scrollHeight, 120)}px`;
   }, []);
 
-  /** Build history for API from display messages (skip initial greeting) */
+  /** Build history for API from display messages (skip greeting + empty bubbles) */
   const buildHistory = useCallback((displayMsgs: DisplayMessage[]): ChatMessage[] => {
     return displayMsgs
-      .filter((m) => m.id !== 0)
+      .filter((m) => m.id !== 0 && m.content.trim() !== '')
       .map((m) => ({ role: m.role, content: m.content }));
   }, []);
 
@@ -241,6 +241,10 @@ export default function ChatPanel({ open, onClose }: ChatPanelProps) {
         } else if (event.type === 'error' && event.message) {
           setError(event.message);
           setActiveTool(null);
+          // Remove empty assistant bubble so it doesn't pollute history on retry
+          setMessages((prev) =>
+            prev.filter((m) => !(m.id === assistantMsg.id && m.content === ''))
+          );
         } else if (event.type === 'done') {
           setActiveTool(null);
         }

--- a/web/src/components/portfolio/index.ts
+++ b/web/src/components/portfolio/index.ts
@@ -10,3 +10,5 @@ export { default as SellModal } from './SellModal';
 export { default as TradeHistory } from './TradeHistory';
 export { default as AllocationCharts } from './AllocationCharts';
 export { default as SellRuleModal } from './SellRuleModal';
+export { default as ArchiveModal } from './ArchiveModal';
+export { default as ChatPanel } from './ChatPanel';

--- a/web/src/contexts/UserSettingsContext.tsx
+++ b/web/src/contexts/UserSettingsContext.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { createContext, useContext, useState, useCallback, type ReactNode } from 'react';
+import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from 'react';
 import type { BaseCurrency } from '@/lib/format';
 
 interface UserSettings {
@@ -41,7 +41,13 @@ function saveSettings(settings: UserSettings) {
 }
 
 export function UserSettingsProvider({ children }: { children: ReactNode }) {
-  const [settings, setSettings] = useState<UserSettings>(() => loadSettings());
+  // Always initialize with DEFAULT_SETTINGS so SSR and client initial render match.
+  // Sync from localStorage after mount to avoid hydration mismatch.
+  const [settings, setSettings] = useState<UserSettings>(DEFAULT_SETTINGS);
+
+  useEffect(() => {
+    setSettings(loadSettings());
+  }, []);
 
   const updateBaseCurrency = useCallback((currency: BaseCurrency) => {
     setSettings((prev) => {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1772,9 +1772,15 @@ export async function* streamPortfolioChat(
     signal,
   });
   if (!res.ok) {
-    // Surface server-side detail (e.g. 503 "ANTHROPIC_API_KEY가 설정되지 않았습니다")
+    // Surface server-side detail — detail may be a string (HTTPException) or
+    // an array of objects (Pydantic 422), so always stringify it.
     let detail = '';
-    try { detail = (await res.json()).detail ?? ''; } catch { /* ignore */ }
+    try {
+      const body = await res.json();
+      detail = typeof body.detail === 'string'
+        ? body.detail
+        : JSON.stringify(body.detail ?? '');
+    } catch { /* ignore */ }
     throw new Error(detail || `Chat error: ${res.status}`);
   }
   if (!res.body) throw new Error('No response body from chat endpoint');

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -55,6 +55,8 @@ import type {
   SellRuleEvaluateResult,
   SellRulePreset,
   OHLCVData,
+  ArchiveSummary,
+  ArchiveDetailResponse,
 } from './types';
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001';
@@ -1695,4 +1697,102 @@ export async function runOptimize(request: OptimizeRequest): Promise<OptimizeRes
     method: 'POST',
     body: JSON.stringify(request),
   });
+}
+
+// ── Portfolio Archives ──────────────────────────────────────────────────────
+
+/**
+ * Create a new portfolio archive (snapshot of current holdings)
+ */
+export async function createPortfolioArchive(data: { name: string; description?: string; clear_after?: boolean }): Promise<ArchiveDetailResponse> {
+  return fetchApi<ArchiveDetailResponse>('/api/portfolio/archives', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+}
+
+/**
+ * List all portfolio archives
+ */
+export async function listPortfolioArchives(): Promise<ArchiveSummary[]> {
+  return fetchApi<ArchiveSummary[]>('/api/portfolio/archives');
+}
+
+/**
+ * Get a single portfolio archive by ID
+ */
+export async function getPortfolioArchive(id: number, withPrices = false): Promise<ArchiveDetailResponse> {
+  return fetchApi<ArchiveDetailResponse>(`/api/portfolio/archives/${id}?with_prices=${withPrices}`);
+}
+
+/**
+ * Delete a portfolio archive by ID
+ */
+export async function deletePortfolioArchive(id: number): Promise<void> {
+  return fetchApi<void>(`/api/portfolio/archives/${id}`, { method: 'DELETE' });
+}
+
+export async function clearPortfolioCache(): Promise<void> {
+  return fetchApi<void>('/api/portfolio/cache/clear', { method: 'POST' });
+}
+
+export async function deleteAllHoldings(): Promise<void> {
+  return fetchApi<void>('/api/portfolio/holdings', { method: 'DELETE' });
+}
+
+// ── Portfolio AI Chat ────────────────────────────────────────────────────────
+
+export interface ChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+export interface ChatStreamEvent {
+  type: string;
+  content?: string;
+  name?: string;
+  input?: unknown;
+  message?: string;
+}
+
+/**
+ * Stream portfolio AI chat responses via SSE.
+ * Yields parsed event objects until the stream ends.
+ * Pass an AbortSignal to cancel mid-stream (e.g. when the panel closes).
+ */
+export async function* streamPortfolioChat(
+  messages: ChatMessage[],
+  includePortfolio = true,
+  signal?: AbortSignal,
+): AsyncGenerator<ChatStreamEvent> {
+  const res = await fetch(`${API_BASE_URL}/api/chat/portfolio`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ messages, include_portfolio: includePortfolio }),
+    signal,
+  });
+  if (!res.ok) {
+    // Surface server-side detail (e.g. 503 "ANTHROPIC_API_KEY가 설정되지 않았습니다")
+    let detail = '';
+    try { detail = (await res.json()).detail ?? ''; } catch { /* ignore */ }
+    throw new Error(detail || `Chat error: ${res.status}`);
+  }
+  if (!res.body) throw new Error('No response body from chat endpoint');
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split(/\r?\n/);
+    buffer = lines.pop() ?? '';
+    for (const line of lines) {
+      if (line.startsWith('data: ')) {
+        try {
+          yield JSON.parse(line.slice(6)) as ChatStreamEvent;
+        } catch { /* skip malformed events */ }
+      }
+    }
+  }
 }

--- a/web/src/lib/strategy/graphSerializer.ts
+++ b/web/src/lib/strategy/graphSerializer.ts
@@ -67,6 +67,7 @@ export interface StrategyEdge {
 }
 
 export interface StrategyGraph {
+  markets?: string[];
   nodes: StrategyNode[];
   edges: StrategyEdge[];
 }
@@ -107,7 +108,13 @@ export function serializeGraph(
     }
   }
 
+  const universeNode = nodes.find((n) => n.data.node_type === 'universe');
+  const markets = universeNode?.data.universe
+    ? parseUniverseSelection(universeNode.data.universe)
+    : ['KOSPI'];
+
   return {
+    markets,
     nodes: nodes.map((n) => ({
       id: n.id,
       data: {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -837,3 +837,28 @@ export interface BuySignal {
   currency: string | null;
   rule_id: number | null;
 }
+
+// Portfolio Archive types
+export interface ArchiveSummary {
+  id: number;
+  name: string;
+  description?: string | null;
+  archived_at: string;
+  total_holdings: number;
+}
+
+export interface ArchiveItemResponse {
+  ticker: string;
+  name?: string | null;
+  quantity: number;
+  avg_price: number;
+  currency: string;
+  bought_at?: string | null;
+  sector?: string | null;
+  current_price?: number | null;
+  pnl_pct?: number | null;
+}
+
+export interface ArchiveDetailResponse extends ArchiveSummary {
+  items: ArchiveItemResponse[];
+}


### PR DESCRIPTION
## Summary

- **Portfolio Archive**: Save snapshot to DB, view with current prices, optional clear-after-archive (FK-safe bulk delete)
- **Bulk Operations**: Delete all holdings, force-refresh price cache button
- **Price Fix**: `auto_adjust=False` in yfinance — prevents dividend-adjusted prices (fixes REITs like Koramco showing ₩4,800 instead of ~₩10,000)
- **CSV Import Validation**: Reject invalid tickers (6-char codes without `.KS`/`.KQ`) instead of silently auto-converting
- **Strategy Export**: Market names included in serialized graph JSON
- **AI Chatbot (Phase 1 + 2)**: SSE streaming with Claude `claude-sonnet-4-6` + tool_use agentic loop
  - Tools: `get_holdings`, `get_price_history`, `get_indicators`, `get_news`, `get_macro_context`
  - `asyncio.Queue` bridge for sync Anthropic SDK → async FastAPI SSE
  - Block-index-aware multi-tool routing (prevents spurious `tool_end` on text blocks)
  - `AbortController` for stream cancellation when panel closes
  - Sliding window history (last 20 messages) to prevent context overflow
  - Inline markdown renderer — no external deps

## Test plan

- [ ] Set `ANTHROPIC_API_KEY` env var, start API (`uvicorn api.main:app --port 8001`), open portfolio page
- [ ] Click "AI 어시스턴트" → chat panel opens; ask about a holding → tools animate → streamed response appears
- [ ] Close panel → reopen → message history preserved (CSS hide, not unmount)
- [ ] Ask while panel closed mid-stream → stream cancels, no error shown
- [ ] Click "아카이브" → create archive → check "비우기" option → holdings cleared on modal close
- [ ] Reopen archive → toggle "현재가로 조회" → prices update
- [ ] Click "강제 새로고침" → cache cleared, prices reload
- [ ] Click "전체 삭제" → confirm dialog → all holdings removed
- [ ] Upload CSV with bare Korean ticker (e.g. `005930`) → error: invalid ticker format
- [ ] Upload CSV with `.KS` ticker → succeeds
- [ ] Export strategy → JSON includes `markets` array

🤖 Generated with [Claude Code](https://claude.com/claude-code)