### PR TITLE
fix(portfolio): respect technical signals toggle

### DIFF
--- a/screener/portfolio_manager.py
+++ b/screener/portfolio_manager.py
@@ -131,6 +131,12 @@ class PortfolioManager:
 
         return get_portfolio_alert_config_service().get_technical_signals_config()
 
+    def is_technical_signals_enabled(self) -> bool:
+        """기술적 매도 신호 평가 활성화 여부 반환"""
+        from api.services.portfolio_alert_config_service import get_portfolio_alert_config_service
+
+        return bool(get_portfolio_alert_config_service().get_config().technical_signals)
+
     def get_holdings(self) -> List[ConfigHolding]:
         """모든 보유 종목 반환 (DB에서 조회)"""
         try:

--- a/scripts/live/portfolio_sell_checker.py
+++ b/scripts/live/portfolio_sell_checker.py
@@ -167,6 +167,7 @@ class PortfolioSellChecker:
         """단일 종목 매도 신호 체크"""
         symbol = holding.symbol
         conditions = self.pm.get_sell_conditions_for(symbol)
+        technical_signals_enabled = self.pm.is_technical_signals_enabled()
 
         # 현재가 조회
         current_price = self.get_current_price(symbol)
@@ -181,8 +182,10 @@ class PortfolioSellChecker:
         price_reasons = self.check_price_conditions(holding, current_price, conditions)
 
         # 기술적 조건 체크
-        price_data = self.get_price_data(symbol)
-        tech_reasons = self.check_technical_conditions(symbol, price_data)
+        tech_reasons: List[str] = []
+        if technical_signals_enabled:
+            price_data = self.get_price_data(symbol)
+            tech_reasons = self.check_technical_conditions(symbol, price_data)
 
         # 모든 이유 합치기
         all_reasons = price_reasons + tech_reasons

--- a/scripts/live/portfolio_sell_checker.py
+++ b/scripts/live/portfolio_sell_checker.py
@@ -12,7 +12,6 @@ import sys
 import argparse
 import logging
 from pathlib import Path
-from datetime import datetime, timedelta
 from typing import Dict, List, Optional
 from dataclasses import dataclass
 from enum import Enum
@@ -21,11 +20,10 @@ from enum import Enum
 project_root = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(project_root))
 
-from screener.portfolio_manager import PortfolioManager, ConfigHolding, SellConditions
-from api.database import SessionLocal
-from api.services.portfolio.portfolio_trailing_service import update_and_check_trailing
-from utils.fetch import get_historical_data
-from utils.timezone_utils import get_current_market_time
+from screener.portfolio_manager import PortfolioManager, ConfigHolding, SellConditions  # noqa: E402
+from api.database import SessionLocal  # noqa: E402
+from api.services.portfolio.portfolio_trailing_service import update_and_check_trailing  # noqa: E402
+from utils.timezone_utils import get_current_market_time  # noqa: E402
 
 
 class Signal(Enum):
@@ -139,6 +137,9 @@ class PortfolioSellChecker:
     def check_technical_conditions(self, symbol: str, price_data: Dict) -> List[str]:
         """기술적 매도 조건 체크"""
         reasons = []
+        if not self.pm.is_technical_signals_enabled():
+            return reasons
+
         tech_config = self.pm.get_technical_signals_config()
 
         if not price_data:

--- a/tests/test_portfolio_manager_settings.py
+++ b/tests/test_portfolio_manager_settings.py
@@ -90,6 +90,10 @@ def test_portfolio_manager_reads_db_backed_technical_signals(manager):
     }
 
 
+def test_portfolio_manager_reads_technical_signals_enabled_flag(manager):
+    assert manager.is_technical_signals_enabled() is True
+
+
 def test_portfolio_manager_uses_db_sell_rules_as_per_holding_overrides(db_session):
     import api.services.portfolio_alert_config_service as config_mod
     import api.database as database_mod

--- a/tests/test_portfolio_sell_checker.py
+++ b/tests/test_portfolio_sell_checker.py
@@ -1,0 +1,51 @@
+"""Tests for PortfolioSellChecker technical signal toggle behavior."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from scripts.live.portfolio_sell_checker import PortfolioSellChecker
+
+
+def test_check_technical_conditions_returns_empty_when_disabled():
+    checker = PortfolioSellChecker()
+    checker.pm = MagicMock()
+    checker.pm.is_technical_signals_enabled.return_value = False
+
+    reasons = checker.check_technical_conditions(
+        "AAPL",
+        {
+            "current": 90.0,
+            "ma_20": 100.0,
+            "ma_60": 110.0,
+            "prev_ma_20": 120.0,
+            "prev_ma_60": 115.0,
+        },
+    )
+
+    assert reasons == []
+    checker.pm.get_technical_signals_config.assert_not_called()
+
+
+def test_check_technical_conditions_evaluates_when_enabled():
+    checker = PortfolioSellChecker()
+    checker.pm = MagicMock()
+    checker.pm.is_technical_signals_enabled.return_value = True
+    checker.pm.get_technical_signals_config.return_value = {
+        "ma_breakdown": True,
+        "death_cross": True,
+    }
+
+    reasons = checker.check_technical_conditions(
+        "AAPL",
+        {
+            "current": 90.0,
+            "ma_20": 100.0,
+            "ma_60": 110.0,
+            "prev_ma_20": 120.0,
+            "prev_ma_60": 115.0,
+        },
+    )
+
+    assert "Below 20-day MA (90 < 100)" in reasons
+    assert "Death cross detected (MA20 crossed below MA60)" in reasons

--- a/tests/test_portfolio_sell_checker.py
+++ b/tests/test_portfolio_sell_checker.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 from scripts.live.portfolio_sell_checker import PortfolioSellChecker
+from screener.portfolio_manager import ConfigHolding
 
 
 def test_check_technical_conditions_returns_empty_when_disabled():
@@ -49,3 +50,29 @@ def test_check_technical_conditions_evaluates_when_enabled():
 
     assert "Below 20-day MA (90 < 100)" in reasons
     assert "Death cross detected (MA20 crossed below MA60)" in reasons
+
+
+def test_check_holding_skips_price_data_fetch_when_technical_signals_disabled():
+    checker = PortfolioSellChecker()
+    checker.pm = MagicMock()
+    checker.pm.get_sell_conditions_for.return_value = MagicMock()
+    checker.pm.is_technical_signals_enabled.return_value = False
+    checker.get_current_price = MagicMock(return_value=100.0)
+    checker.check_price_conditions = MagicMock(return_value=[])
+    checker.get_price_data = MagicMock()
+    checker.check_technical_conditions = MagicMock(return_value=["unexpected"])
+
+    holding = ConfigHolding(
+        symbol="AAPL",
+        name="Apple",
+        buy_price=90.0,
+        quantity=10,
+        buy_date=None,
+    )
+
+    result = checker.check_holding(holding)
+
+    assert result is not None
+    assert result.signal.value == "HOLD"
+    checker.get_price_data.assert_not_called()
+    checker.check_technical_conditions.assert_not_called()


### PR DESCRIPTION
## Summary
- make the live portfolio sell checker respect the DB-backed `technical_signals` enabled flag
- add a PortfolioManager helper for the runtime toggle check
- add focused tests for the enabled/disabled technical-signal paths

## Testing
- ruff check screener/portfolio_manager.py scripts/live/portfolio_sell_checker.py tests/test_portfolio_manager_settings.py tests/test_portfolio_sell_checker.py
- pytest tests/test_portfolio_manager_settings.py tests/test_portfolio_sell_checker.py -q