### PR TITLE
refactor(settings): persist portfolio alert and sell config in DB

### DIFF
--- a/api/database.py
+++ b/api/database.py
@@ -57,6 +57,7 @@ def init_db() -> None:
     import api.models.strategy  # noqa: F401 — register model with Base
     import api.models.strategy_backtest_result  # noqa: F401 — register model with Base
     import api.models.portfolio_alert  # noqa: F401 — register model with Base
+    import api.models.portfolio_alert_config  # noqa: F401 — register model with Base
     import api.models.strategy_alert  # noqa: F401 — register model with Base
     import api.models.strategy_webhook  # noqa: F401 — register model with Base
     import api.models.watchlist  # noqa: F401 — register model with Base
@@ -69,6 +70,7 @@ def init_db() -> None:
     _migrate_sell_rule_preset_id()
 
     _migrate_strategy_status()
+    _migrate_portfolio_alert_config_columns()
 
     _migrate_json_data()
     _migrate_portfolio_json()
@@ -188,6 +190,27 @@ def _migrate_strategy_status() -> None:
                 logger.info("Added strategies.status column")
     except Exception as e:
         logger.warning("strategies status migration skipped: %s", e)
+
+
+def _migrate_portfolio_alert_config_columns() -> None:
+    """Add new portfolio_alert_config columns for stage-2 DB-backed settings."""
+    try:
+        with engine.begin() as conn:
+            existing_columns = _get_column_names(conn, "portfolio_alert_config")
+            if existing_columns is None:
+                return
+            additions = [
+                ("default_stop_loss_pct", "FLOAT DEFAULT 0.05"),
+                ("default_take_profit_pct", "FLOAT DEFAULT 0.15"),
+                ("default_trailing_stop_pct", "FLOAT DEFAULT 0.08"),
+                ("technical_signals_json", "TEXT DEFAULT '{}'"),
+            ]
+            for col, col_type in additions:
+                if col not in existing_columns:
+                    conn.execute(text(f"ALTER TABLE portfolio_alert_config ADD COLUMN {col} {col_type}"))
+                    logger.info("Added portfolio_alert_config.%s column", col)
+    except Exception as e:
+        logger.warning("portfolio_alert_config schema migration skipped: %s", e)
 
 
 def _migrate_json_data() -> None:

--- a/api/models/portfolio_alert_config.py
+++ b/api/models/portfolio_alert_config.py
@@ -1,0 +1,34 @@
+"""Persistent portfolio alert settings."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, Float, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from api.database import Base
+
+
+class PortfolioAlertConfig(Base):
+    """Store portfolio alert runtime settings in the database."""
+
+    __tablename__ = "portfolio_alert_config"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, default=1)
+    enabled: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    scan_interval_seconds: Mapped[int] = mapped_column(Integer, default=60, nullable=False)
+    stop_loss_pct: Mapped[float] = mapped_column(Float, default=0.20, nullable=False)
+    take_profit_pct: Mapped[float] = mapped_column(Float, default=0.30, nullable=False)
+    trailing_stop_pct: Mapped[float] = mapped_column(Float, default=0.10, nullable=False)
+    technical_signals: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    market_hours_only: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    channels_json: Mapped[str] = mapped_column(Text, default='["telegram"]', nullable=False)
+    default_stop_loss_pct: Mapped[float] = mapped_column(Float, default=0.05, nullable=False)
+    default_take_profit_pct: Mapped[float] = mapped_column(Float, default=0.15, nullable=False)
+    default_trailing_stop_pct: Mapped[float] = mapped_column(Float, default=0.08, nullable=False)
+    technical_signals_json: Mapped[str] = mapped_column(Text, default="{}", nullable=False)
+    migrated_from_yaml: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )

--- a/api/models/portfolio_alert_config.py
+++ b/api/models/portfolio_alert_config.py
@@ -1,4 +1,15 @@
-"""Persistent portfolio alert settings."""
+"""Persistent portfolio alert and sell settings.
+
+Runtime readers use this table as the primary source of truth for:
+- portfolio alert settings
+- global sell-condition defaults
+- technical sell-signal config
+
+At present, only alert settings are mutated through the public API path.
+Global sell defaults and technical signal config are bootstrap-compatible and
+DB-backed for runtime reads, but still need a dedicated write path if we want
+them to become fully user-editable outside legacy YAML migration flows.
+"""
 
 from __future__ import annotations
 

--- a/api/routers/portfolio_alerts.py
+++ b/api/routers/portfolio_alerts.py
@@ -24,54 +24,18 @@ async def get_alert_history(limit: int = Query(50, ge=1, le=200)):
 
 @router.get("/config", response_model=PortfolioAlertConfigResponse)
 async def get_alert_config():
-    """Get current alert settings from portfolio.yaml."""
-    from api.services.portfolio_alert_scanner import load_config
+    """Get current alert settings from DB-backed config."""
+    from api.services.portfolio_alert_config_service import get_portfolio_alert_config_service
 
-    _, settings = load_config()
-    return PortfolioAlertConfigResponse(
-        enabled=settings.enabled,
-        scan_interval_seconds=settings.scan_interval_seconds,
-        stop_loss_pct=settings.stop_loss_pct,
-        take_profit_pct=settings.take_profit_pct,
-        trailing_stop_pct=settings.trailing_stop_pct,
-        technical_signals=settings.technical_signals,
-        market_hours_only=settings.market_hours_only,
-        channels=settings.channels or ["telegram"],
-    )
+    return get_portfolio_alert_config_service().get_config()
 
 
 @router.put("/config", response_model=PortfolioAlertConfigResponse)
 async def update_alert_config(body: PortfolioAlertConfigUpdate):
-    """Update alert settings in portfolio.yaml."""
-    import yaml
-    from api.services.portfolio_alert_scanner import _CONFIG_PATH
+    """Update alert settings in DB-backed config."""
+    from api.services.portfolio_alert_config_service import get_portfolio_alert_config_service
 
-    if not _CONFIG_PATH.exists():
-        return PortfolioAlertConfigResponse()
-
-    with open(_CONFIG_PATH, "r", encoding="utf-8") as f:
-        data = yaml.safe_load(f) or {}
-
-    alert_raw = data.setdefault("alert_settings", {})
-
-    for field in (
-        "enabled",
-        "scan_interval_seconds",
-        "stop_loss_pct",
-        "take_profit_pct",
-        "trailing_stop_pct",
-        "technical_signals",
-        "market_hours_only",
-        "channels",
-    ):
-        val = getattr(body, field, None)
-        if val is not None:
-            alert_raw[field] = val
-
-    with open(_CONFIG_PATH, "w", encoding="utf-8") as f:
-        yaml.dump(data, f, allow_unicode=True, default_flow_style=False)
-
-    return PortfolioAlertConfigResponse(**alert_raw)
+    return get_portfolio_alert_config_service().save_config(body.model_dump())
 
 
 @router.post("/scan", response_model=PortfolioAlertScanResult)

--- a/api/services/portfolio/portfolio_alert_service.py
+++ b/api/services/portfolio/portfolio_alert_service.py
@@ -23,6 +23,7 @@ from api.database import SessionLocal
 from api.models.portfolio_alert import PortfolioAlertHistory
 from api.schemas.portfolio_alert import PortfolioAlertHistoryEntry, PortfolioAlertHistoryResponse
 from api.services.portfolio_alert_config_service import (
+    # Re-exported here for the backward-compat scanner shim.
     _CONFIG_PATH,
     get_portfolio_alert_config_service,
 )

--- a/api/services/portfolio/portfolio_alert_service.py
+++ b/api/services/portfolio/portfolio_alert_service.py
@@ -15,24 +15,19 @@ import threading
 import time
 from dataclasses import dataclass
 from datetime import date, datetime
-from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-import yaml
 from sqlalchemy.exc import IntegrityError
 
 from api.database import SessionLocal
 from api.models.portfolio_alert import PortfolioAlertHistory
 from api.schemas.portfolio_alert import PortfolioAlertHistoryEntry, PortfolioAlertHistoryResponse
+from api.services.portfolio_alert_config_service import (
+    _CONFIG_PATH,
+    get_portfolio_alert_config_service,
+)
 
 logger = logging.getLogger(__name__)
-
-# ---------------------------------------------------------------------------
-# Config loader
-# ---------------------------------------------------------------------------
-
-_CONFIG_PATH = Path(__file__).resolve().parents[3] / "config" / "portfolio.yaml"
-
 
 @dataclass
 class HoldingInfo:
@@ -83,14 +78,8 @@ def _load_holdings_from_db() -> list[HoldingInfo]:
 
 
 def _load_alert_settings() -> AlertSettings:
-    """Load alert settings from portfolio.yaml."""
-    if not _CONFIG_PATH.exists():
-        return AlertSettings(enabled=False)
-
-    with open(_CONFIG_PATH, "r", encoding="utf-8") as f:
-        data = yaml.safe_load(f) or {}
-
-    alert_raw = data.get("alert_settings", {})
+    """Load alert settings from DB-backed config service."""
+    alert_raw = get_portfolio_alert_config_service().get_config().model_dump()
     return AlertSettings(
         enabled=alert_raw.get("enabled", True),
         scan_interval_seconds=alert_raw.get("scan_interval_seconds", 60),
@@ -104,7 +93,7 @@ def _load_alert_settings() -> AlertSettings:
 
 
 def load_config() -> tuple[list[HoldingInfo], AlertSettings]:
-    """Load holdings from DB and alert settings from YAML."""
+    """Load holdings from DB and alert settings from DB-backed config."""
     holdings = _load_holdings_from_db()
     settings = _load_alert_settings()
     return holdings, settings

--- a/api/services/portfolio_alert_config_service.py
+++ b/api/services/portfolio_alert_config_service.py
@@ -1,0 +1,164 @@
+"""DB-backed portfolio alert settings with YAML bootstrap fallback."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from api.database import SessionLocal
+from api.models.portfolio_alert_config import PortfolioAlertConfig
+from api.schemas.portfolio_alert import PortfolioAlertConfigResponse
+
+_CONFIG_PATH = Path(__file__).resolve().parents[2] / "config" / "portfolio.yaml"
+
+
+class PortfolioAlertConfigService:
+    """Manage portfolio alert settings persistence."""
+
+    ROW_ID = 1
+
+    def _load_yaml_root(self) -> dict[str, Any]:
+        if not _CONFIG_PATH.exists():
+            return {}
+        with open(_CONFIG_PATH, "r", encoding="utf-8") as f:
+            return yaml.safe_load(f) or {}
+
+    def _deserialize_channels(self, raw: str | None) -> list[str]:
+        if not raw:
+            return ["telegram"]
+        try:
+            data = json.loads(raw)
+        except Exception:
+            return ["telegram"]
+        if isinstance(data, list) and data:
+            return [str(item) for item in data]
+        return ["telegram"]
+
+    def _deserialize_json_dict(self, raw: str | None) -> dict[str, Any]:
+        if not raw:
+            return {}
+        try:
+            data = json.loads(raw)
+        except Exception:
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _response_from_row(self, row: PortfolioAlertConfig) -> PortfolioAlertConfigResponse:
+        return PortfolioAlertConfigResponse(
+            enabled=row.enabled,
+            scan_interval_seconds=row.scan_interval_seconds,
+            stop_loss_pct=row.stop_loss_pct,
+            take_profit_pct=row.take_profit_pct,
+            trailing_stop_pct=row.trailing_stop_pct,
+            technical_signals=row.technical_signals,
+            market_hours_only=row.market_hours_only,
+            channels=self._deserialize_channels(row.channels_json),
+        )
+
+    def get_config(self) -> PortfolioAlertConfigResponse:
+        db = SessionLocal()
+        try:
+            row = db.get(PortfolioAlertConfig, self.ROW_ID)
+            if row is None:
+                root = self._load_yaml_root()
+                fallback = root.get("alert_settings", {}) or {}
+                default_sell = root.get("default_sell_conditions", {}) or {}
+                technical_sell = root.get("technical_sell_signals", {}) or {}
+                row = PortfolioAlertConfig(
+                    id=self.ROW_ID,
+                    enabled=bool(fallback.get("enabled", False if not fallback else True)),
+                    scan_interval_seconds=int(fallback.get("scan_interval_seconds", 60)),
+                    stop_loss_pct=float(fallback.get("stop_loss_pct", 0.20)),
+                    take_profit_pct=float(fallback.get("take_profit_pct", 0.30)),
+                    trailing_stop_pct=float(fallback.get("trailing_stop_pct", 0.10)),
+                    technical_signals=bool(fallback.get("technical_signals", True)),
+                    market_hours_only=bool(fallback.get("market_hours_only", True)),
+                    channels_json=json.dumps(fallback.get("channels", ["telegram"])),
+                    default_stop_loss_pct=float(default_sell.get("stop_loss_pct", 0.05)),
+                    default_take_profit_pct=float(default_sell.get("take_profit_pct", 0.15)),
+                    default_trailing_stop_pct=float(default_sell.get("trailing_stop_pct", 0.08)),
+                    technical_signals_json=json.dumps(technical_sell),
+                    migrated_from_yaml=bool(fallback or default_sell or technical_sell),
+                )
+                db.add(row)
+                db.commit()
+                db.refresh(row)
+            return self._response_from_row(row)
+        finally:
+            db.close()
+
+    def save_config(self, payload: dict[str, Any]) -> PortfolioAlertConfigResponse:
+        current = self.get_config()
+        merged = current.model_dump()
+        for field, value in payload.items():
+            if value is not None:
+                merged[field] = value
+
+        db = SessionLocal()
+        try:
+            row = db.get(PortfolioAlertConfig, self.ROW_ID)
+            if row is None:
+                row = PortfolioAlertConfig(id=self.ROW_ID)
+                db.add(row)
+
+            row.enabled = bool(merged["enabled"])
+            row.scan_interval_seconds = int(merged["scan_interval_seconds"])
+            row.stop_loss_pct = float(merged["stop_loss_pct"])
+            row.take_profit_pct = float(merged["take_profit_pct"])
+            row.trailing_stop_pct = float(merged["trailing_stop_pct"])
+            row.technical_signals = bool(merged["technical_signals"])
+            row.market_hours_only = bool(merged["market_hours_only"])
+            row.channels_json = json.dumps(merged.get("channels") or ["telegram"])
+            row.migrated_from_yaml = False
+            db.commit()
+            db.refresh(row)
+            return self._response_from_row(row)
+        finally:
+            db.close()
+
+    def get_default_sell_conditions(self) -> dict[str, float]:
+        db = SessionLocal()
+        try:
+            row = db.get(PortfolioAlertConfig, self.ROW_ID)
+            if row is None:
+                self.get_config()
+                row = db.get(PortfolioAlertConfig, self.ROW_ID)
+            if row is None:
+                return {
+                    "stop_loss_pct": 0.05,
+                    "take_profit_pct": 0.15,
+                    "trailing_stop_pct": 0.08,
+                }
+            return {
+                "stop_loss_pct": row.default_stop_loss_pct,
+                "take_profit_pct": row.default_take_profit_pct,
+                "trailing_stop_pct": row.default_trailing_stop_pct,
+            }
+        finally:
+            db.close()
+
+    def get_technical_signals_config(self) -> dict[str, Any]:
+        db = SessionLocal()
+        try:
+            row = db.get(PortfolioAlertConfig, self.ROW_ID)
+            if row is None:
+                self.get_config()
+                row = db.get(PortfolioAlertConfig, self.ROW_ID)
+            if row is None:
+                return {}
+            return self._deserialize_json_dict(row.technical_signals_json)
+        finally:
+            db.close()
+
+
+_service: PortfolioAlertConfigService | None = None
+
+
+def get_portfolio_alert_config_service() -> PortfolioAlertConfigService:
+    global _service
+    if _service is None:
+        _service = PortfolioAlertConfigService()
+    return _service

--- a/api/services/portfolio_alert_config_service.py
+++ b/api/services/portfolio_alert_config_service.py
@@ -11,6 +11,7 @@ import yaml
 from api.database import SessionLocal
 from api.models.portfolio_alert_config import PortfolioAlertConfig
 from api.schemas.portfolio_alert import PortfolioAlertConfigResponse
+from sqlalchemy.exc import IntegrityError
 
 _CONFIG_PATH = Path(__file__).resolve().parents[2] / "config" / "portfolio.yaml"
 
@@ -58,34 +59,53 @@ class PortfolioAlertConfigService:
             channels=self._deserialize_channels(row.channels_json),
         )
 
+    def _build_bootstrap_row(self) -> PortfolioAlertConfig:
+        root = self._load_yaml_root()
+        fallback = root.get("alert_settings", {}) or {}
+        default_sell = root.get("default_sell_conditions", {}) or {}
+        technical_sell = root.get("technical_sell_signals", {}) or {}
+        return PortfolioAlertConfig(
+            id=self.ROW_ID,
+            # No YAML at all -> disabled by default. YAML present but missing the key
+            # keeps the historical default-on behavior for alert scanning.
+            enabled=bool(fallback.get("enabled", False if not fallback else True)),
+            scan_interval_seconds=int(fallback.get("scan_interval_seconds", 60)),
+            stop_loss_pct=float(fallback.get("stop_loss_pct", 0.20)),
+            take_profit_pct=float(fallback.get("take_profit_pct", 0.30)),
+            trailing_stop_pct=float(fallback.get("trailing_stop_pct", 0.10)),
+            technical_signals=bool(fallback.get("technical_signals", True)),
+            market_hours_only=bool(fallback.get("market_hours_only", True)),
+            channels_json=json.dumps(fallback.get("channels", ["telegram"])),
+            default_stop_loss_pct=float(default_sell.get("stop_loss_pct", 0.05)),
+            default_take_profit_pct=float(default_sell.get("take_profit_pct", 0.15)),
+            default_trailing_stop_pct=float(default_sell.get("trailing_stop_pct", 0.08)),
+            technical_signals_json=json.dumps(technical_sell),
+            migrated_from_yaml=bool(fallback or default_sell or technical_sell),
+        )
+
+    def _get_or_bootstrap_row(self, db) -> PortfolioAlertConfig:
+        row = db.get(PortfolioAlertConfig, self.ROW_ID)
+        if row is not None:
+            return row
+
+        row = self._build_bootstrap_row()
+        db.add(row)
+        try:
+            db.commit()
+        except IntegrityError:
+            db.rollback()
+            row = db.get(PortfolioAlertConfig, self.ROW_ID)
+            if row is None:
+                raise
+            return row
+
+        db.refresh(row)
+        return row
+
     def get_config(self) -> PortfolioAlertConfigResponse:
         db = SessionLocal()
         try:
-            row = db.get(PortfolioAlertConfig, self.ROW_ID)
-            if row is None:
-                root = self._load_yaml_root()
-                fallback = root.get("alert_settings", {}) or {}
-                default_sell = root.get("default_sell_conditions", {}) or {}
-                technical_sell = root.get("technical_sell_signals", {}) or {}
-                row = PortfolioAlertConfig(
-                    id=self.ROW_ID,
-                    enabled=bool(fallback.get("enabled", False if not fallback else True)),
-                    scan_interval_seconds=int(fallback.get("scan_interval_seconds", 60)),
-                    stop_loss_pct=float(fallback.get("stop_loss_pct", 0.20)),
-                    take_profit_pct=float(fallback.get("take_profit_pct", 0.30)),
-                    trailing_stop_pct=float(fallback.get("trailing_stop_pct", 0.10)),
-                    technical_signals=bool(fallback.get("technical_signals", True)),
-                    market_hours_only=bool(fallback.get("market_hours_only", True)),
-                    channels_json=json.dumps(fallback.get("channels", ["telegram"])),
-                    default_stop_loss_pct=float(default_sell.get("stop_loss_pct", 0.05)),
-                    default_take_profit_pct=float(default_sell.get("take_profit_pct", 0.15)),
-                    default_trailing_stop_pct=float(default_sell.get("trailing_stop_pct", 0.08)),
-                    technical_signals_json=json.dumps(technical_sell),
-                    migrated_from_yaml=bool(fallback or default_sell or technical_sell),
-                )
-                db.add(row)
-                db.commit()
-                db.refresh(row)
+            row = self._get_or_bootstrap_row(db)
             return self._response_from_row(row)
         finally:
             db.close()
@@ -99,10 +119,7 @@ class PortfolioAlertConfigService:
 
         db = SessionLocal()
         try:
-            row = db.get(PortfolioAlertConfig, self.ROW_ID)
-            if row is None:
-                row = PortfolioAlertConfig(id=self.ROW_ID)
-                db.add(row)
+            row = self._get_or_bootstrap_row(db)
 
             row.enabled = bool(merged["enabled"])
             row.scan_interval_seconds = int(merged["scan_interval_seconds"])
@@ -112,7 +129,6 @@ class PortfolioAlertConfigService:
             row.technical_signals = bool(merged["technical_signals"])
             row.market_hours_only = bool(merged["market_hours_only"])
             row.channels_json = json.dumps(merged.get("channels") or ["telegram"])
-            row.migrated_from_yaml = False
             db.commit()
             db.refresh(row)
             return self._response_from_row(row)
@@ -122,16 +138,7 @@ class PortfolioAlertConfigService:
     def get_default_sell_conditions(self) -> dict[str, float]:
         db = SessionLocal()
         try:
-            row = db.get(PortfolioAlertConfig, self.ROW_ID)
-            if row is None:
-                self.get_config()
-                row = db.get(PortfolioAlertConfig, self.ROW_ID)
-            if row is None:
-                return {
-                    "stop_loss_pct": 0.05,
-                    "take_profit_pct": 0.15,
-                    "trailing_stop_pct": 0.08,
-                }
+            row = self._get_or_bootstrap_row(db)
             return {
                 "stop_loss_pct": row.default_stop_loss_pct,
                 "take_profit_pct": row.default_take_profit_pct,
@@ -143,12 +150,7 @@ class PortfolioAlertConfigService:
     def get_technical_signals_config(self) -> dict[str, Any]:
         db = SessionLocal()
         try:
-            row = db.get(PortfolioAlertConfig, self.ROW_ID)
-            if row is None:
-                self.get_config()
-                row = db.get(PortfolioAlertConfig, self.ROW_ID)
-            if row is None:
-                return {}
+            row = self._get_or_bootstrap_row(db)
             return self._deserialize_json_dict(row.technical_signals_json)
         finally:
             db.close()

--- a/screener/portfolio_manager.py
+++ b/screener/portfolio_manager.py
@@ -8,7 +8,7 @@ import logging
 from pathlib import Path
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Any
-from datetime import datetime, date
+from datetime import date
 
 
 @dataclass
@@ -48,6 +48,13 @@ class SellConditions:
             take_profit_pct=data.get('take_profit_pct', 0.15),
             trailing_stop_pct=data.get('trailing_stop_pct', 0.08)
         )
+
+    def to_dict(self) -> Dict[str, float]:
+        return {
+            'stop_loss_pct': self.stop_loss_pct,
+            'take_profit_pct': self.take_profit_pct,
+            'trailing_stop_pct': self.trailing_stop_pct,
+        }
 
 
 class PortfolioManager:
@@ -113,12 +120,16 @@ class PortfolioManager:
 
     def get_default_sell_conditions(self) -> SellConditions:
         """기본 매도 조건 반환"""
-        conditions = self.config.get('default_sell_conditions', {})
+        from api.services.portfolio_alert_config_service import get_portfolio_alert_config_service
+
+        conditions = get_portfolio_alert_config_service().get_default_sell_conditions()
         return SellConditions.from_dict(conditions)
 
     def get_technical_signals_config(self) -> Dict[str, Any]:
         """기술적 매도 신호 설정 반환"""
-        return self.config.get('technical_sell_signals', {})
+        from api.services.portfolio_alert_config_service import get_portfolio_alert_config_service
+
+        return get_portfolio_alert_config_service().get_technical_signals_config()
 
     def get_holdings(self) -> List[ConfigHolding]:
         """모든 보유 종목 반환 (DB에서 조회)"""
@@ -152,8 +163,68 @@ class PortfolioManager:
         return None
 
     def get_sell_conditions_for(self, symbol: str) -> SellConditions:
-        """종목의 매도 조건 반환 (현재 기본 조건만 지원)."""
-        return self.get_default_sell_conditions()
+        """종목의 매도 조건 반환.
+
+        Priority:
+        1. DB-backed per-holding SellRule overrides
+        2. Legacy YAML holding overrides (temporary compatibility)
+        3. DB-backed global defaults
+        """
+        defaults = self.get_default_sell_conditions().to_dict()
+        merged = defaults.copy()
+
+        try:
+            from api.database import SessionLocal
+            from api.models.portfolio import SellRule
+
+            db = SessionLocal()
+            try:
+                symbol_upper = symbol.upper()
+                aliases = {symbol_upper}
+                if symbol_upper.endswith(('.KS', '.KQ')):
+                    aliases.add(symbol_upper.split('.')[0])
+                elif '.' not in symbol_upper:
+                    aliases.add(f"{symbol_upper}.KS")
+                    aliases.add(f"{symbol_upper}.KQ")
+
+                rules = (
+                    db.query(SellRule)
+                    .filter(SellRule.ticker.in_(list(aliases)), SellRule.is_active.is_(True))
+                    .order_by(SellRule.created_at.asc())
+                    .all()
+                )
+            finally:
+                db.close()
+
+            for rule in rules:
+                params = rule.params or {}
+                if rule.rule_type == 'stop_loss' and params.get('pct') is not None:
+                    merged['stop_loss_pct'] = abs(float(params['pct'])) / 100
+                elif rule.rule_type == 'take_profit' and params.get('pct') is not None:
+                    merged['take_profit_pct'] = abs(float(params['pct'])) / 100
+                elif rule.rule_type == 'trailing_stop' and params.get('pct') is not None:
+                    merged['trailing_stop_pct'] = abs(float(params['pct'])) / 100
+        except Exception as e:
+            self.logger.warning(f"Failed to load sell rule overrides from DB: {e}")
+
+        holdings = self.config.get('holdings', {}) or {}
+        holding_config = None
+        for ticker, config in holdings.items():
+            if ticker.upper() == symbol.upper():
+                holding_config = config or {}
+                break
+
+        if holding_config:
+            overrides = (
+                holding_config.get('sell_conditions')
+                or holding_config.get('custom_conditions')
+                or {}
+            )
+            for key in ('stop_loss_pct', 'take_profit_pct', 'trailing_stop_pct'):
+                if key in overrides and overrides[key] is not None:
+                    merged[key] = overrides[key]
+
+        return SellConditions.from_dict(merged)
 
     def add_holding(self, symbol: str, buy_price: float, quantity: int,
                     buy_date: date = None, custom_conditions: Dict = None) -> bool:

--- a/tests/test_portfolio_alert_config_service.py
+++ b/tests/test_portfolio_alert_config_service.py
@@ -1,0 +1,180 @@
+"""Tests for DB-backed portfolio alert config service."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from api.database import Base
+from api.models.portfolio_alert_config import PortfolioAlertConfig  # noqa: F401
+
+
+@pytest.fixture()
+def db_session():
+    engine = create_engine("sqlite://", connect_args={"check_same_thread": False})
+    testing_session = sessionmaker(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    yield testing_session
+    engine.dispose()
+
+
+@pytest.fixture()
+def service(db_session, tmp_path: Path):
+    import api.services.portfolio_alert_config_service as mod
+
+    orig_session = mod.SessionLocal
+    orig_path = mod._CONFIG_PATH
+    mod.SessionLocal = db_session
+    mod._CONFIG_PATH = tmp_path / "portfolio.yaml"
+    from api.services.portfolio_alert_config_service import PortfolioAlertConfigService
+
+    svc = PortfolioAlertConfigService()
+    yield svc, mod._CONFIG_PATH
+    mod.SessionLocal = orig_session
+    mod._CONFIG_PATH = orig_path
+
+
+def test_get_config_bootstraps_from_yaml(service):
+    svc, config_path = service
+    config_path.write_text(
+        """
+alert_settings:
+  enabled: true
+  scan_interval_seconds: 90
+  stop_loss_pct: 0.11
+  take_profit_pct: 0.22
+  trailing_stop_pct: 0.09
+  technical_signals: false
+  market_hours_only: false
+  channels:
+    - telegram
+    - slack
+default_sell_conditions:
+  stop_loss_pct: 0.07
+  take_profit_pct: 0.18
+  trailing_stop_pct: 0.06
+technical_sell_signals:
+  ma_breakdown: true
+  death_cross: false
+""".strip(),
+        encoding="utf-8",
+    )
+
+    config = svc.get_config()
+    assert config.enabled is True
+    assert config.scan_interval_seconds == 90
+    assert config.stop_loss_pct == 0.11
+    assert config.take_profit_pct == 0.22
+    assert config.trailing_stop_pct == 0.09
+    assert config.technical_signals is False
+    assert config.market_hours_only is False
+    assert config.channels == ["telegram", "slack"]
+    assert svc.get_default_sell_conditions() == {
+        "stop_loss_pct": 0.07,
+        "take_profit_pct": 0.18,
+        "trailing_stop_pct": 0.06,
+    }
+    assert svc.get_technical_signals_config() == {
+        "ma_breakdown": True,
+        "death_cross": False,
+    }
+
+
+def test_save_config_persists_to_db_and_overrides_yaml(service):
+    svc, config_path = service
+    config_path.write_text(
+        """
+alert_settings:
+  enabled: false
+  scan_interval_seconds: 60
+  stop_loss_pct: 0.20
+  take_profit_pct: 0.30
+  trailing_stop_pct: 0.10
+  technical_signals: true
+  market_hours_only: true
+  channels:
+    - telegram
+default_sell_conditions:
+  stop_loss_pct: 0.05
+  take_profit_pct: 0.15
+  trailing_stop_pct: 0.08
+technical_sell_signals:
+  ma_breakdown: true
+""".strip(),
+        encoding="utf-8",
+    )
+
+    saved = svc.save_config(
+        {
+            "enabled": True,
+            "scan_interval_seconds": 120,
+            "stop_loss_pct": 0.15,
+            "take_profit_pct": 0.40,
+            "trailing_stop_pct": 0.12,
+            "technical_signals": False,
+            "market_hours_only": False,
+            "channels": ["slack"],
+        }
+    )
+    assert saved.enabled is True
+    assert saved.scan_interval_seconds == 120
+    assert saved.channels == ["slack"]
+
+    config_path.write_text(
+        """
+alert_settings:
+  enabled: false
+  scan_interval_seconds: 15
+""".strip(),
+        encoding="utf-8",
+    )
+
+    loaded = svc.get_config()
+    assert loaded.enabled is True
+    assert loaded.scan_interval_seconds == 120
+    assert loaded.stop_loss_pct == 0.15
+    assert loaded.take_profit_pct == 0.40
+    assert loaded.trailing_stop_pct == 0.12
+    assert loaded.technical_signals is False
+    assert loaded.market_hours_only is False
+    assert loaded.channels == ["slack"]
+    assert svc.get_default_sell_conditions() == {
+        "stop_loss_pct": 0.05,
+        "take_profit_pct": 0.15,
+        "trailing_stop_pct": 0.08,
+    }
+    assert svc.get_technical_signals_config() == {"ma_breakdown": True}
+
+
+def test_save_config_does_not_mutate_default_sell_conditions_or_technical_config(service):
+    svc, config_path = service
+    config_path.write_text(
+        """
+alert_settings:
+  enabled: true
+default_sell_conditions:
+  stop_loss_pct: 0.09
+  take_profit_pct: 0.19
+  trailing_stop_pct: 0.11
+technical_sell_signals:
+  ma_breakdown: false
+  death_cross: true
+""".strip(),
+        encoding="utf-8",
+    )
+
+    svc.get_config()
+    svc.save_config({"enabled": False, "channels": ["telegram", "slack"]})
+
+    assert svc.get_default_sell_conditions() == {
+        "stop_loss_pct": 0.09,
+        "take_profit_pct": 0.19,
+        "trailing_stop_pct": 0.11,
+    }
+    assert svc.get_technical_signals_config() == {
+        "ma_breakdown": False,
+        "death_cross": True,
+    }

--- a/tests/test_portfolio_manager_settings.py
+++ b/tests/test_portfolio_manager_settings.py
@@ -1,0 +1,207 @@
+"""Tests for PortfolioManager reading DB-backed sell/technical settings."""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from api.database import Base
+from api.models.portfolio import Holding, SellRule
+from api.models.portfolio_alert_config import PortfolioAlertConfig
+
+
+@pytest.fixture()
+def db_session():
+    engine = create_engine("sqlite://", connect_args={"check_same_thread": False})
+    testing_session = sessionmaker(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    yield testing_session
+    engine.dispose()
+
+
+@pytest.fixture()
+def manager(db_session):
+    import api.services.portfolio_alert_config_service as config_mod
+    import api.database as database_mod
+
+    orig_session = config_mod.SessionLocal
+    orig_db_session = database_mod.SessionLocal
+    config_mod.SessionLocal = db_session
+    database_mod.SessionLocal = db_session
+
+    db = db_session()
+    try:
+        db.add(
+            PortfolioAlertConfig(
+                id=1,
+                enabled=True,
+                scan_interval_seconds=60,
+                stop_loss_pct=0.20,
+                take_profit_pct=0.30,
+                trailing_stop_pct=0.10,
+                technical_signals=True,
+                market_hours_only=True,
+                channels_json='["telegram"]',
+                default_stop_loss_pct=0.04,
+                default_take_profit_pct=0.21,
+                default_trailing_stop_pct=0.07,
+                technical_signals_json=json.dumps({"ma_breakdown": True, "death_cross": False}),
+                migrated_from_yaml=False,
+            )
+        )
+        db.add(
+            Holding(
+                ticker="AAPL",
+                name="Apple",
+                quantity=10,
+                avg_price=150.0,
+                currency="USD",
+                bought_at=date(2026, 1, 1),
+            )
+        )
+        db.commit()
+    finally:
+        db.close()
+
+    from screener.portfolio_manager import PortfolioManager
+
+    mgr = PortfolioManager(config_path="/nonexistent/portfolio.yaml")
+    yield mgr
+    config_mod.SessionLocal = orig_session
+    database_mod.SessionLocal = orig_db_session
+
+
+def test_portfolio_manager_reads_db_backed_default_sell_conditions(manager):
+    conditions = manager.get_default_sell_conditions()
+
+    assert conditions.stop_loss_pct == 0.04
+    assert conditions.take_profit_pct == 0.21
+    assert conditions.trailing_stop_pct == 0.07
+
+
+def test_portfolio_manager_reads_db_backed_technical_signals(manager):
+    assert manager.get_technical_signals_config() == {
+        "ma_breakdown": True,
+        "death_cross": False,
+    }
+
+
+def test_portfolio_manager_uses_db_sell_rules_as_per_holding_overrides(db_session):
+    import api.services.portfolio_alert_config_service as config_mod
+    import api.database as database_mod
+
+    orig_session = config_mod.SessionLocal
+    orig_db_session = database_mod.SessionLocal
+    config_mod.SessionLocal = db_session
+    database_mod.SessionLocal = db_session
+
+    db = db_session()
+    try:
+        db.add(
+            PortfolioAlertConfig(
+                id=1,
+                enabled=True,
+                scan_interval_seconds=60,
+                stop_loss_pct=0.20,
+                take_profit_pct=0.30,
+                trailing_stop_pct=0.10,
+                technical_signals=True,
+                market_hours_only=True,
+                channels_json='["telegram"]',
+                default_stop_loss_pct=0.05,
+                default_take_profit_pct=0.15,
+                default_trailing_stop_pct=0.08,
+                technical_signals_json="{}",
+                migrated_from_yaml=False,
+            )
+        )
+        db.add(
+            Holding(
+                ticker="AAPL",
+                name="Apple",
+                quantity=10,
+                avg_price=150.0,
+                currency="USD",
+                bought_at=date(2026, 1, 1),
+            )
+        )
+        db.add(SellRule(ticker="AAPL", rule_type="stop_loss", params={"pct": -3}, is_active=True))
+        db.add(SellRule(ticker="AAPL", rule_type="take_profit", params={"pct": 25}, is_active=True))
+        db.add(SellRule(ticker="AAPL", rule_type="trailing_stop", params={"pct": 12}, is_active=True))
+        db.commit()
+    finally:
+        db.close()
+
+    from screener.portfolio_manager import PortfolioManager
+
+    mgr = PortfolioManager(config_path="/nonexistent/portfolio.yaml")
+    conditions = mgr.get_sell_conditions_for("AAPL")
+
+    assert conditions.stop_loss_pct == 0.03
+    assert conditions.take_profit_pct == 0.25
+    assert conditions.trailing_stop_pct == 0.12
+
+    config_mod.SessionLocal = orig_session
+    database_mod.SessionLocal = orig_db_session
+
+
+def test_portfolio_manager_still_supports_legacy_yaml_override_fallback(db_session, tmp_path):
+    import api.services.portfolio_alert_config_service as config_mod
+    import api.database as database_mod
+
+    orig_session = config_mod.SessionLocal
+    orig_db_session = database_mod.SessionLocal
+    config_mod.SessionLocal = db_session
+    database_mod.SessionLocal = db_session
+
+    db = db_session()
+    try:
+        db.add(
+            PortfolioAlertConfig(
+                id=1,
+                enabled=True,
+                scan_interval_seconds=60,
+                stop_loss_pct=0.20,
+                take_profit_pct=0.30,
+                trailing_stop_pct=0.10,
+                technical_signals=True,
+                market_hours_only=True,
+                channels_json='["telegram"]',
+                default_stop_loss_pct=0.05,
+                default_take_profit_pct=0.15,
+                default_trailing_stop_pct=0.08,
+                technical_signals_json="{}",
+                migrated_from_yaml=False,
+            )
+        )
+        db.commit()
+    finally:
+        db.close()
+
+    config_path = tmp_path / "portfolio.yaml"
+    config_path.write_text(
+        """
+holdings:
+  TSLA:
+    custom_conditions:
+      stop_loss_pct: 0.02
+      take_profit_pct: 0.30
+""".strip(),
+        encoding="utf-8",
+    )
+
+    from screener.portfolio_manager import PortfolioManager
+
+    mgr = PortfolioManager(config_path=str(config_path))
+    conditions = mgr.get_sell_conditions_for("TSLA")
+
+    assert conditions.stop_loss_pct == 0.02
+    assert conditions.take_profit_pct == 0.30
+    assert conditions.trailing_stop_pct == 0.08
+
+    config_mod.SessionLocal = orig_session
+    database_mod.SessionLocal = orig_db_session


### PR DESCRIPTION
## Summary
- move portfolio alert runtime settings from YAML to DB-backed persistence
- persist global sell conditions and technical sell settings in the same DB-backed config row
- make `PortfolioManager` prefer DB-backed `sell_rules` for per-holding runtime overrides, with YAML kept only as bootstrap/legacy fallback

## Why
Portfolio runtime behavior was split across DB state and `config/portfolio.yaml`.
This PR makes the runtime source of truth DB-backed for:
- alert settings
- global sell conditions
- technical sell settings
- per-holding runtime override resolution

## Changes
- add `portfolio_alert_config` model and DB-backed settings service
- switch `/api/portfolio/alerts/config` GET/PUT to DB-backed storage
- switch portfolio alert runtime config loading to DB-backed storage
- extend DB migration path for new config columns
- update `PortfolioManager` to read DB-backed global settings and DB `sell_rules`
- keep YAML only as bootstrap/legacy fallback for now

## Validation
- `python3 -m py_compile api/models/portfolio_alert_config.py api/services/portfolio_alert_config_service.py api/database.py api/routers/portfolio_alerts.py api/services/portfolio/portfolio_alert_service.py screener/portfolio_manager.py tests/test_portfolio_alert_config_service.py tests/test_portfolio_manager_settings.py`
- `source /Users/miyoungjang/Repository/quant/quant-investment/venv/bin/activate && pytest tests/test_portfolio_alert_config_service.py tests/test_portfolio_manager_settings.py -q`

## Issue
- closes #1402
