### PR TITLE
fix(portfolio): prefer DB sell rules over legacy YAML overrides

### DIFF
--- a/screener/portfolio_manager.py
+++ b/screener/portfolio_manager.py
@@ -172,6 +172,7 @@ class PortfolioManager:
         """
         defaults = self.get_default_sell_conditions().to_dict()
         merged = defaults.copy()
+        db_override_keys: set[str] = set()
 
         try:
             from api.database import SessionLocal
@@ -200,10 +201,13 @@ class PortfolioManager:
                 params = rule.params or {}
                 if rule.rule_type == 'stop_loss' and params.get('pct') is not None:
                     merged['stop_loss_pct'] = abs(float(params['pct'])) / 100
+                    db_override_keys.add('stop_loss_pct')
                 elif rule.rule_type == 'take_profit' and params.get('pct') is not None:
                     merged['take_profit_pct'] = abs(float(params['pct'])) / 100
+                    db_override_keys.add('take_profit_pct')
                 elif rule.rule_type == 'trailing_stop' and params.get('pct') is not None:
                     merged['trailing_stop_pct'] = abs(float(params['pct'])) / 100
+                    db_override_keys.add('trailing_stop_pct')
         except Exception as e:
             self.logger.warning(f"Failed to load sell rule overrides from DB: {e}")
 
@@ -221,7 +225,7 @@ class PortfolioManager:
                 or {}
             )
             for key in ('stop_loss_pct', 'take_profit_pct', 'trailing_stop_pct'):
-                if key in overrides and overrides[key] is not None:
+                if key in overrides and overrides[key] is not None and key not in db_override_keys:
                     merged[key] = overrides[key]
         return SellConditions.from_dict(merged)
 

--- a/screener/portfolio_manager.py
+++ b/screener/portfolio_manager.py
@@ -223,7 +223,6 @@ class PortfolioManager:
             for key in ('stop_loss_pct', 'take_profit_pct', 'trailing_stop_pct'):
                 if key in overrides and overrides[key] is not None:
                     merged[key] = overrides[key]
-
         return SellConditions.from_dict(merged)
 
     def add_holding(self, symbol: str, buy_price: float, quantity: int,

--- a/tests/test_portfolio_manager.py
+++ b/tests/test_portfolio_manager.py
@@ -10,6 +10,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from api.database import Base
+from api.models.portfolio import SellRule
 from api.models.portfolio_alert_config import PortfolioAlertConfig
 from screener.portfolio_manager import PortfolioManager
 
@@ -126,3 +127,28 @@ holdings:
     assert conditions.stop_loss_pct == 0.03
     assert conditions.take_profit_pct == 0.15
     assert conditions.trailing_stop_pct == 0.08
+
+
+def test_get_sell_conditions_for_prefers_db_sell_rules_over_yaml_override(tmp_path, patch_db_sessions):
+    _seed_default_config(patch_db_sessions)
+    db = patch_db_sessions()
+    try:
+        db.add(SellRule(ticker="AAPL", rule_type="trailing_stop", params={"pct": 12}, is_active=True))
+        db.commit()
+    finally:
+        db.close()
+
+    config_path = _write_config(
+        tmp_path,
+        """
+holdings:
+  AAPL:
+    sell_conditions:
+      trailing_stop_pct: 0.20
+""".strip(),
+    )
+
+    manager = PortfolioManager(config_path=str(config_path))
+    conditions = manager.get_sell_conditions_for("AAPL")
+
+    assert conditions.trailing_stop_pct == 0.12

--- a/tests/test_portfolio_manager.py
+++ b/tests/test_portfolio_manager.py
@@ -1,0 +1,79 @@
+"""Tests for PortfolioManager sell-condition resolution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from screener.portfolio_manager import PortfolioManager
+
+
+def _write_config(tmp_path: Path, body: str) -> Path:
+    config_path = tmp_path / "portfolio.yaml"
+    config_path.write_text(body, encoding="utf-8")
+    return config_path
+
+
+def test_get_sell_conditions_for_returns_defaults_without_holding_override(tmp_path):
+    config_path = _write_config(
+        tmp_path,
+        """
+default_sell_conditions:
+  stop_loss_pct: 0.05
+  take_profit_pct: 0.15
+  trailing_stop_pct: 0.08
+""".strip(),
+    )
+
+    manager = PortfolioManager(config_path=str(config_path))
+    conditions = manager.get_sell_conditions_for("AAPL")
+
+    assert conditions.stop_loss_pct == 0.05
+    assert conditions.take_profit_pct == 0.15
+    assert conditions.trailing_stop_pct == 0.08
+
+
+def test_get_sell_conditions_for_merges_sell_conditions_override(tmp_path):
+    config_path = _write_config(
+        tmp_path,
+        """
+default_sell_conditions:
+  stop_loss_pct: 0.05
+  take_profit_pct: 0.15
+  trailing_stop_pct: 0.08
+holdings:
+  AAPL:
+    sell_conditions:
+      take_profit_pct: 0.25
+      trailing_stop_pct: 0.12
+""".strip(),
+    )
+
+    manager = PortfolioManager(config_path=str(config_path))
+    conditions = manager.get_sell_conditions_for("AAPL")
+
+    assert conditions.stop_loss_pct == 0.05
+    assert conditions.take_profit_pct == 0.25
+    assert conditions.trailing_stop_pct == 0.12
+
+
+def test_get_sell_conditions_for_supports_legacy_custom_conditions_key(tmp_path):
+    config_path = _write_config(
+        tmp_path,
+        """
+default_sell_conditions:
+  stop_loss_pct: 0.05
+  take_profit_pct: 0.15
+  trailing_stop_pct: 0.08
+holdings:
+  TSLA:
+    custom_conditions:
+      stop_loss_pct: 0.03
+""".strip(),
+    )
+
+    manager = PortfolioManager(config_path=str(config_path))
+    conditions = manager.get_sell_conditions_for("tsla")
+
+    assert conditions.stop_loss_pct == 0.03
+    assert conditions.take_profit_pct == 0.15
+    assert conditions.trailing_stop_pct == 0.08

--- a/tests/test_portfolio_manager.py
+++ b/tests/test_portfolio_manager.py
@@ -3,7 +3,14 @@
 from __future__ import annotations
 
 from pathlib import Path
+import json
 
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from api.database import Base
+from api.models.portfolio_alert_config import PortfolioAlertConfig
 from screener.portfolio_manager import PortfolioManager
 
 
@@ -13,14 +20,62 @@ def _write_config(tmp_path: Path, body: str) -> Path:
     return config_path
 
 
-def test_get_sell_conditions_for_returns_defaults_without_holding_override(tmp_path):
+@pytest.fixture()
+def db_session():
+    engine = create_engine("sqlite://", connect_args={"check_same_thread": False})
+    testing_session = sessionmaker(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    yield testing_session
+    engine.dispose()
+
+
+@pytest.fixture()
+def patch_db_sessions(db_session):
+    import api.database as database_mod
+    import api.services.portfolio_alert_config_service as config_mod
+
+    orig_db_session = database_mod.SessionLocal
+    orig_config_session = config_mod.SessionLocal
+    database_mod.SessionLocal = db_session
+    config_mod.SessionLocal = db_session
+    try:
+        yield db_session
+    finally:
+        database_mod.SessionLocal = orig_db_session
+        config_mod.SessionLocal = orig_config_session
+
+
+def _seed_default_config(db_session) -> None:
+    db = db_session()
+    try:
+        db.add(
+            PortfolioAlertConfig(
+                id=1,
+                enabled=True,
+                scan_interval_seconds=60,
+                stop_loss_pct=0.20,
+                take_profit_pct=0.30,
+                trailing_stop_pct=0.10,
+                technical_signals=True,
+                market_hours_only=True,
+                channels_json='["telegram"]',
+                default_stop_loss_pct=0.05,
+                default_take_profit_pct=0.15,
+                default_trailing_stop_pct=0.08,
+                technical_signals_json=json.dumps({}),
+                migrated_from_yaml=False,
+            )
+        )
+        db.commit()
+    finally:
+        db.close()
+
+
+def test_get_sell_conditions_for_returns_defaults_without_holding_override(tmp_path, patch_db_sessions):
+    _seed_default_config(patch_db_sessions)
     config_path = _write_config(
         tmp_path,
         """
-default_sell_conditions:
-  stop_loss_pct: 0.05
-  take_profit_pct: 0.15
-  trailing_stop_pct: 0.08
 """.strip(),
     )
 
@@ -32,14 +87,11 @@ default_sell_conditions:
     assert conditions.trailing_stop_pct == 0.08
 
 
-def test_get_sell_conditions_for_merges_sell_conditions_override(tmp_path):
+def test_get_sell_conditions_for_merges_sell_conditions_override(tmp_path, patch_db_sessions):
+    _seed_default_config(patch_db_sessions)
     config_path = _write_config(
         tmp_path,
         """
-default_sell_conditions:
-  stop_loss_pct: 0.05
-  take_profit_pct: 0.15
-  trailing_stop_pct: 0.08
 holdings:
   AAPL:
     sell_conditions:
@@ -56,14 +108,11 @@ holdings:
     assert conditions.trailing_stop_pct == 0.12
 
 
-def test_get_sell_conditions_for_supports_legacy_custom_conditions_key(tmp_path):
+def test_get_sell_conditions_for_supports_legacy_custom_conditions_key(tmp_path, patch_db_sessions):
+    _seed_default_config(patch_db_sessions)
     config_path = _write_config(
         tmp_path,
         """
-default_sell_conditions:
-  stop_loss_pct: 0.05
-  take_profit_pct: 0.15
-  trailing_stop_pct: 0.08
 holdings:
   TSLA:
     custom_conditions:


### PR DESCRIPTION
## Summary
- keep DB sell_rules as the highest-priority per-holding override source
- fall back to legacy YAML sell_conditions/custom_conditions only for fields without DB overrides
- add regression coverage for default, sell_conditions, custom_conditions, and DB-priority cases

## Testing
- python3 -m py_compile screener/portfolio_manager.py tests/test_portfolio_manager.py
- pytest tests/test_portfolio_manager.py tests/test_portfolio_manager_settings.py -q