### PR TITLE
refactor(portfolio): decouple PortfolioManager from API imports

### DIFF
--- a/api/services/portfolio/portfolio_alert_service.py
+++ b/api/services/portfolio/portfolio_alert_service.py
@@ -21,6 +21,7 @@ from sqlalchemy.exc import IntegrityError
 from api.database import SessionLocal
 from api.models.portfolio_alert import PortfolioAlertHistory
 from api.schemas.portfolio_alert import PortfolioAlertHistoryEntry, PortfolioAlertHistoryResponse
+from api.services.portfolio_manager_provider import build_db_portfolio_manager
 from api.services.portfolio_alert_config_service import (  # noqa: F401
     # Re-exported here for the backward-compat scanner shim.
     _CONFIG_PATH,
@@ -99,9 +100,7 @@ def _load_sell_conditions_for_tickers(tickers: list[str]) -> dict[str, Any]:
         return {}
 
     try:
-        from screener.portfolio_manager import PortfolioManager
-
-        manager = PortfolioManager()
+        manager = build_db_portfolio_manager()
         return {ticker: manager.get_sell_conditions_for(ticker) for ticker in tickers}
     except Exception:
         logger.warning("Failed to load per-holding sell conditions", exc_info=True)

--- a/api/services/portfolio_manager_provider.py
+++ b/api/services/portfolio_manager_provider.py
@@ -1,0 +1,103 @@
+"""API-side DB provider for PortfolioManager runtime data."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Any, Callable, Protocol
+
+from api.database import SessionLocal
+from api.models.portfolio import Holding as DBHolding
+from api.models.portfolio import SellRule
+from api.services.portfolio_alert_config_service import get_portfolio_alert_config_service
+from screener.portfolio_manager import ConfigHolding, PortfolioDataProvider, PortfolioManager
+
+
+class PortfolioConfigServiceLike(Protocol):
+    def get_default_sell_conditions(self) -> dict[str, float]:
+        ...
+
+    def get_technical_signals_config(self) -> dict[str, Any]:
+        ...
+
+    def get_config(self) -> Any:
+        ...
+
+
+@dataclass
+class DBPortfolioDataProvider(PortfolioDataProvider):
+    """Read portfolio runtime settings and holdings from the DB-backed API layer."""
+
+    session_factory: Callable[[], Any] = SessionLocal
+    config_service: PortfolioConfigServiceLike | None = None
+
+    def __post_init__(self) -> None:
+        if self.config_service is None:
+            self.config_service = get_portfolio_alert_config_service()
+
+    def get_default_sell_conditions(self) -> dict[str, float]:
+        return self.config_service.get_default_sell_conditions()
+
+    def get_technical_signals_config(self) -> dict[str, Any]:
+        return self.config_service.get_technical_signals_config()
+
+    def is_technical_signals_enabled(self) -> bool:
+        return bool(self.config_service.get_config().technical_signals)
+
+    def get_holdings(self) -> list[ConfigHolding]:
+        db = self.session_factory()
+        try:
+            rows = db.query(DBHolding).filter(DBHolding.quantity > 0).all()
+            return [
+                ConfigHolding(
+                    symbol=row.ticker,
+                    name=row.name or row.ticker,
+                    buy_price=float(row.avg_price or 0),
+                    quantity=int(row.quantity),
+                    buy_date=row.bought_at or date.today(),
+                )
+                for row in rows
+            ]
+        finally:
+            db.close()
+
+    def get_sell_condition_overrides(self, symbol: str) -> dict[str, float]:
+        db = self.session_factory()
+        try:
+            symbol_upper = symbol.upper()
+            aliases = {symbol_upper}
+            if symbol_upper.endswith((".KS", ".KQ")):
+                aliases.add(symbol_upper.split(".")[0])
+            elif "." not in symbol_upper:
+                aliases.add(f"{symbol_upper}.KS")
+                aliases.add(f"{symbol_upper}.KQ")
+
+            rules = (
+                db.query(SellRule)
+                .filter(SellRule.ticker.in_(list(aliases)), SellRule.is_active.is_(True))
+                .order_by(SellRule.created_at.asc())
+                .all()
+            )
+        finally:
+            db.close()
+
+        overrides: dict[str, float] = {}
+        for rule in rules:
+            params = rule.params or {}
+            pct = params.get("pct")
+            if pct is None:
+                continue
+            normalized_pct = abs(float(pct)) / 100
+            if rule.rule_type == "stop_loss":
+                overrides["stop_loss_pct"] = normalized_pct
+            elif rule.rule_type == "take_profit":
+                overrides["take_profit_pct"] = normalized_pct
+            elif rule.rule_type == "trailing_stop":
+                overrides["trailing_stop_pct"] = normalized_pct
+
+        return overrides
+
+
+def build_db_portfolio_manager(config_path: str | None = None) -> PortfolioManager:
+    """Construct a PortfolioManager with the DB-backed API provider."""
+    return PortfolioManager(config_path=config_path, provider=DBPortfolioDataProvider())

--- a/api/services/portfolio_manager_provider.py
+++ b/api/services/portfolio_manager_provider.py
@@ -63,6 +63,7 @@ class DBPortfolioDataProvider(PortfolioDataProvider):
 
     def get_sell_condition_overrides(self, symbol: str) -> dict[str, float]:
         db = self.session_factory()
+        rules: list[SellRule] = []
         try:
             symbol_upper = symbol.upper()
             aliases = {symbol_upper}

--- a/screener/portfolio_manager.py
+++ b/screener/portfolio_manager.py
@@ -3,11 +3,11 @@ Portfolio Manager Module
 보유 종목 및 매도 조건 관리
 """
 
-import yaml
 import logging
+import yaml
 from pathlib import Path
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Any
+from typing import Any, Dict, List, Optional, Protocol
 from datetime import date
 
 
@@ -57,10 +57,29 @@ class SellConditions:
         }
 
 
+class PortfolioDataProvider(Protocol):
+    """Optional runtime provider for DB-backed portfolio data."""
+
+    def get_default_sell_conditions(self) -> Dict[str, float]:
+        ...
+
+    def get_technical_signals_config(self) -> Dict[str, Any]:
+        ...
+
+    def is_technical_signals_enabled(self) -> bool:
+        ...
+
+    def get_holdings(self) -> List[ConfigHolding]:
+        ...
+
+    def get_sell_condition_overrides(self, symbol: str) -> Dict[str, float]:
+        ...
+
+
 class PortfolioManager:
     """포트폴리오 관리 클래스"""
 
-    def __init__(self, config_path: str = None):
+    def __init__(self, config_path: str = None, provider: PortfolioDataProvider | None = None):
         self.logger = logging.getLogger(__name__)
         self.project_root = Path(__file__).parent.parent
 
@@ -69,6 +88,7 @@ class PortfolioManager:
 
         self.config_path = Path(config_path)
         self.config = self._load_config()
+        self.provider = provider
 
     def _load_config(self) -> Dict[str, Any]:
         """포트폴리오 설정 로드"""
@@ -120,46 +140,55 @@ class PortfolioManager:
 
     def get_default_sell_conditions(self) -> SellConditions:
         """기본 매도 조건 반환"""
-        from api.services.portfolio_alert_config_service import get_portfolio_alert_config_service
+        if self.provider is not None:
+            return SellConditions.from_dict(self.provider.get_default_sell_conditions())
 
-        conditions = get_portfolio_alert_config_service().get_default_sell_conditions()
+        conditions = self.config.get('default_sell_conditions', {}) or {}
         return SellConditions.from_dict(conditions)
 
     def get_technical_signals_config(self) -> Dict[str, Any]:
         """기술적 매도 신호 설정 반환"""
-        from api.services.portfolio_alert_config_service import get_portfolio_alert_config_service
-
-        return get_portfolio_alert_config_service().get_technical_signals_config()
+        if self.provider is not None:
+            return self.provider.get_technical_signals_config()
+        return self.config.get('technical_sell_signals', {}) or {}
 
     def is_technical_signals_enabled(self) -> bool:
         """기술적 매도 신호 평가 활성화 여부 반환"""
-        from api.services.portfolio_alert_config_service import get_portfolio_alert_config_service
-
-        return bool(get_portfolio_alert_config_service().get_config().technical_signals)
+        if self.provider is not None:
+            return self.provider.is_technical_signals_enabled()
+        alert_settings = self.config.get('alert_settings', {}) or {}
+        return bool(alert_settings.get('technical_signals', True))
 
     def get_holdings(self) -> List[ConfigHolding]:
-        """모든 보유 종목 반환 (DB에서 조회)"""
-        try:
-            from api.database import SessionLocal
-            from api.models.portfolio import Holding as DBHolding
-            db = SessionLocal()
-            try:
-                rows = db.query(DBHolding).filter(DBHolding.quantity > 0).all()
-                return [
-                    ConfigHolding(
-                        symbol=row.ticker,
-                        name=row.name or row.ticker,
-                        buy_price=float(row.avg_price or 0),
-                        quantity=int(row.quantity),
-                        buy_date=row.bought_at or date.today(),
-                    )
-                    for row in rows
-                ]
-            finally:
-                db.close()
-        except Exception as e:
-            self.logger.warning(f"Failed to load holdings from DB: {e}")
-            return []
+        """모든 보유 종목 반환"""
+        if self.provider is not None:
+            return self.provider.get_holdings()
+
+        holdings = self.config.get('holdings', {}) or {}
+        rows: List[ConfigHolding] = []
+        for symbol, raw in holdings.items():
+            if not raw:
+                continue
+            raw_buy_date = raw.get('buy_date')
+            buy_date = date.today()
+            if isinstance(raw_buy_date, date):
+                buy_date = raw_buy_date
+            elif isinstance(raw_buy_date, str):
+                try:
+                    buy_date = date.fromisoformat(raw_buy_date)
+                except ValueError:
+                    buy_date = date.today()
+
+            rows.append(
+                ConfigHolding(
+                    symbol=symbol,
+                    name=raw.get('name') or symbol,
+                    buy_price=float(raw.get('buy_price') or 0),
+                    quantity=int(raw.get('quantity') or 0),
+                    buy_date=buy_date,
+                )
+            )
+        return rows
 
     def get_holding(self, symbol: str) -> Optional[ConfigHolding]:
         """특정 종목 정보 반환 (DB에서 조회)"""
@@ -174,48 +203,21 @@ class PortfolioManager:
         Priority:
         1. DB-backed per-holding SellRule overrides
         2. Legacy YAML holding overrides (temporary compatibility)
-        3. DB-backed global defaults
+        3. Global defaults
         """
         defaults = self.get_default_sell_conditions().to_dict()
         merged = defaults.copy()
-        db_override_keys: set[str] = set()
+        provider_override_keys: set[str] = set()
 
-        try:
-            from api.database import SessionLocal
-            from api.models.portfolio import SellRule
-
-            db = SessionLocal()
+        if self.provider is not None:
             try:
-                symbol_upper = symbol.upper()
-                aliases = {symbol_upper}
-                if symbol_upper.endswith(('.KS', '.KQ')):
-                    aliases.add(symbol_upper.split('.')[0])
-                elif '.' not in symbol_upper:
-                    aliases.add(f"{symbol_upper}.KS")
-                    aliases.add(f"{symbol_upper}.KQ")
-
-                rules = (
-                    db.query(SellRule)
-                    .filter(SellRule.ticker.in_(list(aliases)), SellRule.is_active.is_(True))
-                    .order_by(SellRule.created_at.asc())
-                    .all()
-                )
-            finally:
-                db.close()
-
-            for rule in rules:
-                params = rule.params or {}
-                if rule.rule_type == 'stop_loss' and params.get('pct') is not None:
-                    merged['stop_loss_pct'] = abs(float(params['pct'])) / 100
-                    db_override_keys.add('stop_loss_pct')
-                elif rule.rule_type == 'take_profit' and params.get('pct') is not None:
-                    merged['take_profit_pct'] = abs(float(params['pct'])) / 100
-                    db_override_keys.add('take_profit_pct')
-                elif rule.rule_type == 'trailing_stop' and params.get('pct') is not None:
-                    merged['trailing_stop_pct'] = abs(float(params['pct'])) / 100
-                    db_override_keys.add('trailing_stop_pct')
-        except Exception as e:
-            self.logger.warning(f"Failed to load sell rule overrides from DB: {e}")
+                overrides = self.provider.get_sell_condition_overrides(symbol)
+                for key, value in overrides.items():
+                    if key in ('stop_loss_pct', 'take_profit_pct', 'trailing_stop_pct') and value is not None:
+                        merged[key] = value
+                        provider_override_keys.add(key)
+            except Exception as e:
+                self.logger.warning(f"Failed to load sell rule overrides from provider: {e}")
 
         holdings = self.config.get('holdings', {}) or {}
         holding_config = None
@@ -231,7 +233,7 @@ class PortfolioManager:
                 or {}
             )
             for key in ('stop_loss_pct', 'take_profit_pct', 'trailing_stop_pct'):
-                if key in overrides and overrides[key] is not None and key not in db_override_keys:
+                if key in overrides and overrides[key] is not None and key not in provider_override_keys:
                     merged[key] = overrides[key]
         return SellConditions.from_dict(merged)
 

--- a/scripts/live/portfolio_sell_checker.py
+++ b/scripts/live/portfolio_sell_checker.py
@@ -20,9 +20,10 @@ from enum import Enum
 project_root = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(project_root))
 
-from screener.portfolio_manager import PortfolioManager, ConfigHolding, SellConditions  # noqa: E402
 from api.database import SessionLocal  # noqa: E402
+from api.services.portfolio_manager_provider import build_db_portfolio_manager  # noqa: E402
 from api.services.portfolio.portfolio_trailing_service import update_and_check_trailing  # noqa: E402
+from screener.portfolio_manager import ConfigHolding, SellConditions  # noqa: E402
 from utils.timezone_utils import get_current_market_time  # noqa: E402
 
 
@@ -51,7 +52,7 @@ class PortfolioSellChecker:
 
     def __init__(self, verbose: bool = False):
         self.logger = self._setup_logger(verbose)
-        self.pm = PortfolioManager()
+        self.pm = build_db_portfolio_manager()
 
     def _setup_logger(self, verbose: bool) -> logging.Logger:
         logger = logging.getLogger(__name__)

--- a/tests/test_portfolio_manager.py
+++ b/tests/test_portfolio_manager.py
@@ -119,3 +119,27 @@ holdings:
     conditions = manager.get_sell_conditions_for("AAPL")
 
     assert conditions.trailing_stop_pct == 0.12
+
+
+def test_get_holdings_reads_yaml_when_provider_is_absent(tmp_path):
+    config_path = _write_config(
+        tmp_path,
+        """
+holdings:
+  AAPL:
+    name: Apple
+    buy_price: 150.5
+    quantity: 7
+    buy_date: 2026-01-15
+""".strip(),
+    )
+
+    manager = PortfolioManager(config_path=str(config_path))
+    holdings = manager.get_holdings()
+
+    assert len(holdings) == 1
+    assert holdings[0].symbol == "AAPL"
+    assert holdings[0].name == "Apple"
+    assert holdings[0].buy_price == 150.5
+    assert holdings[0].quantity == 7
+    assert holdings[0].buy_date.isoformat() == "2026-01-15"

--- a/tests/test_portfolio_manager.py
+++ b/tests/test_portfolio_manager.py
@@ -3,16 +3,42 @@
 from __future__ import annotations
 
 from pathlib import Path
-import json
 
-import pytest
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
-
-from api.database import Base
-from api.models.portfolio import SellRule
-from api.models.portfolio_alert_config import PortfolioAlertConfig
 from screener.portfolio_manager import PortfolioManager
+
+
+class StubProvider:
+    def __init__(
+        self,
+        *,
+        default_sell_conditions: dict[str, float] | None = None,
+        technical_signals_config: dict | None = None,
+        technical_signals_enabled: bool = True,
+        sell_condition_overrides: dict[str, dict[str, float]] | None = None,
+    ) -> None:
+        self._default_sell_conditions = default_sell_conditions or {
+            "stop_loss_pct": 0.05,
+            "take_profit_pct": 0.15,
+            "trailing_stop_pct": 0.08,
+        }
+        self._technical_signals_config = technical_signals_config or {}
+        self._technical_signals_enabled = technical_signals_enabled
+        self._sell_condition_overrides = sell_condition_overrides or {}
+
+    def get_default_sell_conditions(self) -> dict[str, float]:
+        return self._default_sell_conditions
+
+    def get_technical_signals_config(self) -> dict:
+        return self._technical_signals_config
+
+    def is_technical_signals_enabled(self) -> bool:
+        return self._technical_signals_enabled
+
+    def get_holdings(self):
+        return []
+
+    def get_sell_condition_overrides(self, symbol: str) -> dict[str, float]:
+        return self._sell_condition_overrides.get(symbol.upper(), {})
 
 
 def _write_config(tmp_path: Path, body: str) -> Path:
@@ -21,66 +47,12 @@ def _write_config(tmp_path: Path, body: str) -> Path:
     return config_path
 
 
-@pytest.fixture()
-def db_session():
-    engine = create_engine("sqlite://", connect_args={"check_same_thread": False})
-    testing_session = sessionmaker(bind=engine)
-    Base.metadata.create_all(bind=engine)
-    yield testing_session
-    engine.dispose()
-
-
-@pytest.fixture()
-def patch_db_sessions(db_session):
-    import api.database as database_mod
-    import api.services.portfolio_alert_config_service as config_mod
-
-    orig_db_session = database_mod.SessionLocal
-    orig_config_session = config_mod.SessionLocal
-    database_mod.SessionLocal = db_session
-    config_mod.SessionLocal = db_session
-    try:
-        yield db_session
-    finally:
-        database_mod.SessionLocal = orig_db_session
-        config_mod.SessionLocal = orig_config_session
-
-
-def _seed_default_config(db_session) -> None:
-    db = db_session()
-    try:
-        db.add(
-            PortfolioAlertConfig(
-                id=1,
-                enabled=True,
-                scan_interval_seconds=60,
-                stop_loss_pct=0.20,
-                take_profit_pct=0.30,
-                trailing_stop_pct=0.10,
-                technical_signals=True,
-                market_hours_only=True,
-                channels_json='["telegram"]',
-                default_stop_loss_pct=0.05,
-                default_take_profit_pct=0.15,
-                default_trailing_stop_pct=0.08,
-                technical_signals_json=json.dumps({}),
-                migrated_from_yaml=False,
-            )
-        )
-        db.commit()
-    finally:
-        db.close()
-
-
-def test_get_sell_conditions_for_returns_defaults_without_holding_override(tmp_path, patch_db_sessions):
-    _seed_default_config(patch_db_sessions)
-    config_path = _write_config(
-        tmp_path,
-        """
-""".strip(),
+def test_get_sell_conditions_for_returns_provider_defaults_without_holding_override(tmp_path):
+    manager = PortfolioManager(
+        config_path=str(_write_config(tmp_path, "")),
+        provider=StubProvider(),
     )
 
-    manager = PortfolioManager(config_path=str(config_path))
     conditions = manager.get_sell_conditions_for("AAPL")
 
     assert conditions.stop_loss_pct == 0.05
@@ -88,8 +60,7 @@ def test_get_sell_conditions_for_returns_defaults_without_holding_override(tmp_p
     assert conditions.trailing_stop_pct == 0.08
 
 
-def test_get_sell_conditions_for_merges_sell_conditions_override(tmp_path, patch_db_sessions):
-    _seed_default_config(patch_db_sessions)
+def test_get_sell_conditions_for_merges_yaml_override_on_top_of_provider_defaults(tmp_path):
     config_path = _write_config(
         tmp_path,
         """
@@ -101,7 +72,7 @@ holdings:
 """.strip(),
     )
 
-    manager = PortfolioManager(config_path=str(config_path))
+    manager = PortfolioManager(config_path=str(config_path), provider=StubProvider())
     conditions = manager.get_sell_conditions_for("AAPL")
 
     assert conditions.stop_loss_pct == 0.05
@@ -109,8 +80,7 @@ holdings:
     assert conditions.trailing_stop_pct == 0.12
 
 
-def test_get_sell_conditions_for_supports_legacy_custom_conditions_key(tmp_path, patch_db_sessions):
-    _seed_default_config(patch_db_sessions)
+def test_get_sell_conditions_for_supports_legacy_custom_conditions_key(tmp_path):
     config_path = _write_config(
         tmp_path,
         """
@@ -121,7 +91,7 @@ holdings:
 """.strip(),
     )
 
-    manager = PortfolioManager(config_path=str(config_path))
+    manager = PortfolioManager(config_path=str(config_path), provider=StubProvider())
     conditions = manager.get_sell_conditions_for("tsla")
 
     assert conditions.stop_loss_pct == 0.03
@@ -129,15 +99,7 @@ holdings:
     assert conditions.trailing_stop_pct == 0.08
 
 
-def test_get_sell_conditions_for_prefers_db_sell_rules_over_yaml_override(tmp_path, patch_db_sessions):
-    _seed_default_config(patch_db_sessions)
-    db = patch_db_sessions()
-    try:
-        db.add(SellRule(ticker="AAPL", rule_type="trailing_stop", params={"pct": 12}, is_active=True))
-        db.commit()
-    finally:
-        db.close()
-
+def test_get_sell_conditions_for_prefers_provider_overrides_over_yaml_override(tmp_path):
     config_path = _write_config(
         tmp_path,
         """
@@ -148,7 +110,12 @@ holdings:
 """.strip(),
     )
 
-    manager = PortfolioManager(config_path=str(config_path))
+    manager = PortfolioManager(
+        config_path=str(config_path),
+        provider=StubProvider(
+            sell_condition_overrides={"AAPL": {"trailing_stop_pct": 0.12}},
+        ),
+    )
     conditions = manager.get_sell_conditions_for("AAPL")
 
     assert conditions.trailing_stop_pct == 0.12

--- a/tests/test_portfolio_manager_settings.py
+++ b/tests/test_portfolio_manager_settings.py
@@ -1,8 +1,8 @@
-"""Tests for PortfolioManager reading DB-backed sell/technical settings."""
+"""Tests for PortfolioManager provider injection and DB-backed provider behavior."""
 
 from __future__ import annotations
 
-import json
+from dataclasses import dataclass
 from datetime import date
 
 import pytest
@@ -11,7 +11,42 @@ from sqlalchemy.orm import sessionmaker
 
 from api.database import Base
 from api.models.portfolio import Holding, SellRule
-from api.models.portfolio_alert_config import PortfolioAlertConfig
+from api.services.portfolio_manager_provider import DBPortfolioDataProvider
+from screener.portfolio_manager import PortfolioManager
+
+
+@dataclass
+class StubConfigResponse:
+    technical_signals: bool
+
+
+class StubConfigService:
+    def __init__(
+        self,
+        *,
+        default_sell_conditions: dict[str, float] | None = None,
+        technical_signals_config: dict | None = None,
+        technical_signals_enabled: bool = True,
+    ) -> None:
+        self._default_sell_conditions = default_sell_conditions or {
+            "stop_loss_pct": 0.04,
+            "take_profit_pct": 0.21,
+            "trailing_stop_pct": 0.07,
+        }
+        self._technical_signals_config = technical_signals_config or {
+            "ma_breakdown": True,
+            "death_cross": False,
+        }
+        self._technical_signals_enabled = technical_signals_enabled
+
+    def get_default_sell_conditions(self) -> dict[str, float]:
+        return self._default_sell_conditions
+
+    def get_technical_signals_config(self) -> dict:
+        return self._technical_signals_config
+
+    def get_config(self) -> StubConfigResponse:
+        return StubConfigResponse(technical_signals=self._technical_signals_enabled)
 
 
 @pytest.fixture()
@@ -24,35 +59,9 @@ def db_session():
 
 
 @pytest.fixture()
-def manager(db_session):
-    import api.services.portfolio_alert_config_service as config_mod
-    import api.database as database_mod
-
-    orig_session = config_mod.SessionLocal
-    orig_db_session = database_mod.SessionLocal
-    config_mod.SessionLocal = db_session
-    database_mod.SessionLocal = db_session
-
+def provider(db_session):
     db = db_session()
     try:
-        db.add(
-            PortfolioAlertConfig(
-                id=1,
-                enabled=True,
-                scan_interval_seconds=60,
-                stop_loss_pct=0.20,
-                take_profit_pct=0.30,
-                trailing_stop_pct=0.10,
-                technical_signals=True,
-                market_hours_only=True,
-                channels_json='["telegram"]',
-                default_stop_loss_pct=0.04,
-                default_take_profit_pct=0.21,
-                default_trailing_stop_pct=0.07,
-                technical_signals_json=json.dumps({"ma_breakdown": True, "death_cross": False}),
-                migrated_from_yaml=False,
-            )
-        )
         db.add(
             Holding(
                 ticker="AAPL",
@@ -67,15 +76,18 @@ def manager(db_session):
     finally:
         db.close()
 
-    from screener.portfolio_manager import PortfolioManager
-
-    mgr = PortfolioManager(config_path="/nonexistent/portfolio.yaml")
-    yield mgr
-    config_mod.SessionLocal = orig_session
-    database_mod.SessionLocal = orig_db_session
+    return DBPortfolioDataProvider(
+        session_factory=db_session,
+        config_service=StubConfigService(),
+    )
 
 
-def test_portfolio_manager_reads_db_backed_default_sell_conditions(manager):
+@pytest.fixture()
+def manager(provider):
+    return PortfolioManager(config_path="/nonexistent/portfolio.yaml", provider=provider)
+
+
+def test_portfolio_manager_reads_provider_backed_default_sell_conditions(manager):
     conditions = manager.get_default_sell_conditions()
 
     assert conditions.stop_loss_pct == 0.04
@@ -83,46 +95,28 @@ def test_portfolio_manager_reads_db_backed_default_sell_conditions(manager):
     assert conditions.trailing_stop_pct == 0.07
 
 
-def test_portfolio_manager_reads_db_backed_technical_signals(manager):
+def test_portfolio_manager_reads_provider_backed_technical_signals(manager):
     assert manager.get_technical_signals_config() == {
         "ma_breakdown": True,
         "death_cross": False,
     }
 
 
-def test_portfolio_manager_reads_technical_signals_enabled_flag(manager):
+def test_portfolio_manager_reads_technical_signals_enabled_flag_from_provider(manager):
     assert manager.is_technical_signals_enabled() is True
 
 
+def test_portfolio_manager_reads_holdings_from_provider(manager):
+    holdings = manager.get_holdings()
+
+    assert len(holdings) == 1
+    assert holdings[0].symbol == "AAPL"
+    assert holdings[0].buy_price == 150.0
+
+
 def test_portfolio_manager_uses_db_sell_rules_as_per_holding_overrides(db_session):
-    import api.services.portfolio_alert_config_service as config_mod
-    import api.database as database_mod
-
-    orig_session = config_mod.SessionLocal
-    orig_db_session = database_mod.SessionLocal
-    config_mod.SessionLocal = db_session
-    database_mod.SessionLocal = db_session
-
     db = db_session()
     try:
-        db.add(
-            PortfolioAlertConfig(
-                id=1,
-                enabled=True,
-                scan_interval_seconds=60,
-                stop_loss_pct=0.20,
-                take_profit_pct=0.30,
-                trailing_stop_pct=0.10,
-                technical_signals=True,
-                market_hours_only=True,
-                channels_json='["telegram"]',
-                default_stop_loss_pct=0.05,
-                default_take_profit_pct=0.15,
-                default_trailing_stop_pct=0.08,
-                technical_signals_json="{}",
-                migrated_from_yaml=False,
-            )
-        )
         db.add(
             Holding(
                 ticker="AAPL",
@@ -140,52 +134,26 @@ def test_portfolio_manager_uses_db_sell_rules_as_per_holding_overrides(db_sessio
     finally:
         db.close()
 
-    from screener.portfolio_manager import PortfolioManager
+    provider = DBPortfolioDataProvider(
+        session_factory=db_session,
+        config_service=StubConfigService(
+            default_sell_conditions={
+                "stop_loss_pct": 0.05,
+                "take_profit_pct": 0.15,
+                "trailing_stop_pct": 0.08,
+            }
+        ),
+    )
 
-    mgr = PortfolioManager(config_path="/nonexistent/portfolio.yaml")
+    mgr = PortfolioManager(config_path="/nonexistent/portfolio.yaml", provider=provider)
     conditions = mgr.get_sell_conditions_for("AAPL")
 
     assert conditions.stop_loss_pct == 0.03
     assert conditions.take_profit_pct == 0.25
     assert conditions.trailing_stop_pct == 0.12
 
-    config_mod.SessionLocal = orig_session
-    database_mod.SessionLocal = orig_db_session
-
 
 def test_portfolio_manager_still_supports_legacy_yaml_override_fallback(db_session, tmp_path):
-    import api.services.portfolio_alert_config_service as config_mod
-    import api.database as database_mod
-
-    orig_session = config_mod.SessionLocal
-    orig_db_session = database_mod.SessionLocal
-    config_mod.SessionLocal = db_session
-    database_mod.SessionLocal = db_session
-
-    db = db_session()
-    try:
-        db.add(
-            PortfolioAlertConfig(
-                id=1,
-                enabled=True,
-                scan_interval_seconds=60,
-                stop_loss_pct=0.20,
-                take_profit_pct=0.30,
-                trailing_stop_pct=0.10,
-                technical_signals=True,
-                market_hours_only=True,
-                channels_json='["telegram"]',
-                default_stop_loss_pct=0.05,
-                default_take_profit_pct=0.15,
-                default_trailing_stop_pct=0.08,
-                technical_signals_json="{}",
-                migrated_from_yaml=False,
-            )
-        )
-        db.commit()
-    finally:
-        db.close()
-
     config_path = tmp_path / "portfolio.yaml"
     config_path.write_text(
         """
@@ -198,14 +166,20 @@ holdings:
         encoding="utf-8",
     )
 
-    from screener.portfolio_manager import PortfolioManager
+    provider = DBPortfolioDataProvider(
+        session_factory=db_session,
+        config_service=StubConfigService(
+            default_sell_conditions={
+                "stop_loss_pct": 0.05,
+                "take_profit_pct": 0.15,
+                "trailing_stop_pct": 0.08,
+            }
+        ),
+    )
 
-    mgr = PortfolioManager(config_path=str(config_path))
+    mgr = PortfolioManager(config_path=str(config_path), provider=provider)
     conditions = mgr.get_sell_conditions_for("TSLA")
 
     assert conditions.stop_loss_pct == 0.02
     assert conditions.take_profit_pct == 0.30
     assert conditions.trailing_stop_pct == 0.08
-
-    config_mod.SessionLocal = orig_session
-    database_mod.SessionLocal = orig_db_session


### PR DESCRIPTION
## Summary\n- add an injectable runtime provider to  so  no longer imports  directly\n- move DB-backed holdings/config/sell-rule lookups into a new API-side provider used by the sell checker and alert scanner\n- refresh focused tests so merge logic is provider-driven and DB behavior is covered explicitly\n\n## Testing\n- python3 -m py_compile screener/portfolio_manager.py api/services/portfolio_manager_provider.py scripts/live/portfolio_sell_checker.py api/services/portfolio/portfolio_alert_service.py tests/test_portfolio_manager.py tests/test_portfolio_manager_settings.py tests/test_portfolio_sell_checker.py\n- pytest tests/test_portfolio_manager.py tests/test_portfolio_manager_settings.py tests/test_portfolio_sell_checker.py -q\n- pytest tests/test_portfolio_alerts.py -q\n\nCloses #1404