### PR TITLE
fix(portfolio): clear alert history on single holding removal

### DIFF
--- a/api/services/portfolio/portfolio_core_service.py
+++ b/api/services/portfolio/portfolio_core_service.py
@@ -13,6 +13,7 @@ from typing import List, Dict, Any, Optional
 
 from api.database import SessionLocal
 from api.models.portfolio import Holding, SellRule, Trade
+from api.models.portfolio_alert import PortfolioAlertHistory
 from api.schemas.portfolio import (
     AdditionalPurchaseRequest,
     HoldingCreate,
@@ -383,6 +384,9 @@ class PortfolioCoreService(PortfolioPriceService):
             row = db.get(Holding, ticker)
             if not row:
                 return False
+            db.query(PortfolioAlertHistory).filter(
+                PortfolioAlertHistory.ticker == ticker
+            ).delete(synchronize_session=False)
             db.delete(row)
             clear_trailing_state(db, ticker)
             db.commit()

--- a/tests/test_portfolio_alerts.py
+++ b/tests/test_portfolio_alerts.py
@@ -242,6 +242,34 @@ class TestPortfolioResetBehavior:
         finally:
             db.close()
 
+    def test_remove_holding_clears_removed_ticker_alert_history_only(self):
+        from api.services.portfolio.portfolio_core_service import PortfolioCoreService
+        from api.services.portfolio_alert_service import record_and_send
+
+        db = SessionLocal()
+        try:
+            db.add(Holding(ticker="AAPL", name="Apple", quantity=10, avg_price=150, currency="USD"))
+            db.add(Holding(ticker="MSFT", name="Microsoft", quantity=5, avg_price=400, currency="USD"))
+            db.commit()
+        finally:
+            db.close()
+
+        with patch("api.services.notification_dispatcher.dispatch", return_value={"telegram": True}):
+            record_and_send("AAPL", "take_profit", "apple alert", 200.0)
+            record_and_send("MSFT", "stop_loss", "msft alert", 350.0)
+
+        service = PortfolioCoreService()
+        assert service.remove_holding("AAPL") is True
+
+        db = SessionLocal()
+        try:
+            rows = db.query(PortfolioAlertHistory).order_by(PortfolioAlertHistory.ticker.asc()).all()
+            assert [row.ticker for row in rows] == ["MSFT"]
+            assert db.query(Holding).count() == 1
+            assert db.get(Holding, "AAPL") is None
+        finally:
+            db.close()
+
 
 # ---------------------------------------------------------------------------
 # Tests — scanner


### PR DESCRIPTION
## Summary
- clear portfolio alert history when a single holding is removed
- add regression coverage so removed ticker history is cleared while other ticker history remains

## Why
`#1401` cleared alert history for replace/delete-all flows, but single holding removal still left stale alert rows behind for removed tickers.

## Validation
- `source /Users/miyoungjang/Repository/quant/quant-investment/venv/bin/activate && pytest tests/test_portfolio_alerts.py -q -k "replace_import_clears_alert_history or delete_all_holdings_clears_alert_history or remove_holding_clears_removed_ticker_alert_history_only"`

## Issue
- closes #1400
