### PR TITLE
refactor: extract broker settings view models

### DIFF
--- a/api/services/broker_settings_service.py
+++ b/api/services/broker_settings_service.py
@@ -8,7 +8,6 @@ import logging
 import os
 import re
 import urllib.request
-from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urlparse
 
@@ -18,6 +17,12 @@ from brokers import refresh_broker
 
 from api.database import SessionLocal
 from api.models.broker_credential import BrokerCredential
+from api.services.broker_settings_views import (
+    IBKRSettingsView,
+    SlackSettingsView,
+    TelegramSettingsView,
+    TigerSettingsView,
+)
 
 try:
     from cryptography.fernet import Fernet, InvalidToken
@@ -27,39 +32,6 @@ except Exception:  # pragma: no cover - handled by runtime guard
     Fernet = None  # type: ignore[assignment]
     InvalidToken = Exception  # type: ignore[assignment]
     _CRYPTO_AVAILABLE = False
-
-
-@dataclass
-class TigerSettingsView:
-    tiger_id: str | None
-    account: str | None
-    license: str | None
-    sandbox: bool
-    has_private_key: bool
-    updated_at: str | None
-
-
-@dataclass
-class IBKRSettingsView:
-    gateway_url: str | None
-    account_id: str | None
-    updated_at: str | None
-
-
-@dataclass
-class TelegramSettingsView:
-    has_bot_token: bool
-    chat_id: str | None
-    enabled: bool
-    updated_at: str | None
-
-
-@dataclass
-class SlackSettingsView:
-    has_webhook_url: bool
-    channel_name: str | None
-    enabled: bool
-    updated_at: str | None
 
 
 class BrokerSettingsService:
@@ -519,7 +491,6 @@ class BrokerSettingsService:
         """Send a test message via Slack webhook."""
         from api.services.notification_dispatcher import _send_slack
         return _send_slack(self, message)
-
 
 _broker_settings_service = BrokerSettingsService()
 

--- a/api/services/broker_settings_views.py
+++ b/api/services/broker_settings_views.py
@@ -1,0 +1,38 @@
+"""View dataclasses returned by BrokerSettingsService."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class TigerSettingsView:
+    tiger_id: str | None
+    account: str | None
+    license: str | None
+    sandbox: bool
+    has_private_key: bool
+    updated_at: str | None
+
+
+@dataclass
+class IBKRSettingsView:
+    gateway_url: str | None
+    account_id: str | None
+    updated_at: str | None
+
+
+@dataclass
+class TelegramSettingsView:
+    has_bot_token: bool
+    chat_id: str | None
+    enabled: bool
+    updated_at: str | None
+
+
+@dataclass
+class SlackSettingsView:
+    has_webhook_url: bool
+    channel_name: str | None
+    enabled: bool
+    updated_at: str | None


### PR DESCRIPTION
## Summary
- move broker settings response dataclasses into `api/services/broker_settings_views.py`
- keep `BrokerSettingsService` behavior and method signatures unchanged
- reduce `broker_settings_service.py` below the 500-line restructure threshold

## Validation
- `wc -l api/services/broker_settings_service.py api/services/broker_settings_views.py`
- `python3 -m py_compile api/services/broker_settings_service.py api/services/broker_settings_views.py`

## Non-scope
- no persistence logic changes
- no runtime broker apply changes

## Rollback
- revert this PR to inline the view dataclasses back into `broker_settings_service.py`

## Retrospective
- user directives/corrections: continue remaining >500-line services as isolated PRs with self-review
- delays encountered: none beyond isolating work into a dedicated worktree/branch
- automation opportunities: `git worktree add`, `gh pr create`, `python3 -m py_compile`
- defaults for next run: prefer type/helper extraction first when a service only barely exceeds the threshold
