### PR TITLE
feat(web): add user/bot avatar icons to strategy chat panel

### DIFF
--- a/web/src/components/strategy/ChatPanel.tsx
+++ b/web/src/components/strategy/ChatPanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useRef, useEffect, useCallback } from 'react';
-import { MessageCircle, X, Send, Loader2 } from 'lucide-react';
+import { MessageCircle, X, Send, Loader2, User, Bot } from 'lucide-react';
 import { useLocale, useTranslations } from 'next-intl';
 import MarkdownMessage from './chat/MarkdownMessage';
 import MessageActions from './chat/MessageActions';
@@ -248,53 +248,68 @@ export default function ChatPanel({ graph, onAddNodes, existingConditionNodes, o
                 </p>
               </div>
             )}
-            <div className="flex flex-col gap-3">
+            <div className="flex flex-col gap-4">
               {messages.map((msg, i) => (
                 <div
                   key={i}
-                  className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}
+                  className={`flex items-end gap-2 ${msg.role === 'user' ? 'flex-row-reverse' : 'flex-row'}`}
                 >
-                  <div
-                    className={`max-w-[80%] rounded-lg p-3 text-sm leading-relaxed ${
-                      msg.role === 'user'
-                        ? 'bg-blue-600 text-white whitespace-pre-wrap'
-                        : 'bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-gray-100'
-                    }`}
-                  >
-                    {msg.role === 'user' ? (
-                      msg.content
-                    ) : msg.structuredPayload ? (
-                      <SectionedMessage
-                        content={msg.content}
-                        payload={msg.structuredPayload}
-                        nodeMappings={msg.nodeMappings}
-                        onAddNodes={onAddNodes}
-                        existingConditionNodes={existingConditionNodes}
-                        onUpdateNode={onUpdateNode}
-                      />
-                    ) : (
-                      <MarkdownMessage content={msg.content} />
-                    )}
-                    {msg.role === 'assistant' &&
-                      i === messages.length - 1 &&
-                      isStreaming && (
-                        <span className="ml-0.5 inline-block h-4 w-1 animate-pulse bg-current align-text-bottom" />
+                  {/* Avatar */}
+                  <div className={`flex-shrink-0 flex h-7 w-7 items-center justify-center rounded-full text-white shadow-sm ${
+                    msg.role === 'user'
+                      ? 'bg-blue-600'
+                      : 'bg-gradient-to-br from-violet-500 to-indigo-600'
+                  }`}>
+                    {msg.role === 'user'
+                      ? <User className="h-3.5 w-3.5" />
+                      : <Bot className="h-3.5 w-3.5" />
+                    }
+                  </div>
+
+                  {/* Bubble */}
+                  <div className={`flex flex-col gap-1 ${msg.role === 'user' ? 'items-end' : 'items-start'}`}>
+                    <div
+                      className={`max-w-[75%] rounded-2xl px-3 py-2.5 text-sm leading-relaxed ${
+                        msg.role === 'user'
+                          ? 'rounded-br-sm bg-blue-600 text-white whitespace-pre-wrap'
+                          : 'rounded-bl-sm bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-gray-100'
+                      }`}
+                    >
+                      {msg.role === 'user' ? (
+                        msg.content
+                      ) : msg.structuredPayload ? (
+                        <SectionedMessage
+                          content={msg.content}
+                          payload={msg.structuredPayload}
+                          nodeMappings={msg.nodeMappings}
+                          onAddNodes={onAddNodes}
+                          existingConditionNodes={existingConditionNodes}
+                          onUpdateNode={onUpdateNode}
+                        />
+                      ) : (
+                        <MarkdownMessage content={msg.content} />
                       )}
+                      {msg.role === 'assistant' &&
+                        i === messages.length - 1 &&
+                        isStreaming && (
+                          <span className="ml-0.5 inline-block h-4 w-1 animate-pulse bg-current align-text-bottom" />
+                        )}
+                      {msg.role === 'assistant' &&
+                        i === messages.length - 1 &&
+                        isStreaming &&
+                        !msg.content && (
+                          <Loader2 className="inline h-3 w-3 animate-spin text-gray-400" />
+                        )}
+                    </div>
                     {msg.role === 'assistant' &&
-                      i === messages.length - 1 &&
-                      isStreaming &&
-                      !msg.content && (
-                        <Loader2 className="inline h-3 w-3 animate-spin text-gray-400" />
+                      msg.content &&
+                      !(i === messages.length - 1 && isStreaming) && (
+                        <MessageActions
+                          content={msg.content}
+                          payload={msg.structuredPayload}
+                        />
                       )}
                   </div>
-                  {msg.role === 'assistant' &&
-                    msg.content &&
-                    !(i === messages.length - 1 && isStreaming) && (
-                      <MessageActions
-                        content={msg.content}
-                        payload={msg.structuredPayload}
-                      />
-                    )}
                 </div>
               ))}
               <div ref={messagesEndRef} />

--- a/web/src/components/strategy/ChatPanel.tsx
+++ b/web/src/components/strategy/ChatPanel.tsx
@@ -7,6 +7,7 @@ import MarkdownMessage from './chat/MarkdownMessage';
 import MessageActions from './chat/MessageActions';
 import SectionedMessage from './chat/SectionedMessage';
 import { normalizeChunk, finalizeStreamText } from './chat/streamTextFormatter';
+import { cn } from '@/lib/utils';
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001';
 
@@ -30,6 +31,7 @@ export interface NodeMapping {
 }
 
 interface ChatMessage {
+  id: string;
   role: 'user' | 'assistant';
   content: string;
   structuredPayload?: StructuredPayload;
@@ -88,9 +90,9 @@ export default function ChatPanel({ graph, onAddNodes, existingConditionNodes, o
     const trimmed = input.trim();
     if (!trimmed || isStreaming) return;
 
-    const userMsg: ChatMessage = { role: 'user', content: trimmed };
+    const userMsg: ChatMessage = { id: crypto.randomUUID(), role: 'user', content: trimmed };
     const newMessages = [...messages, userMsg];
-    setMessages([...newMessages, { role: 'assistant', content: '' }]);
+    setMessages([...newMessages, { id: crypto.randomUUID(), role: 'assistant', content: '' }]);
     setInput('');
     setIsStreaming(true);
 
@@ -251,29 +253,35 @@ export default function ChatPanel({ graph, onAddNodes, existingConditionNodes, o
             <div className="flex flex-col gap-4">
               {messages.map((msg, i) => (
                 <div
-                  key={i}
+                  key={msg.id}
+                  aria-label={msg.role === 'user' ? 'You' : 'AI Assistant'}
                   className={`flex items-end gap-2 ${msg.role === 'user' ? 'flex-row-reverse' : 'flex-row'}`}
                 >
                   {/* Avatar */}
-                  <div className={`flex-shrink-0 flex h-7 w-7 items-center justify-center rounded-full text-white shadow-sm ${
-                    msg.role === 'user'
-                      ? 'bg-blue-600'
-                      : 'bg-gradient-to-br from-violet-500 to-indigo-600'
-                  }`}>
+                  <div
+                    aria-hidden="true"
+                    className={cn(
+                      'flex-shrink-0 flex h-7 w-7 items-center justify-center rounded-full text-white shadow-sm',
+                      msg.role === 'user'
+                        ? 'bg-blue-600'
+                        : 'bg-gradient-to-br from-violet-500 to-indigo-600',
+                    )}
+                  >
                     {msg.role === 'user'
                       ? <User className="h-3.5 w-3.5" />
                       : <Bot className="h-3.5 w-3.5" />
                     }
                   </div>
 
-                  {/* Bubble */}
-                  <div className={`flex flex-col gap-1 ${msg.role === 'user' ? 'items-end' : 'items-start'}`}>
+                  {/* Bubble wrapper */}
+                  <div className={`flex max-w-[75%] flex-col gap-1 ${msg.role === 'user' ? 'items-end' : 'items-start'}`}>
                     <div
-                      className={`max-w-[75%] rounded-2xl px-3 py-2.5 text-sm leading-relaxed ${
+                      className={cn(
+                        'rounded-2xl px-3 py-2.5 text-sm leading-relaxed',
                         msg.role === 'user'
                           ? 'rounded-br-sm bg-blue-600 text-white whitespace-pre-wrap'
-                          : 'rounded-bl-sm bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-gray-100'
-                      }`}
+                          : 'rounded-bl-sm bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-gray-100',
+                      )}
                     >
                       {msg.role === 'user' ? (
                         msg.content
@@ -289,17 +297,11 @@ export default function ChatPanel({ graph, onAddNodes, existingConditionNodes, o
                       ) : (
                         <MarkdownMessage content={msg.content} />
                       )}
-                      {msg.role === 'assistant' &&
-                        i === messages.length - 1 &&
-                        isStreaming && (
-                          <span className="ml-0.5 inline-block h-4 w-1 animate-pulse bg-current align-text-bottom" />
-                        )}
-                      {msg.role === 'assistant' &&
-                        i === messages.length - 1 &&
-                        isStreaming &&
-                        !msg.content && (
-                          <Loader2 className="inline h-3 w-3 animate-spin text-gray-400" />
-                        )}
+                      {msg.role === 'assistant' && i === messages.length - 1 && isStreaming && (
+                        msg.content
+                          ? <span className="ml-0.5 inline-block h-4 w-1 animate-pulse bg-current align-text-bottom" />
+                          : <Loader2 className="inline h-3 w-3 animate-spin text-gray-400" />
+                      )}
                     </div>
                     {msg.role === 'assistant' &&
                       msg.content &&


### PR DESCRIPTION
## Summary
- Add circular avatar icons to each chat message in the strategy AI chat panel
- Blue circle with `User` icon on the right side for user messages
- Violet-indigo gradient circle with `Bot` icon on the left side for assistant messages
- Bubble corners directionally rounded (`rounded-br-sm` for user, `rounded-bl-sm` for bot) to reinforce the visual chat tail convention

## Test plan
- [ ] Open strategy page and click the chat bubble
- [ ] Send a message and verify blue user avatar appears on the right
- [ ] Verify bot response shows violet-indigo gradient avatar on the left
- [ ] Confirm bubble shapes have correct directional rounded corners

🤖 Generated with [Claude Code](https://claude.com/claude-code)