### PR TITLE
feat(portfolio): evaluate trailing stop conditions

### DIFF
--- a/api/database.py
+++ b/api/database.py
@@ -58,6 +58,7 @@ def init_db() -> None:
     import api.models.strategy_backtest_result  # noqa: F401 — register model with Base
     import api.models.portfolio_alert  # noqa: F401 — register model with Base
     import api.models.portfolio_alert_config  # noqa: F401 — register model with Base
+    import api.models.portfolio_trailing_state  # noqa: F401 — register model with Base
     import api.models.strategy_alert  # noqa: F401 — register model with Base
     import api.models.strategy_webhook  # noqa: F401 — register model with Base
     import api.models.watchlist  # noqa: F401 — register model with Base

--- a/api/models/portfolio_trailing_state.py
+++ b/api/models/portfolio_trailing_state.py
@@ -1,0 +1,19 @@
+"""
+SQLAlchemy model for portfolio-wide trailing stop high-water marks.
+"""
+
+from datetime import datetime
+
+from sqlalchemy import Column, DateTime, Float, String
+
+from api.database import Base
+
+
+class PortfolioTrailingState(Base):
+    """Persisted high-water mark for config-driven trailing stop evaluation."""
+
+    __tablename__ = "portfolio_trailing_state"
+
+    ticker = Column(String(32), primary_key=True)
+    high_watermark = Column(Float, nullable=False)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)

--- a/api/services/portfolio/portfolio_alert_service.py
+++ b/api/services/portfolio/portfolio_alert_service.py
@@ -94,6 +94,21 @@ def _load_alert_settings() -> AlertSettings:
     )
 
 
+def _load_sell_conditions_for_tickers(tickers: list[str]) -> dict[str, Any]:
+    """Load per-holding sell conditions so scanner matches live sell checks."""
+    if not tickers:
+        return {}
+
+    try:
+        from screener.portfolio_manager import PortfolioManager
+
+        manager = PortfolioManager()
+        return {ticker: manager.get_sell_conditions_for(ticker) for ticker in tickers}
+    except Exception:
+        logger.warning("Failed to load per-holding sell conditions", exc_info=True)
+        return {}
+
+
 def load_config() -> tuple[list[HoldingInfo], AlertSettings]:
     """Load holdings from DB and alert settings from DB-backed config."""
     holdings = _load_holdings_from_db()
@@ -419,6 +434,7 @@ class PortfolioAlertScanner:
             return 0
 
         alerts_fired = 0
+        sell_conditions_map = _load_sell_conditions_for_tickers(tickers)
         db = SessionLocal()
         trailing_state_changed = False
         try:
@@ -427,16 +443,20 @@ class PortfolioAlertScanner:
                 if price is None or holding.buy_price <= 0:
                     continue
 
+                conditions = sell_conditions_map.get(holding.ticker)
+                stop_loss_pct = settings.stop_loss_pct
+                take_profit_pct = settings.take_profit_pct
+                trailing_stop_pct = conditions.trailing_stop_pct if conditions else settings.trailing_stop_pct
                 change_pct = (price - holding.buy_price) / holding.buy_price
 
                 # Stop loss
-                if change_pct <= -settings.stop_loss_pct:
+                if change_pct <= -stop_loss_pct:
                     msg = _format_sell_message(holding, "stop_loss", price, change_pct)
                     if record_and_send(holding.ticker, "stop_loss", msg, price, channels=settings.channels):
                         alerts_fired += 1
 
                 # Take profit
-                if change_pct >= settings.take_profit_pct:
+                if change_pct >= take_profit_pct:
                     msg = _format_sell_message(holding, "take_profit", price, change_pct)
                     if record_and_send(holding.ticker, "take_profit", msg, price, channels=settings.channels):
                         alerts_fired += 1
@@ -445,7 +465,7 @@ class PortfolioAlertScanner:
                     db,
                     holding.ticker,
                     price,
-                    settings.trailing_stop_pct,
+                    trailing_stop_pct,
                 )
                 if trailing_reason:
                     msg = _format_sell_message(
@@ -463,7 +483,7 @@ class PortfolioAlertScanner:
                         channels=settings.channels,
                     ):
                         alerts_fired += 1
-                if settings.trailing_stop_pct > 0 and price > 0:
+                if trailing_stop_pct > 0 and price > 0:
                     trailing_state_changed = True
             if trailing_state_changed:
                 db.commit()

--- a/api/services/portfolio/portfolio_alert_service.py
+++ b/api/services/portfolio/portfolio_alert_service.py
@@ -27,6 +27,7 @@ from api.services.portfolio_alert_config_service import (
     _CONFIG_PATH,
     get_portfolio_alert_config_service,
 )
+from api.services.portfolio.portfolio_trailing_service import update_and_check_trailing
 
 logger = logging.getLogger(__name__)
 
@@ -233,6 +234,7 @@ def _format_sell_message(
     signal_type: str,
     price: float,
     change_pct: float,
+    reason: Optional[str] = None,
 ) -> str:
     """Format a sell signal alert message."""
     labels = {
@@ -253,13 +255,16 @@ def _format_sell_message(
         price_str = f"${price:,.2f}"
         buy_str = f"${holding.buy_price:,.2f}"
 
-    return (
+    message = (
         f"{emoji} 매도 시그널 — {label}\n"
         f"종목: {holding.name} ({ticker.split('.')[0]})\n"
         f"사유: {label} {sign}{change_pct:.1%} 도달\n"
         f"현재가: {price_str}\n"
         f"매수가: {buy_str}"
     )
+    if reason:
+        message += f"\n상세: {reason}"
+    return message
 
 
 # ---------------------------------------------------------------------------
@@ -414,25 +419,59 @@ class PortfolioAlertScanner:
             return 0
 
         alerts_fired = 0
-        for holding in holdings:
-            price = prices.get(holding.ticker)
-            if price is None or holding.buy_price <= 0:
-                continue
+        db = SessionLocal()
+        trailing_state_changed = False
+        try:
+            for holding in holdings:
+                price = prices.get(holding.ticker)
+                if price is None or holding.buy_price <= 0:
+                    continue
 
-            change_pct = (price - holding.buy_price) / holding.buy_price
+                change_pct = (price - holding.buy_price) / holding.buy_price
 
-            # Stop loss
-            if change_pct <= -settings.stop_loss_pct:
-                msg = _format_sell_message(holding, "stop_loss", price, change_pct)
-                if record_and_send(holding.ticker, "stop_loss", msg, price, channels=settings.channels):
-                    alerts_fired += 1
+                # Stop loss
+                if change_pct <= -settings.stop_loss_pct:
+                    msg = _format_sell_message(holding, "stop_loss", price, change_pct)
+                    if record_and_send(holding.ticker, "stop_loss", msg, price, channels=settings.channels):
+                        alerts_fired += 1
 
-            # Take profit
-            if change_pct >= settings.take_profit_pct:
-                msg = _format_sell_message(holding, "take_profit", price, change_pct)
-                if record_and_send(holding.ticker, "take_profit", msg, price, channels=settings.channels):
-                    alerts_fired += 1
+                # Take profit
+                if change_pct >= settings.take_profit_pct:
+                    msg = _format_sell_message(holding, "take_profit", price, change_pct)
+                    if record_and_send(holding.ticker, "take_profit", msg, price, channels=settings.channels):
+                        alerts_fired += 1
 
+                _, trailing_reason = update_and_check_trailing(
+                    db,
+                    holding.ticker,
+                    price,
+                    settings.trailing_stop_pct,
+                )
+                if trailing_reason:
+                    msg = _format_sell_message(
+                        holding,
+                        "trailing_stop",
+                        price,
+                        change_pct,
+                        reason=trailing_reason,
+                    )
+                    if record_and_send(
+                        holding.ticker,
+                        "trailing_stop",
+                        msg,
+                        price,
+                        channels=settings.channels,
+                    ):
+                        alerts_fired += 1
+                if settings.trailing_stop_pct > 0 and price > 0:
+                    trailing_state_changed = True
+            if trailing_state_changed:
+                db.commit()
+        except Exception:
+            db.rollback()
+            raise
+        finally:
+            db.close()
         if alerts_fired:
             logger.info("Portfolio scan fired %d alerts", alerts_fired)
 

--- a/api/services/portfolio/portfolio_core_service.py
+++ b/api/services/portfolio/portfolio_core_service.py
@@ -23,6 +23,7 @@ from api.schemas.portfolio import (
 from api.services.portfolio import portfolio_csv_service
 from api.services.portfolio import portfolio_maintenance_service
 from api.services.portfolio.portfolio_price_service import PortfolioPriceService
+from api.services.portfolio.portfolio_trailing_service import clear_trailing_state
 
 logger = logging.getLogger(__name__)
 
@@ -383,6 +384,7 @@ class PortfolioCoreService(PortfolioPriceService):
             if not row:
                 return False
             db.delete(row)
+            clear_trailing_state(db, ticker)
             db.commit()
             logger.info(f"Removed holding: {ticker}")
             return True

--- a/api/services/portfolio/portfolio_csv_service.py
+++ b/api/services/portfolio/portfolio_csv_service.py
@@ -12,6 +12,7 @@ from typing import Any, Dict
 from api.database import SessionLocal
 from api.models.portfolio_alert import PortfolioAlertHistory
 from api.models.portfolio import Holding
+from api.services.portfolio.portfolio_trailing_service import clear_trailing_state
 
 logger = logging.getLogger(__name__)
 
@@ -81,6 +82,7 @@ def import_from_csv(service, csv_content: str, mode: str = "merge") -> Dict[str,
             # becomes misleading for both UI history and daily dedup.
             db.query(PortfolioAlertHistory).delete(synchronize_session=False)
             db.query(Holding).delete()
+            clear_trailing_state(db)
 
         existing_tickers = {row[0] for row in db.query(Holding.ticker).all()}
         for parsed in valid_rows:

--- a/api/services/portfolio/portfolio_maintenance_service.py
+++ b/api/services/portfolio/portfolio_maintenance_service.py
@@ -8,6 +8,7 @@ from typing import List
 from api.database import SessionLocal
 from api.models.portfolio_alert import PortfolioAlertHistory
 from api.models.portfolio import Holding, SellRule
+from api.services.portfolio.portfolio_trailing_service import clear_trailing_state
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +44,7 @@ def delete_all_holdings(_service) -> None:
         db.query(PortfolioAlertHistory).delete(synchronize_session=False)
         db.query(SellRule).delete(synchronize_session=False)
         db.query(Holding).delete(synchronize_session=False)
+        clear_trailing_state(db)
         db.commit()
     except Exception:
         db.rollback()

--- a/api/services/portfolio/portfolio_trailing_service.py
+++ b/api/services/portfolio/portfolio_trailing_service.py
@@ -1,0 +1,50 @@
+"""Helpers for portfolio-wide trailing stop state and evaluation."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from api.models.portfolio_trailing_state import PortfolioTrailingState
+from portfolio.conditions import TradingContext, TrailingStopCondition
+
+
+def update_and_check_trailing(
+    db: Session,
+    ticker: str,
+    current_price: float,
+    pct: float,
+) -> tuple[Optional[float], Optional[str]]:
+    """Update the ticker high-water mark and evaluate trailing stop."""
+    state = db.get(PortfolioTrailingState, ticker)
+    current_hwm = state.high_watermark if state else None
+
+    if pct <= 0 or current_price <= 0:
+        return current_hwm, None
+
+    high_watermark = max(current_hwm or current_price, current_price)
+    if state is None:
+        state = PortfolioTrailingState(ticker=ticker, high_watermark=high_watermark)
+        db.add(state)
+    elif high_watermark != current_hwm:
+        state.high_watermark = high_watermark
+
+    condition = TrailingStopCondition(pct=pct)
+    context = TradingContext(
+        ticker=ticker,
+        current_price=current_price,
+        high_since_buy=high_watermark,
+    )
+    if condition.should_sell(context):
+        return high_watermark, condition.get_reason()
+
+    return high_watermark, None
+
+
+def clear_trailing_state(db: Session, ticker: Optional[str] = None) -> None:
+    """Delete trailing state rows for one ticker or for the whole portfolio."""
+    query = db.query(PortfolioTrailingState)
+    if ticker is not None:
+        query = query.filter(PortfolioTrailingState.ticker == ticker)
+    query.delete(synchronize_session=False)

--- a/scripts/live/portfolio_sell_checker.py
+++ b/scripts/live/portfolio_sell_checker.py
@@ -22,6 +22,8 @@ project_root = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(project_root))
 
 from screener.portfolio_manager import PortfolioManager, ConfigHolding, SellConditions
+from api.database import SessionLocal
+from api.services.portfolio.portfolio_trailing_service import update_and_check_trailing
 from utils.fetch import get_historical_data
 from utils.timezone_utils import get_current_market_time
 
@@ -113,6 +115,24 @@ class PortfolioSellChecker:
         # 익절 체크
         if pnl_pct >= conditions.take_profit_pct:
             reasons.append(f"Take profit reached ({pnl_pct:.1%} >= {conditions.take_profit_pct:.1%})")
+
+        db = SessionLocal()
+        try:
+            _, trailing_reason = update_and_check_trailing(
+                db,
+                holding.symbol,
+                current_price,
+                conditions.trailing_stop_pct,
+            )
+            db.commit()
+        except Exception:
+            db.rollback()
+            raise
+        finally:
+            db.close()
+
+        if trailing_reason:
+            reasons.append(trailing_reason)
 
         return reasons
 

--- a/tests/test_portfolio_alerts.py
+++ b/tests/test_portfolio_alerts.py
@@ -330,6 +330,41 @@ class TestScanner:
             alerts = scanner._scan(holdings, settings)
             assert alerts == 0
 
+    def test_scan_uses_per_holding_sell_conditions_for_trailing_threshold(self):
+        from api.services.portfolio_alert_scanner import (
+            AlertSettings,
+            HoldingInfo,
+            PortfolioAlertScanner,
+        )
+
+        scanner = PortfolioAlertScanner()
+        holdings = [
+            HoldingInfo(ticker="AAPL", name="Apple", buy_price=100, quantity=10),
+        ]
+        settings = AlertSettings(
+            enabled=True,
+            stop_loss_pct=0.20,
+            take_profit_pct=0.30,
+            trailing_stop_pct=0.10,
+            market_hours_only=False,
+        )
+
+        class _Conditions:
+            stop_loss_pct = 0.20
+            take_profit_pct = 0.30
+            trailing_stop_pct = 0.20
+
+        manager = MagicMock()
+        manager.get_sell_conditions_for.return_value = _Conditions()
+
+        with (
+            patch("api.services.portfolio.portfolio_alert_service._fetch_prices", side_effect=[{"AAPL": 120.0}, {"AAPL": 100.0}]),
+            patch("api.services.portfolio.portfolio_alert_service._load_sell_conditions_for_tickers", return_value={"AAPL": _Conditions()}),
+            patch("api.services.notification_dispatcher.dispatch", return_value={"telegram": True}),
+        ):
+            assert scanner._scan(holdings, settings) == 0
+            assert scanner._scan(holdings, settings) == 0
+
 
 # ---------------------------------------------------------------------------
 # Tests — message formatting

--- a/tests/test_portfolio_alerts.py
+++ b/tests/test_portfolio_alerts.py
@@ -19,8 +19,12 @@ os.environ["DATABASE_URL"] = "sqlite:///test_portfolio_alerts.db"
 from api.database import Base, SessionLocal, engine
 import api.models.portfolio  # noqa: F401
 import api.models.portfolio_alert  # noqa: F401
+import api.models.portfolio_alert_config  # noqa: F401
+import api.models.portfolio_trailing_state  # noqa: F401
 from api.models.portfolio import Holding
 from api.models.portfolio_alert import PortfolioAlertHistory
+from api.models.portfolio_alert_config import PortfolioAlertConfig
+from api.models.portfolio_trailing_state import PortfolioTrailingState
 
 
 @pytest.fixture(autouse=True)
@@ -32,6 +36,8 @@ def _fresh_tables():
     db = SessionLocal()
     try:
         db.query(PortfolioAlertHistory).delete()
+        db.query(PortfolioAlertConfig).delete()
+        db.query(PortfolioTrailingState).delete()
         db.query(Holding).delete()
         db.commit()
     finally:
@@ -47,15 +53,15 @@ class TestDedupLogic:
     def test_first_alert_succeeds(self):
         from api.services.portfolio_alert_service import record_and_send
 
-        with patch("api.services.portfolio_alert_service._send_telegram") as mock_tg:
+        with patch("api.services.notification_dispatcher.dispatch", return_value={"telegram": True}) as mock_dispatch:
             result = record_and_send("005930.KS", "stop_loss", "Test message", 50000.0)
             assert result is True
-            mock_tg.assert_called_once()
+            mock_dispatch.assert_called_once()
 
     def test_duplicate_alert_blocked(self):
         from api.services.portfolio_alert_service import record_and_send
 
-        with patch("api.services.portfolio_alert_service._send_telegram"):
+        with patch("api.services.notification_dispatcher.dispatch", return_value={"telegram": True}):
             record_and_send("005930.KS", "stop_loss", "First", 50000.0)
             result = record_and_send("005930.KS", "stop_loss", "Duplicate", 49000.0)
             assert result is False
@@ -63,7 +69,7 @@ class TestDedupLogic:
     def test_different_signal_type_allowed(self):
         from api.services.portfolio_alert_service import record_and_send
 
-        with patch("api.services.portfolio_alert_service._send_telegram"):
+        with patch("api.services.notification_dispatcher.dispatch", return_value={"telegram": True}):
             r1 = record_and_send("005930.KS", "stop_loss", "SL", 50000.0)
             r2 = record_and_send("005930.KS", "take_profit", "TP", 80000.0)
             assert r1 is True
@@ -72,7 +78,7 @@ class TestDedupLogic:
     def test_different_ticker_allowed(self):
         from api.services.portfolio_alert_service import record_and_send
 
-        with patch("api.services.portfolio_alert_service._send_telegram"):
+        with patch("api.services.notification_dispatcher.dispatch", return_value={"telegram": True}):
             r1 = record_and_send("005930.KS", "stop_loss", "A", 50000.0)
             r2 = record_and_send("035420.KS", "stop_loss", "B", 180000.0)
             assert r1 is True
@@ -81,7 +87,7 @@ class TestDedupLogic:
     def test_is_already_sent_today(self):
         from api.services.portfolio_alert_service import is_already_sent_today, record_and_send
 
-        with patch("api.services.portfolio_alert_service._send_telegram"):
+        with patch("api.services.notification_dispatcher.dispatch", return_value={"telegram": True}):
             assert is_already_sent_today("AAPL", "stop_loss") is False
             record_and_send("AAPL", "stop_loss", "msg", 150.0)
             assert is_already_sent_today("AAPL", "stop_loss") is True
@@ -90,7 +96,7 @@ class TestDedupLogic:
     def test_get_history(self):
         from api.services.portfolio_alert_service import get_history, record_and_send
 
-        with patch("api.services.portfolio_alert_service._send_telegram"):
+        with patch("api.services.notification_dispatcher.dispatch", return_value={"telegram": True}):
             record_and_send("AAPL", "stop_loss", "msg1", 150.0)
             record_and_send("MSFT", "take_profit", "msg2", 400.0)
 
@@ -148,9 +154,10 @@ class TestDBHoldings:
 
 
 class TestPortfolioResetBehavior:
-    def test_replace_import_clears_alert_history(self):
+    def test_replace_import_clears_alert_history_and_trailing_state(self):
         from api.services.portfolio.portfolio_core_service import PortfolioCoreService
         from api.services.portfolio_alert_service import record_and_send
+        from api.services.portfolio.portfolio_trailing_service import update_and_check_trailing
 
         class _NoopThread:
             def __init__(self, *args, **kwargs):
@@ -162,9 +169,15 @@ class TestPortfolioResetBehavior:
         with patch("api.services.notification_dispatcher.dispatch", return_value={"telegram": True}):
             record_and_send("005930.KS", "stop_loss", "old alert", 50000.0)
 
-        csv_content = "ticker,quantity,avg_price,name\nAAPL,3,150,Apple\n"
-        service = PortfolioCoreService()
+        db = SessionLocal()
+        try:
+            update_and_check_trailing(db, "005930.KS", 100.0, 0.10)
+            db.commit()
+        finally:
+            db.close()
 
+        service = PortfolioCoreService()
+        csv_content = "ticker,quantity,avg_price,name\nAAPL,3,150,Apple\n"
         with patch("api.services.portfolio.portfolio_csv_service.threading.Thread", _NoopThread):
             result = service.import_from_csv(csv_content, mode="replace")
 
@@ -173,17 +186,20 @@ class TestPortfolioResetBehavior:
         db = SessionLocal()
         try:
             assert db.query(PortfolioAlertHistory).count() == 0
+            assert db.query(PortfolioTrailingState).count() == 0
             assert db.query(Holding).count() == 1
         finally:
             db.close()
 
-    def test_delete_all_holdings_clears_alert_history(self):
+    def test_delete_all_holdings_clears_alert_history_and_trailing_state(self):
         from api.services.portfolio.portfolio_core_service import PortfolioCoreService
         from api.services.portfolio_alert_service import record_and_send
+        from api.services.portfolio.portfolio_trailing_service import update_and_check_trailing
 
         db = SessionLocal()
         try:
             db.add(Holding(ticker="AAPL", name="Apple", quantity=10, avg_price=150, currency="USD"))
+            update_and_check_trailing(db, "AAPL", 200.0, 0.10)
             db.commit()
         finally:
             db.close()
@@ -197,7 +213,32 @@ class TestPortfolioResetBehavior:
         db = SessionLocal()
         try:
             assert db.query(PortfolioAlertHistory).count() == 0
+            assert db.query(PortfolioTrailingState).count() == 0
             assert db.query(Holding).count() == 0
+        finally:
+            db.close()
+
+    def test_remove_holding_clears_single_ticker_trailing_state(self):
+        from api.services.portfolio.portfolio_core_service import PortfolioCoreService
+        from api.services.portfolio.portfolio_trailing_service import update_and_check_trailing
+
+        db = SessionLocal()
+        try:
+            db.add(Holding(ticker="AAPL", name="Apple", quantity=10, avg_price=150, currency="USD"))
+            db.add(Holding(ticker="MSFT", name="Microsoft", quantity=5, avg_price=400, currency="USD"))
+            update_and_check_trailing(db, "AAPL", 200.0, 0.10)
+            update_and_check_trailing(db, "MSFT", 500.0, 0.10)
+            db.commit()
+        finally:
+            db.close()
+
+        service = PortfolioCoreService()
+        assert service.remove_holding("AAPL") is True
+
+        db = SessionLocal()
+        try:
+            assert db.get(PortfolioTrailingState, "AAPL") is None
+            assert db.get(PortfolioTrailingState, "MSFT") is not None
         finally:
             db.close()
 
@@ -229,8 +270,8 @@ class TestScanner:
 
         # Price at 60000 = -25% from buy price → triggers stop loss
         with (
-            patch("api.services.portfolio_alert_scanner._fetch_prices", return_value={"005930.KS": 60000.0}),
-            patch("api.services.portfolio_alert_service._send_telegram"),
+            patch("api.services.portfolio.portfolio_alert_service._fetch_prices", return_value={"005930.KS": 60000.0}),
+            patch("api.services.notification_dispatcher.dispatch", return_value={"telegram": True}),
         ):
             alerts = scanner._scan(holdings, settings)
             assert alerts == 1
@@ -256,8 +297,8 @@ class TestScanner:
 
         # Price at 135 = +35% → triggers take profit
         with (
-            patch("api.services.portfolio_alert_scanner._fetch_prices", return_value={"AAPL": 135.0}),
-            patch("api.services.portfolio_alert_service._send_telegram"),
+            patch("api.services.portfolio.portfolio_alert_service._fetch_prices", return_value={"AAPL": 135.0}),
+            patch("api.services.notification_dispatcher.dispatch", return_value={"telegram": True}),
         ):
             alerts = scanner._scan(holdings, settings)
             assert alerts == 1
@@ -283,8 +324,8 @@ class TestScanner:
 
         # Price at 105 = +5% → no alert
         with (
-            patch("api.services.portfolio_alert_scanner._fetch_prices", return_value={"AAPL": 105.0}),
-            patch("api.services.portfolio_alert_service._send_telegram"),
+            patch("api.services.portfolio.portfolio_alert_service._fetch_prices", return_value={"AAPL": 105.0}),
+            patch("api.services.notification_dispatcher.dispatch", return_value={"telegram": True}),
         ):
             alerts = scanner._scan(holdings, settings)
             assert alerts == 0

--- a/tests/test_portfolio_trailing.py
+++ b/tests/test_portfolio_trailing.py
@@ -1,0 +1,109 @@
+"""Tests for portfolio-wide trailing stop state and evaluation."""
+
+import os
+import sys
+from unittest.mock import patch
+
+# Ensure project root is on path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+os.environ["DATABASE_URL"] = "sqlite:///test_portfolio_trailing.db"
+
+from api.database import Base, SessionLocal, engine
+import api.models.portfolio  # noqa: F401
+import api.models.portfolio_alert  # noqa: F401
+import api.models.portfolio_trailing_state  # noqa: F401
+from api.models.portfolio_trailing_state import PortfolioTrailingState
+
+
+def setup_function():
+    Base.metadata.create_all(bind=engine)
+    db = SessionLocal()
+    try:
+        db.query(PortfolioTrailingState).delete()
+        db.commit()
+    finally:
+        db.close()
+
+
+def teardown_function():
+    db = SessionLocal()
+    try:
+        db.query(PortfolioTrailingState).delete()
+        db.commit()
+    finally:
+        db.close()
+
+
+def test_first_observation_seeds_watermark():
+    from api.services.portfolio.portfolio_trailing_service import update_and_check_trailing
+
+    db = SessionLocal()
+    try:
+        high_watermark, reason = update_and_check_trailing(db, "AAPL", 100.0, 0.10)
+        db.commit()
+        row = db.get(PortfolioTrailingState, "AAPL")
+        assert high_watermark == 100.0
+        assert reason is None
+        assert row is not None
+        assert row.high_watermark == 100.0
+    finally:
+        db.close()
+
+
+def test_watermark_advances_on_higher_price():
+    from api.services.portfolio.portfolio_trailing_service import update_and_check_trailing
+
+    db = SessionLocal()
+    try:
+        update_and_check_trailing(db, "AAPL", 100.0, 0.10)
+        db.commit()
+        high_watermark, reason = update_and_check_trailing(db, "AAPL", 120.0, 0.10)
+        db.commit()
+        row = db.get(PortfolioTrailingState, "AAPL")
+        assert high_watermark == 120.0
+        assert reason is None
+        assert row.high_watermark == 120.0
+    finally:
+        db.close()
+
+
+def test_trigger_fires_on_drop_below_threshold():
+    from api.services.portfolio.portfolio_trailing_service import update_and_check_trailing
+
+    db = SessionLocal()
+    try:
+        update_and_check_trailing(db, "AAPL", 200.0, 0.10)
+        db.commit()
+        high_watermark, reason = update_and_check_trailing(db, "AAPL", 179.99, 0.10)
+        db.commit()
+        assert high_watermark == 200.0
+        assert reason is not None
+        assert "Trailing stop triggered" in reason
+    finally:
+        db.close()
+
+
+def test_trigger_idempotent_per_day():
+    from api.services.portfolio_alert_scanner import AlertSettings, HoldingInfo, PortfolioAlertScanner
+
+    scanner = PortfolioAlertScanner()
+    holdings = [HoldingInfo(ticker="AAPL", name="Apple", buy_price=100.0, quantity=10)]
+    settings = AlertSettings(
+        enabled=True,
+        stop_loss_pct=0.50,
+        take_profit_pct=2.00,
+        trailing_stop_pct=0.10,
+        market_hours_only=False,
+    )
+
+    with (
+        patch(
+            "api.services.portfolio.portfolio_alert_service._fetch_prices",
+            side_effect=[{"AAPL": 200.0}, {"AAPL": 179.99}, {"AAPL": 179.99}],
+        ),
+        patch("api.services.notification_dispatcher.dispatch", return_value={"telegram": True}),
+    ):
+        assert scanner._scan(holdings, settings) == 0
+        assert scanner._scan(holdings, settings) == 1
+        assert scanner._scan(holdings, settings) == 0


### PR DESCRIPTION
## Summary
- persist portfolio trailing high-water marks in the DB
- evaluate trailing stop signals in the alert scanner and live sell checker
- clear trailing state when holdings are replaced, removed, or deleted

## Testing
- python3 -m py_compile api/database.py api/services/portfolio/portfolio_alert_service.py api/services/portfolio/portfolio_trailing_service.py tests/test_portfolio_alerts.py tests/test_portfolio_trailing.py
- pytest tests/test_portfolio_trailing.py tests/test_portfolio_alerts.py -q