### PR TITLE
docs: mark directory restructure completed

### DIFF
--- a/docs/works/20260427_directory_restructure.md
+++ b/docs/works/20260427_directory_restructure.md
@@ -1,7 +1,7 @@
 # Directory Restructure Plan
 
 **Date**: 2026-04-27  
-**Status**: Phase 1-3 completed. Post-restructure hardening pending (9 service files >500 lines).  
+**Status**: Completed.  
 **Epic Issue**: TBD
 
 ---
@@ -196,7 +196,7 @@ Replace manual type sync between `api/schemas/` and `web/src/lib/types.ts`:
 
 ## Completion Criteria
 
-- [ ] All service files under 500 lines (9 files remain >500L: macro_service 975, portfolio_risk 703, portfolio_core 699, watchlist 672, screening 655, chat 580, strategy_chat 554, broker_settings 528, notification_dispatcher 519)
+- [x] All service files under 500 lines (#1386-#1394)
 - [x] No duplicate business logic across modules (#1377)
 - [x] `data_sources/` package has >80% of all data fetch logic (#1380)
 - [x] `web/src/lib/api.ts` deleted (split into domain files) (#1376)


### PR DESCRIPTION
## Summary
- mark the directory restructure plan as completed
- update the final completion criterion for service file size
- align the document status with the merged refactor PRs

## Validation
- git show origin/main:<service-file> | wc -l for the 9 split services
- confirmed all 9 files are now under 500 lines on top of #1386-#1394