### PR TITLE
feat: worldmonitor self-host + FastAPI integration (#1381)

### DIFF
--- a/api/routers/market.py
+++ b/api/routers/market.py
@@ -11,6 +11,10 @@ from typing import Annotated, List, Literal
 from fastapi import APIRouter, HTTPException, Query
 
 from api.schemas.market import (
+    CountryRiskResponse,
+    CountryRiskSignal,
+    GlobalBriefItem,
+    GlobalBriefResponse,
     MacroBondSnapshot,
     MacroBundleResponse,
     MacroDataQuality,
@@ -18,6 +22,8 @@ from api.schemas.market import (
     MacroHistoryResponse,
     MacroUsMarketSnapshot,
     MacroVolatilitySnapshot,
+    MarketRadarExchange,
+    MarketRadarResponse,
     OHLCVResponse,
     QuoteResponse,
     TechnicalIndicators,
@@ -343,3 +349,103 @@ def get_macro_history(
         result["data_coverage_pct"] = 0.0
 
     return MacroHistoryResponse(**result)
+
+
+# ---------------------------------------------------------------------------
+# Worldmonitor endpoints (additive — existing macro page unaffected)
+# ---------------------------------------------------------------------------
+
+
+def _get_wm_client():
+    """Lazy import to avoid startup failure when worldmonitor is not installed."""
+    from data_sources.external.worldmonitor import get_worldmonitor_client
+    return get_worldmonitor_client()
+
+
+@router.get(
+    "/macro/market-radar",
+    response_model=MarketRadarResponse,
+    summary="Global Market Radar",
+    description="92-exchange global market radar via self-hosted worldmonitor.",
+)
+def get_market_radar() -> MarketRadarResponse:
+    client = _get_wm_client()
+    raw = client.get_market_radar()
+    if raw is None:
+        return MarketRadarResponse(available=False)
+
+    exchanges = []
+    for item in raw.get("exchanges", raw.get("quotes", [])):
+        exchanges.append(MarketRadarExchange(
+            name=item.get("name") or item.get("exchange"),
+            country=item.get("country"),
+            index=item.get("index") or item.get("symbol"),
+            value=item.get("value") or item.get("price") or item.get("last"),
+            change_pct=item.get("change_pct") or item.get("changePercent"),
+            status=item.get("status"),
+        ))
+
+    return MarketRadarResponse(
+        exchanges=exchanges,
+        commodities=raw.get("commodities"),
+        crypto=raw.get("crypto"),
+        updated_at=raw.get("updated_at") or raw.get("timestamp"),
+    )
+
+
+@router.get(
+    "/macro/country-risk/{country_code}",
+    response_model=CountryRiskResponse,
+    summary="Country Intelligence Index",
+    description="Country risk score across 12 signal categories via worldmonitor CII.",
+)
+def get_country_risk(country_code: str) -> CountryRiskResponse:
+    client = _get_wm_client()
+    raw = client.get_country_risk(country_code)
+    if raw is None:
+        return CountryRiskResponse(country_code=country_code.upper(), available=False)
+
+    signals = []
+    for sig in raw.get("signals", []):
+        signals.append(CountryRiskSignal(
+            category=sig.get("category", "unknown"),
+            score=sig.get("score"),
+            trend=sig.get("trend"),
+        ))
+
+    return CountryRiskResponse(
+        country_code=raw.get("country_code", country_code.upper()),
+        country_name=raw.get("country_name") or raw.get("name"),
+        overall_score=raw.get("overall_score") or raw.get("score"),
+        risk_level=raw.get("risk_level") or raw.get("level"),
+        signals=signals,
+        updated_at=raw.get("updated_at") or raw.get("timestamp"),
+    )
+
+
+@router.get(
+    "/macro/global-brief",
+    response_model=GlobalBriefResponse,
+    summary="Global Intelligence Brief",
+    description="AI-synthesized world situation brief from worldmonitor.",
+)
+def get_global_brief() -> GlobalBriefResponse:
+    client = _get_wm_client()
+    raw = client.get_global_brief()
+    if raw is None:
+        return GlobalBriefResponse(available=False)
+
+    items = []
+    for entry in raw.get("items", raw.get("briefs", raw.get("entries", []))):
+        items.append(GlobalBriefItem(
+            domain=entry.get("domain") or entry.get("category"),
+            headline=entry.get("headline") or entry.get("title"),
+            summary=entry.get("summary") or entry.get("body") or entry.get("text"),
+            severity=entry.get("severity") or entry.get("priority"),
+            region=entry.get("region"),
+        ))
+
+    return GlobalBriefResponse(
+        items=items,
+        generated_at=raw.get("generated_at") or raw.get("timestamp"),
+    )

--- a/api/routers/market.py
+++ b/api/routers/market.py
@@ -362,6 +362,15 @@ def _get_wm_client():
     return get_worldmonitor_client()
 
 
+def _first(d: dict, *keys):
+    """Return the first non-None value for the given keys (0 is valid)."""
+    for k in keys:
+        v = d.get(k)
+        if v is not None:
+            return v
+    return None
+
+
 @router.get(
     "/macro/market-radar",
     response_model=MarketRadarResponse,
@@ -377,11 +386,11 @@ def get_market_radar() -> MarketRadarResponse:
     exchanges = []
     for item in raw.get("exchanges", raw.get("quotes", [])):
         exchanges.append(MarketRadarExchange(
-            name=item.get("name") or item.get("exchange"),
+            name=_first(item, "name", "exchange"),
             country=item.get("country"),
-            index=item.get("index") or item.get("symbol"),
-            value=item.get("value") or item.get("price") or item.get("last"),
-            change_pct=item.get("change_pct") or item.get("changePercent"),
+            index=_first(item, "index", "symbol"),
+            value=_first(item, "value", "price", "last"),
+            change_pct=_first(item, "change_pct", "changePercent"),
             status=item.get("status"),
         ))
 
@@ -389,7 +398,7 @@ def get_market_radar() -> MarketRadarResponse:
         exchanges=exchanges,
         commodities=raw.get("commodities"),
         crypto=raw.get("crypto"),
-        updated_at=raw.get("updated_at") or raw.get("timestamp"),
+        updated_at=_first(raw, "updated_at", "timestamp"),
     )
 
 
@@ -415,11 +424,11 @@ def get_country_risk(country_code: str) -> CountryRiskResponse:
 
     return CountryRiskResponse(
         country_code=raw.get("country_code", country_code.upper()),
-        country_name=raw.get("country_name") or raw.get("name"),
-        overall_score=raw.get("overall_score") or raw.get("score"),
-        risk_level=raw.get("risk_level") or raw.get("level"),
+        country_name=_first(raw, "country_name", "name"),
+        overall_score=_first(raw, "overall_score", "score"),
+        risk_level=_first(raw, "risk_level", "level"),
         signals=signals,
-        updated_at=raw.get("updated_at") or raw.get("timestamp"),
+        updated_at=_first(raw, "updated_at", "timestamp"),
     )
 
 
@@ -438,10 +447,10 @@ def get_global_brief() -> GlobalBriefResponse:
     items = []
     for entry in raw.get("items", raw.get("briefs", raw.get("entries", []))):
         items.append(GlobalBriefItem(
-            domain=entry.get("domain") or entry.get("category"),
-            headline=entry.get("headline") or entry.get("title"),
-            summary=entry.get("summary") or entry.get("body") or entry.get("text"),
-            severity=entry.get("severity") or entry.get("priority"),
+            domain=_first(entry, "domain", "category"),
+            headline=_first(entry, "headline", "title"),
+            summary=_first(entry, "summary", "body", "text"),
+            severity=_first(entry, "severity", "priority"),
             region=entry.get("region"),
         ))
 

--- a/api/schemas/market.py
+++ b/api/schemas/market.py
@@ -309,3 +309,61 @@ class MacroHistoryResponse(BaseModel):
     window: str = Field(..., description="Requested window string")
     points: List[MacroHistoryPoint] = Field(default_factory=list, description="History points")
     data_coverage_pct: Optional[float] = Field(None, description="Percentage of non-null macro_score points (0-100)")
+
+
+# ---------------------------------------------------------------------------
+# Worldmonitor schemas
+# ---------------------------------------------------------------------------
+
+
+class MarketRadarExchange(BaseModel):
+    """Single exchange entry in the market radar."""
+    name: Optional[str] = Field(None, description="Exchange name")
+    country: Optional[str] = Field(None, description="Country code")
+    index: Optional[str] = Field(None, description="Primary index symbol")
+    value: Optional[float] = Field(None, description="Current index value")
+    change_pct: Optional[float] = Field(None, description="Daily change %")
+    status: Optional[str] = Field(None, description="open / closed / pre-market")
+
+
+class MarketRadarResponse(BaseModel):
+    """92-exchange global market radar from worldmonitor."""
+    exchanges: List[MarketRadarExchange] = Field(default_factory=list)
+    commodities: Optional[Dict[str, Any]] = Field(None, description="Commodity prices")
+    crypto: Optional[Dict[str, Any]] = Field(None, description="Crypto prices")
+    updated_at: Optional[str] = Field(None, description="Data timestamp")
+    available: bool = Field(True, description="Whether worldmonitor is reachable")
+
+
+class CountryRiskSignal(BaseModel):
+    """Single risk signal category score."""
+    category: str = Field(..., description="Signal category name")
+    score: Optional[float] = Field(None, description="Risk score (0-100)")
+    trend: Optional[str] = Field(None, description="improving / stable / deteriorating")
+
+
+class CountryRiskResponse(BaseModel):
+    """Country Intelligence Index (CII) from worldmonitor."""
+    country_code: str = Field(..., description="ISO 3166-1 alpha-2")
+    country_name: Optional[str] = Field(None)
+    overall_score: Optional[float] = Field(None, description="Composite CII score (0-100)")
+    risk_level: Optional[str] = Field(None, description="low / moderate / high / critical")
+    signals: List[CountryRiskSignal] = Field(default_factory=list)
+    updated_at: Optional[str] = Field(None)
+    available: bool = Field(True, description="Whether worldmonitor is reachable")
+
+
+class GlobalBriefItem(BaseModel):
+    """Single item in the global brief."""
+    domain: Optional[str] = Field(None, description="geopolitics / finance / energy / climate / security")
+    headline: Optional[str] = None
+    summary: Optional[str] = None
+    severity: Optional[str] = Field(None, description="low / medium / high / critical")
+    region: Optional[str] = None
+
+
+class GlobalBriefResponse(BaseModel):
+    """AI-synthesized world situation brief from worldmonitor."""
+    items: List[GlobalBriefItem] = Field(default_factory=list)
+    generated_at: Optional[str] = Field(None, description="Brief generation timestamp")
+    available: bool = Field(True, description="Whether worldmonitor is reachable")

--- a/data_sources/external/worldmonitor.py
+++ b/data_sources/external/worldmonitor.py
@@ -1,0 +1,142 @@
+"""
+Worldmonitor API client.
+Canonical location: data_sources/external/worldmonitor.py
+
+Connects to a self-hosted worldmonitor instance (koala73/worldmonitor)
+to fetch global macro intelligence: market radar, country risk, global brief.
+
+Usage:
+    from data_sources.external.worldmonitor import get_worldmonitor_client
+
+    client = get_worldmonitor_client()
+    radar = client.get_market_radar()
+    brief = client.get_global_brief()
+    risk = client.get_country_risk("KR")
+"""
+
+import logging
+import os
+import time
+from typing import Any, Dict, List, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+# Default: self-hosted worldmonitor in docker-compose
+_DEFAULT_BASE_URL = "http://localhost:3000"
+_DEFAULT_TIMEOUT = 15
+
+
+class WorldmonitorClient:
+    """HTTP client for self-hosted worldmonitor API."""
+
+    def __init__(
+        self,
+        base_url: Optional[str] = None,
+        timeout: int = _DEFAULT_TIMEOUT,
+    ) -> None:
+        self.base_url = (
+            base_url
+            or os.getenv("WORLDMONITOR_API_URL")
+            or _DEFAULT_BASE_URL
+        ).rstrip("/")
+        self.timeout = timeout
+        self._session = requests.Session()
+        self._session.headers.update({"Accept": "application/json"})
+
+    def _get(self, path: str, params: Optional[Dict[str, Any]] = None) -> Optional[Dict[str, Any]]:
+        url = f"{self.base_url}{path}"
+        try:
+            resp = self._session.get(url, params=params, timeout=self.timeout)
+            resp.raise_for_status()
+            return resp.json()
+        except requests.exceptions.ConnectionError:
+            logger.warning("Worldmonitor unavailable at %s", self.base_url)
+            return None
+        except requests.exceptions.Timeout:
+            logger.warning("Worldmonitor request timed out: %s", path)
+            return None
+        except requests.exceptions.HTTPError as e:
+            logger.warning("Worldmonitor HTTP error %s: %s", e.response.status_code, path)
+            return None
+        except Exception:
+            logger.warning("Worldmonitor request failed: %s", path, exc_info=True)
+            return None
+
+    # ------------------------------------------------------------------
+    # Market Radar — 92-exchange finance radar
+    # ------------------------------------------------------------------
+
+    def get_market_radar(self) -> Optional[Dict[str, Any]]:
+        """
+        Fetch global market radar data from worldmonitor.
+
+        Returns dict with exchange quotes, indices, commodities, crypto
+        across 92 exchanges worldwide.
+        """
+        return self._get("/api/market/v1/quotes")
+
+    # ------------------------------------------------------------------
+    # Country Risk — Country Intelligence Index (CII)
+    # ------------------------------------------------------------------
+
+    def get_country_risk(self, country_code: str) -> Optional[Dict[str, Any]]:
+        """
+        Fetch Country Intelligence Index for a specific country.
+
+        Args:
+            country_code: ISO 3166-1 alpha-2 code (e.g., "KR", "US", "CN")
+
+        Returns dict with risk scores across 12 signal categories.
+        """
+        return self._get(
+            "/api/intelligence/v1/cii",
+            params={"country": country_code.upper()},
+        )
+
+    def get_all_country_risks(self) -> Optional[List[Dict[str, Any]]]:
+        """Fetch CII scores for all tracked countries."""
+        return self._get("/api/intelligence/v1/cii")
+
+    # ------------------------------------------------------------------
+    # Global Brief — AI-synthesized world situation summary
+    # ------------------------------------------------------------------
+
+    def get_global_brief(self) -> Optional[Dict[str, Any]]:
+        """
+        Fetch AI-generated global situation brief.
+
+        Returns a curated summary of world events across geopolitics,
+        finance, energy, climate, and security domains.
+        """
+        return self._get("/api/intelligence/v1/brief")
+
+    # ------------------------------------------------------------------
+    # Health check
+    # ------------------------------------------------------------------
+
+    def is_available(self) -> bool:
+        """Check if worldmonitor instance is reachable."""
+        try:
+            resp = self._session.get(
+                f"{self.base_url}/health",
+                timeout=3,
+            )
+            return resp.status_code == 200
+        except Exception:
+            return False
+
+
+# ---------------------------------------------------------------------------
+# Singleton
+# ---------------------------------------------------------------------------
+
+_client: Optional[WorldmonitorClient] = None
+
+
+def get_worldmonitor_client() -> WorldmonitorClient:
+    global _client
+    if _client is None:
+        _client = WorldmonitorClient()
+    return _client

--- a/data_sources/external/worldmonitor.py
+++ b/data_sources/external/worldmonitor.py
@@ -23,8 +23,8 @@ import requests
 
 logger = logging.getLogger(__name__)
 
-# Default: self-hosted worldmonitor in docker-compose
-_DEFAULT_BASE_URL = "http://localhost:3000"
+# Default: self-hosted worldmonitor in docker-compose (WM_PORT=3002)
+_DEFAULT_BASE_URL = "http://localhost:3002"
 _DEFAULT_TIMEOUT = 15
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,9 +66,56 @@ services:
         condition: service_healthy
     restart: unless-stopped
 
+  # ---------------------------------------------------------------------------
+  # Worldmonitor — global macro intelligence (optional)
+  # Start with: docker compose --profile worldmonitor up -d
+  # ---------------------------------------------------------------------------
+  worldmonitor-redis:
+    image: redis:7-alpine
+    container_name: quant-wm-redis
+    command: redis-server --maxmemory 256mb --maxmemory-policy allkeys-lru
+    volumes:
+      - wm-redis-data:/data
+    profiles: [worldmonitor]
+    restart: unless-stopped
+
+  worldmonitor-redis-rest:
+    build:
+      context: https://github.com/koala73/worldmonitor.git
+      dockerfile: Dockerfile.redis-rest
+    container_name: quant-wm-redis-rest
+    ports:
+      - "127.0.0.1:8079:80"
+    environment:
+      REDIS_URL: redis://worldmonitor-redis:6379
+    depends_on:
+      - worldmonitor-redis
+    profiles: [worldmonitor]
+    restart: unless-stopped
+
+  worldmonitor:
+    build:
+      context: https://github.com/koala73/worldmonitor.git
+    container_name: quant-wm
+    ports:
+      - "${WM_PORT:-3002}:8080"
+    environment:
+      UPSTASH_REDIS_REST_URL: http://worldmonitor-redis-rest:80
+      UPSTASH_REDIS_REST_TOKEN: wm-local-token
+      LOCAL_API_PORT: "8080"
+      FINNHUB_API_KEY: ${FINNHUB_API_KEY:-}
+      FRED_API_KEY: ${FRED_API_KEY:-}
+      GROQ_API_KEY: ${GROQ_API_KEY:-}
+    depends_on:
+      - worldmonitor-redis-rest
+    profiles: [worldmonitor]
+    restart: unless-stopped
+
 volumes:
   pgdata:
     name: quant-investment-pgdata
+  wm-redis-data:
+    name: quant-wm-redis-data
 
 networks:
   default:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       - API_PORT=8000
       - DEBUG=false
       - DATABASE_URL=postgresql://${DB_USER:-quant}:${DB_PASSWORD:-quant}@db:5432/${DB_NAME:-quant}
+      - WORLDMONITOR_API_URL=http://worldmonitor:8080
     env_file:
       - path: .env
         required: false

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -366,7 +366,13 @@
     "explainGold": "Safe-haven proxy — rising gold with falling equities signals risk-off sentiment",
     "explainCopper": "Industrial demand proxy — copper/gold ratio indicates growth vs safety preference",
     "explainMsciEm": "Emerging market equity benchmark — tracks global EM capital flow momentum",
-    "explainMsciDm": "Developed market equity benchmark — EM/DM ratio shows relative risk appetite"
+    "explainMsciDm": "Developed market equity benchmark — EM/DM ratio shows relative risk appetite",
+    "worldmonitorTitle": "Global Intelligence",
+    "worldmonitorUnavailable": "Worldmonitor service unavailable",
+    "globalBrief": "Global Brief",
+    "noBriefItems": "No intelligence briefs available",
+    "marketRadar": "Market Radar",
+    "countryRisk": "Country Risk Index"
   },
   "screening": {
     "title": "Stock Screening",
@@ -1034,7 +1040,6 @@
     "statusFilter": "Status",
     "noLeaderboardEntries": "No strategies with backtest results yet",
     "strategiesRanked": "strategies ranked",
-    "strategyName": "Strategy Name",
     "exportPineScript": "Pine Script",
     "noConditionsToExport": "No conditions to export",
     "pineExportSuccess": "Pine Script exported successfully",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -366,7 +366,13 @@
     "explainGold": "안전자산 프록시 — 주식 하락 시 금 상승은 리스크오프 신호",
     "explainCopper": "산업 수요 프록시 — 구리/금 비율은 성장 vs 안전 선호도를 나타냄",
     "explainMsciEm": "신흥국 주식 벤치마크 — 글로벌 신흥국 자금 흐름 모멘텀 추적",
-    "explainMsciDm": "선진국 주식 벤치마크 — EM/DM 비율은 상대적 위험 선호도를 표시"
+    "explainMsciDm": "선진국 주식 벤치마크 — EM/DM 비율은 상대적 위험 선호도를 표시",
+    "worldmonitorTitle": "글로벌 인텔리전스",
+    "worldmonitorUnavailable": "Worldmonitor 서비스를 사용할 수 없습니다",
+    "globalBrief": "글로벌 브리프",
+    "noBriefItems": "인텔리전스 브리프가 없습니다",
+    "marketRadar": "마켓 레이더",
+    "countryRisk": "국가 리스크 지수"
   },
   "screening": {
     "title": "종목 스크리닝",
@@ -1034,7 +1040,6 @@
     "statusFilter": "상태",
     "noLeaderboardEntries": "백테스트 결과가 있는 전략이 없습니다",
     "strategiesRanked": "개 전략 순위",
-    "strategyName": "전략 이름",
     "exportPineScript": "Pine Script",
     "noConditionsToExport": "내보낼 조건이 없습니다",
     "pineExportSuccess": "Pine Script 내보내기 완료",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -366,7 +366,13 @@
     "explainGold": "避险资产代理 — 股市下跌时金价上涨信号避险情绪",
     "explainCopper": "工业需求代理 — 铜金比显示增长vs安全偏好",
     "explainMsciEm": "新兴市场股票基准 — 追踪全球新兴市场资金流动动能",
-    "explainMsciDm": "发达市场股票基准 — EM/DM比率显示相对风险偏好"
+    "explainMsciDm": "发达市场股票基准 — EM/DM比率显示相对风险偏好",
+    "worldmonitorTitle": "全球情报",
+    "worldmonitorUnavailable": "Worldmonitor 服务不可用",
+    "globalBrief": "全球简报",
+    "noBriefItems": "暂无情报简报",
+    "marketRadar": "市场雷达",
+    "countryRisk": "国家风险指数"
   },
   "screening": {
     "title": "股票筛选",
@@ -1034,7 +1040,6 @@
     "statusFilter": "状态",
     "noLeaderboardEntries": "暂无回测结果的策略",
     "strategiesRanked": "个策略已排名",
-    "strategyName": "策略名称",
     "exportPineScript": "Pine Script",
     "noConditionsToExport": "没有可导出的条件",
     "pineExportSuccess": "Pine Script 导出成功",

--- a/web/src/app/[locale]/macro/page.tsx
+++ b/web/src/app/[locale]/macro/page.tsx
@@ -5,6 +5,7 @@ import { useMemo, useState, type ReactNode } from 'react';
 import { Card } from '@/components/ui';
 import { useMacroBundle, useMacroHistory, usePrefetchMacroHistory, useOhlcv } from '@/hooks/useMarket';
 import CandleChart from '@/features/charts/CandleChart';
+import { GlobalBriefCard, MarketRadarCard, CountryRiskCard } from '@/features/macro';
 import { formatPercent } from '@/lib/format';
 import {
   Activity,
@@ -1362,6 +1363,16 @@ export default function MacroPage() {
           {t('bundleUnavailable')}
         </p>
       )}
+
+      {/* Worldmonitor — Global Intelligence */}
+      <div className="space-y-4">
+        <h2 className="text-xl font-bold text-[var(--foreground)]">{t('worldmonitorTitle')}</h2>
+        <GlobalBriefCard />
+        <div className="grid gap-4 lg:grid-cols-2">
+          <MarketRadarCard />
+          <CountryRiskCard />
+        </div>
+      </div>
     </div>
   );
 }

--- a/web/src/features/macro/CountryRiskCard.tsx
+++ b/web/src/features/macro/CountryRiskCard.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Card } from '@/components/ui';
+import { useCountryRisk } from '@/hooks/useMarket';
+import { ShieldAlert, TrendingDown, TrendingUp, Minus } from 'lucide-react';
+
+const RISK_COLOR: Record<string, string> = {
+  low: 'text-green-500',
+  moderate: 'text-yellow-500',
+  high: 'text-orange-500',
+  critical: 'text-red-500',
+};
+
+const RISK_BG: Record<string, string> = {
+  low: 'bg-green-500/10',
+  moderate: 'bg-yellow-500/10',
+  high: 'bg-orange-500/10',
+  critical: 'bg-red-500/10',
+};
+
+const TREND_ICON = {
+  improving: TrendingDown,
+  deteriorating: TrendingUp,
+  stable: Minus,
+};
+
+const DEFAULT_COUNTRIES = ['KR', 'US', 'CN', 'JP'] as const;
+
+export default function CountryRiskCard() {
+  const t = useTranslations('macro');
+  const [selected, setSelected] = useState<string>('KR');
+  const { data, isLoading } = useCountryRisk(selected);
+
+  if (isLoading) {
+    return (
+      <Card className="animate-pulse p-4">
+        <div className="h-6 w-40 rounded bg-[var(--background-secondary)]" />
+        <div className="mt-3 h-32 rounded bg-[var(--background-secondary)]" />
+      </Card>
+    );
+  }
+
+  if (!data?.available) {
+    return (
+      <Card className="p-4">
+        <div className="flex items-center gap-2 text-[var(--foreground-muted)]">
+          <ShieldAlert className="h-5 w-5" />
+          <span>{t('worldmonitorUnavailable')}</span>
+        </div>
+      </Card>
+    );
+  }
+
+  const riskClass = RISK_COLOR[data.risk_level ?? ''] ?? '';
+  const riskBg = RISK_BG[data.risk_level ?? ''] ?? '';
+
+  return (
+    <Card className="p-4">
+      <div className="flex items-center justify-between">
+        <h3 className="flex items-center gap-2 text-lg font-semibold">
+          <ShieldAlert className="h-5 w-5 text-[var(--accent)]" />
+          {t('countryRisk')}
+        </h3>
+        <div className="flex gap-1">
+          {DEFAULT_COUNTRIES.map((code) => (
+            <button
+              key={code}
+              type="button"
+              onClick={() => setSelected(code)}
+              className={`rounded px-2 py-1 text-xs font-medium transition-colors ${
+                selected === code
+                  ? 'bg-[var(--accent)] text-white'
+                  : 'bg-[var(--background-secondary)] text-[var(--foreground-muted)] hover:text-[var(--foreground)]'
+              }`}
+            >
+              {code}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-3">
+        <div className="flex items-center gap-3">
+          <div className={`rounded-lg px-3 py-2 ${riskBg}`}>
+            <span className="text-2xl font-bold tabular-nums">
+              {data.overall_score != null ? data.overall_score.toFixed(0) : '-'}
+            </span>
+            <span className="text-xs text-[var(--foreground-muted)]">/100</span>
+          </div>
+          <div>
+            <p className="text-sm font-medium">
+              {data.country_name ?? data.country_code}
+            </p>
+            {data.risk_level && (
+              <p className={`text-xs font-semibold uppercase ${riskClass}`}>
+                {data.risk_level}
+              </p>
+            )}
+          </div>
+        </div>
+
+        {data.signals.length > 0 && (
+          <div className="mt-3 grid grid-cols-2 gap-1.5 sm:grid-cols-3">
+            {data.signals.map((sig, i) => {
+              const TrendIcon = TREND_ICON[sig.trend as keyof typeof TREND_ICON] ?? Minus;
+              return (
+                <div key={i} className="rounded border border-[var(--border)] px-2 py-1.5">
+                  <div className="flex items-center justify-between">
+                    <span className="text-[10px] text-[var(--foreground-muted)] truncate">{sig.category}</span>
+                    <TrendIcon className="h-3 w-3 text-[var(--foreground-muted)]" />
+                  </div>
+                  <span className="text-sm font-semibold tabular-nums">
+                    {sig.score != null ? sig.score.toFixed(0) : '-'}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/web/src/features/macro/GlobalBriefCard.tsx
+++ b/web/src/features/macro/GlobalBriefCard.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { Card } from '@/components/ui';
+import { useGlobalBrief } from '@/hooks/useMarket';
+import { Globe, AlertTriangle, Shield, Flame, TrendingUp, Cloud } from 'lucide-react';
+
+const DOMAIN_ICON: Record<string, typeof Globe> = {
+  geopolitics: Shield,
+  finance: TrendingUp,
+  energy: Flame,
+  climate: Cloud,
+  security: AlertTriangle,
+};
+
+const SEVERITY_COLOR: Record<string, string> = {
+  critical: 'text-red-500',
+  high: 'text-orange-500',
+  medium: 'text-yellow-500',
+  low: 'text-[var(--foreground-muted)]',
+};
+
+export default function GlobalBriefCard() {
+  const t = useTranslations('macro');
+  const { data, isLoading } = useGlobalBrief();
+
+  if (isLoading) {
+    return (
+      <Card className="animate-pulse p-4">
+        <div className="h-6 w-40 rounded bg-[var(--background-secondary)]" />
+        <div className="mt-3 space-y-2">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-16 rounded bg-[var(--background-secondary)]" />
+          ))}
+        </div>
+      </Card>
+    );
+  }
+
+  if (!data?.available) {
+    return (
+      <Card className="p-4">
+        <div className="flex items-center gap-2 text-[var(--foreground-muted)]">
+          <Globe className="h-5 w-5" />
+          <span>{t('worldmonitorUnavailable')}</span>
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="p-4">
+      <div className="flex items-center justify-between">
+        <h3 className="flex items-center gap-2 text-lg font-semibold">
+          <Globe className="h-5 w-5 text-[var(--accent)]" />
+          {t('globalBrief')}
+        </h3>
+        {data.generated_at && (
+          <span className="text-xs text-[var(--foreground-muted)]">
+            {new Date(data.generated_at).toLocaleTimeString()}
+          </span>
+        )}
+      </div>
+
+      <div className="mt-3 space-y-3">
+        {data.items.length === 0 && (
+          <p className="text-sm text-[var(--foreground-muted)]">{t('noBriefItems')}</p>
+        )}
+        {data.items.map((item, i) => {
+          const Icon = DOMAIN_ICON[item.domain ?? ''] ?? Globe;
+          const sevClass = SEVERITY_COLOR[item.severity ?? 'low'] ?? '';
+          return (
+            <div key={i} className="rounded-lg border border-[var(--border)] p-3">
+              <div className="flex items-start gap-2">
+                <Icon className={`mt-0.5 h-4 w-4 shrink-0 ${sevClass}`} />
+                <div className="min-w-0">
+                  <p className="text-sm font-medium">{item.headline ?? '-'}</p>
+                  {item.summary && (
+                    <p className="mt-1 text-xs text-[var(--foreground-muted)] line-clamp-2">{item.summary}</p>
+                  )}
+                  <div className="mt-1 flex gap-2 text-xs text-[var(--foreground-muted)]">
+                    {item.domain && <span className="capitalize">{item.domain}</span>}
+                    {item.region && <span>{item.region}</span>}
+                  </div>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </Card>
+  );
+}

--- a/web/src/features/macro/MarketRadarCard.tsx
+++ b/web/src/features/macro/MarketRadarCard.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { Card } from '@/components/ui';
+import { useMarketRadar } from '@/hooks/useMarket';
+import { Radio, TrendingDown, TrendingUp, Minus } from 'lucide-react';
+
+export default function MarketRadarCard() {
+  const t = useTranslations('macro');
+  const { data, isLoading } = useMarketRadar();
+
+  if (isLoading) {
+    return (
+      <Card className="animate-pulse p-4">
+        <div className="h-6 w-40 rounded bg-[var(--background-secondary)]" />
+        <div className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div key={i} className="h-16 rounded bg-[var(--background-secondary)]" />
+          ))}
+        </div>
+      </Card>
+    );
+  }
+
+  if (!data?.available) {
+    return (
+      <Card className="p-4">
+        <div className="flex items-center gap-2 text-[var(--foreground-muted)]">
+          <Radio className="h-5 w-5" />
+          <span>{t('worldmonitorUnavailable')}</span>
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="p-4">
+      <div className="flex items-center justify-between">
+        <h3 className="flex items-center gap-2 text-lg font-semibold">
+          <Radio className="h-5 w-5 text-[var(--accent)]" />
+          {t('marketRadar')}
+        </h3>
+        {data.updated_at && (
+          <span className="text-xs text-[var(--foreground-muted)]">
+            {new Date(data.updated_at).toLocaleTimeString()}
+          </span>
+        )}
+      </div>
+
+      {data.exchanges.length > 0 && (
+        <div className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4">
+          {data.exchanges.map((ex, i) => {
+            const pct = ex.change_pct;
+            const isUp = pct != null && pct > 0;
+            const isDown = pct != null && pct < 0;
+            return (
+              <div
+                key={i}
+                className="rounded-lg border border-[var(--border)] p-2.5"
+              >
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-medium truncate" title={ex.name ?? undefined}>
+                    {ex.index ?? ex.name ?? '-'}
+                  </span>
+                  {ex.status && (
+                    <span className={`text-[10px] ${ex.status === 'open' ? 'text-green-500' : 'text-[var(--foreground-muted)]'}`}>
+                      {ex.status}
+                    </span>
+                  )}
+                </div>
+                <div className="mt-1 flex items-center justify-between">
+                  <span className="text-sm font-semibold tabular-nums">
+                    {ex.value != null ? ex.value.toLocaleString(undefined, { maximumFractionDigits: 1 }) : '-'}
+                  </span>
+                  {pct != null && (
+                    <span className={`flex items-center gap-0.5 text-xs font-medium ${isUp ? 'text-green-500' : isDown ? 'text-red-500' : 'text-[var(--foreground-muted)]'}`}>
+                      {isUp ? <TrendingUp className="h-3 w-3" /> : isDown ? <TrendingDown className="h-3 w-3" /> : <Minus className="h-3 w-3" />}
+                      {pct > 0 ? '+' : ''}{pct.toFixed(2)}%
+                    </span>
+                  )}
+                </div>
+                {ex.country && (
+                  <span className="text-[10px] text-[var(--foreground-muted)]">{ex.country}</span>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/web/src/features/macro/index.ts
+++ b/web/src/features/macro/index.ts
@@ -1,0 +1,3 @@
+export { default as GlobalBriefCard } from './GlobalBriefCard';
+export { default as MarketRadarCard } from './MarketRadarCard';
+export { default as CountryRiskCard } from './CountryRiskCard';

--- a/web/src/hooks/useMarket.ts
+++ b/web/src/hooks/useMarket.ts
@@ -3,7 +3,15 @@
 import { useEffect } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { queryKeys } from '@/lib/queryKeys';
-import { getMacroBundle, getMacroHistory, getOhlcv, searchTickers } from '@/lib/api';
+import {
+  getMacroBundle,
+  getMacroHistory,
+  getOhlcv,
+  searchTickers,
+  getMarketRadar,
+  getCountryRisk,
+  getGlobalBrief,
+} from '@/lib/api';
 
 const MACRO_POLL_MS = 30 * 1000; // shared polling cadence for macro queries
 
@@ -87,5 +95,37 @@ export function useOhlcv(ticker: string, days = 30, enabled = true) {
     queryFn: () => getOhlcv(ticker, days),
     staleTime: 60 * 60 * 1000, // 1 hour — daily OHLCV doesn't change often
     enabled: enabled && !!ticker,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Worldmonitor hooks
+// ---------------------------------------------------------------------------
+
+export function useMarketRadar(enabled = true) {
+  return useQuery({
+    queryKey: queryKeys.market.marketRadar(),
+    queryFn: getMarketRadar,
+    staleTime: 5 * 60 * 1000, // 5 min
+    refetchInterval: enabled ? 5 * 60 * 1000 : false,
+    enabled,
+  });
+}
+
+export function useCountryRisk(countryCode: string, enabled = true) {
+  return useQuery({
+    queryKey: queryKeys.market.countryRisk(countryCode),
+    queryFn: () => getCountryRisk(countryCode),
+    staleTime: 10 * 60 * 1000, // 10 min
+    enabled: enabled && !!countryCode,
+  });
+}
+
+export function useGlobalBrief(enabled = true) {
+  return useQuery({
+    queryKey: queryKeys.market.globalBrief(),
+    queryFn: getGlobalBrief,
+    staleTime: 5 * 60 * 1000, // 5 min
+    enabled,
   });
 }

--- a/web/src/lib/api/marketApi.ts
+++ b/web/src/lib/api/marketApi.ts
@@ -37,3 +37,66 @@ export interface SectorListResponse {
 export async function getSectors(market: string = 'KOSPI'): Promise<SectorListResponse> {
   return fetchApi<SectorListResponse>(`/api/strategy/sectors?market=${encodeURIComponent(market)}`);
 }
+
+// ---------------------------------------------------------------------------
+// Worldmonitor endpoints
+// ---------------------------------------------------------------------------
+
+export interface MarketRadarExchange {
+  name: string | null;
+  country: string | null;
+  index: string | null;
+  value: number | null;
+  change_pct: number | null;
+  status: string | null;
+}
+
+export interface MarketRadarResponse {
+  exchanges: MarketRadarExchange[];
+  commodities: Record<string, unknown> | null;
+  crypto: Record<string, unknown> | null;
+  updated_at: string | null;
+  available: boolean;
+}
+
+export interface CountryRiskSignal {
+  category: string;
+  score: number | null;
+  trend: string | null;
+}
+
+export interface CountryRiskResponse {
+  country_code: string;
+  country_name: string | null;
+  overall_score: number | null;
+  risk_level: string | null;
+  signals: CountryRiskSignal[];
+  updated_at: string | null;
+  available: boolean;
+}
+
+export interface GlobalBriefItem {
+  domain: string | null;
+  headline: string | null;
+  summary: string | null;
+  severity: string | null;
+  region: string | null;
+}
+
+export interface GlobalBriefResponse {
+  items: GlobalBriefItem[];
+  generated_at: string | null;
+  available: boolean;
+}
+
+export async function getMarketRadar(): Promise<MarketRadarResponse> {
+  return fetchApi<MarketRadarResponse>('/api/market/macro/market-radar');
+}
+
+export async function getCountryRisk(countryCode: string): Promise<CountryRiskResponse> {
+  return fetchApi<CountryRiskResponse>(`/api/market/macro/country-risk/${encodeURIComponent(countryCode)}`);
+}
+
+export async function getGlobalBrief(): Promise<GlobalBriefResponse> {
+  return fetchApi<GlobalBriefResponse>('/api/market/macro/global-brief');
+}

--- a/web/src/lib/queryKeys.ts
+++ b/web/src/lib/queryKeys.ts
@@ -23,6 +23,9 @@ export const queryKeys = {
     macroBundle: (mode: string = 'kr') => [...queryKeys.market.all, 'macro-bundle', mode] as const,
     macroHistory: (window: string) => [...queryKeys.market.all, 'macro-history', window] as const,
     ohlcv: (ticker: string, days: number) => [...queryKeys.market.all, 'ohlcv', ticker, days] as const,
+    marketRadar: () => [...queryKeys.market.all, 'market-radar'] as const,
+    countryRisk: (code: string) => [...queryKeys.market.all, 'country-risk', code] as const,
+    globalBrief: () => [...queryKeys.market.all, 'global-brief'] as const,
   },
   strategy: {
     all: ['strategy'] as const,


### PR DESCRIPTION
## Summary

`docs/works/20260427_directory_restructure.md` Phase 3-B 구현.

- worldmonitor (koala73/worldmonitor) 셀프호스트 Docker 스택 추가
- `data_sources/external/worldmonitor.py` HTTP 클라이언트
- 3개 신규 엔드포인트: market-radar, country-risk, global-brief
- 프론트엔드 3개 카드 컴포넌트 + hooks + i18n

### Docker 실행

```bash
docker compose --profile worldmonitor up -d
./scripts/run-seeders.sh  # worldmonitor 디렉토리에서
```

기존 서비스는 영향 없음 (`--profile worldmonitor` 없이 기동 시 worldmonitor 미시작).

### Graceful degradation

worldmonitor 미실행 시 → `available: false` 반환 → UI에 "서비스 unavailable" 표시.

## Test plan

- [x] `next build` 통과
- [x] Backend import 확인 (3 endpoints)
- [x] Client `is_available()` = False (worldmonitor 미실행 시 정상)
- [ ] `docker compose --profile worldmonitor up -d` 후 엔드포인트 실제 데이터 확인

Closes #1381

🤖 Generated with [Claude Code](https://claude.com/claude-code)