### PR TITLE
fix(backtest): reject universe nodes in single-ticker graph runs

### DIFF
--- a/api/services/backtest_service.py
+++ b/api/services/backtest_service.py
@@ -112,6 +112,23 @@ STRATEGY_META: Dict[str, Dict[str, Any]] = {
 }
 
 
+def _validate_single_ticker_graph_backtest(request: GraphBacktestRequest) -> None:
+    """Reject graph backtests whose graph semantics do not match single-ticker execution."""
+    unsupported_scope_nodes = [
+        node.data.node_type
+        for node in request.graph.nodes
+        if node.data.node_type in {"universe", "sector"}
+    ]
+    if not unsupported_scope_nodes:
+        return
+
+    unique_types = ", ".join(sorted(set(unsupported_scope_nodes)))
+    raise ValueError(
+        "Graph backtest only supports single-ticker graphs. "
+        f"Remove scope-setting node(s): {unique_types}, or use a portfolio/universe backtest mode."
+    )
+
+
 def _sanitize_value(v: Any) -> Any:
     """
     Convert numpy/pandas types to native Python types for JSON serialization.
@@ -394,6 +411,8 @@ def run_graph_backtest(request: GraphBacktestRequest) -> GraphBacktestResponse:
         ValueError: If no backtestable conditions are found.
     """
     from api.services.strategy_builder import build_strategy_from_graph
+
+    _validate_single_ticker_graph_backtest(request)
 
     # Build strategy from graph
     build_result = build_strategy_from_graph(

--- a/api/tests/test_backtest.py
+++ b/api/tests/test_backtest.py
@@ -2,12 +2,10 @@
 Tests for backtest API endpoints.
 """
 
-from dataclasses import dataclass
 from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pandas as pd
-import pytest
 from fastapi.testclient import TestClient
 
 from api.main import app
@@ -78,6 +76,46 @@ def _make_mock_backtest_result(
     stats._strategy = mock_strategy
 
     return result
+
+
+def _make_graph_request(*, include_universe: bool = False):
+    nodes = []
+    edges = []
+    if include_universe:
+        nodes.append(
+            {
+                "id": "u1",
+                "data": {"node_type": "universe", "universe": "SP500", "universes": ["SP500"]},
+            }
+        )
+    nodes.extend(
+        [
+            {
+                "id": "c1",
+                "data": {
+                    "node_type": "condition",
+                    "condition_type": "rsi_oversold",
+                    "params": {"period": 14, "threshold": 30},
+                },
+            },
+            {"id": "o1", "data": {"node_type": "output"}},
+        ]
+    )
+    if include_universe:
+        edges.extend(
+            [
+                {"id": "e1", "source": "u1", "target": "c1"},
+                {"id": "e2", "source": "c1", "target": "o1"},
+            ]
+        )
+    else:
+        edges.append({"id": "e1", "source": "c1", "target": "o1"})
+
+    return {
+        "graph": {"nodes": nodes, "edges": edges},
+        "ticker": "AAPL",
+        "period": "1y",
+    }
 
 
 class TestStrategiesEndpoint:
@@ -522,3 +560,29 @@ class TestSanitization:
         data = response.json()
         # Should not raise a serialization error; trades should be present
         assert len(data["trades"]) > 0
+
+
+class TestGraphBacktestEndpoint:
+    @patch("api.services.backtest_service.BacktestEngine")
+    def test_run_graph_backtest_success_for_single_ticker_graph(self, mock_engine_cls):
+        mock_result = _make_mock_backtest_result()
+        mock_engine = MagicMock()
+        mock_engine.run.return_value = mock_result
+        mock_engine_cls.return_value = mock_engine
+
+        response = client.post("/api/backtest/run-graph", json=_make_graph_request())
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["ticker"] == "AAPL"
+        assert data["strategy"] == "graph"
+        assert "warnings" in data
+
+    def test_run_graph_backtest_rejects_universe_node(self):
+        response = client.post(
+            "/api/backtest/run-graph",
+            json=_make_graph_request(include_universe=True),
+        )
+
+        assert response.status_code == 400
+        assert "single-ticker graphs" in response.json()["detail"]

--- a/tests/test_auto_promote.py
+++ b/tests/test_auto_promote.py
@@ -25,6 +25,18 @@ from api.services.strategy_backtest_result_service import get_results
 def _make_graph():
     return StrategyGraph(
         nodes=[
+            StrategyNode(id="c1", data=StrategyNodeData(node_type="condition", condition_type="rsi_oversold", params={"period": 14, "threshold": 30})),
+            StrategyNode(id="o1", data=StrategyNodeData(node_type="output")),
+        ],
+        edges=[
+            StrategyEdge(id="e1", source="c1", target="o1"),
+        ],
+    )
+
+
+def _make_universe_graph():
+    return StrategyGraph(
+        nodes=[
             StrategyNode(id="u1", data=StrategyNodeData(node_type="universe", universe="SP500", universes=["SP500"])),
             StrategyNode(id="c1", data=StrategyNodeData(node_type="condition", condition_type="rsi_oversold", params={"period": 14, "threshold": 30})),
             StrategyNode(id="o1", data=StrategyNodeData(node_type="output")),
@@ -39,7 +51,8 @@ def _make_graph():
 @pytest.fixture(autouse=True)
 def _use_in_memory_db(monkeypatch):
     from api import database
-    from api.services import strategy_save_service, strategy_backtest_result_service
+    from api.services import strategy_save_service
+    from api.services.strategy import strategy_analytics_service
 
     from sqlalchemy import create_engine
     from sqlalchemy.orm import sessionmaker
@@ -50,7 +63,7 @@ def _use_in_memory_db(monkeypatch):
     monkeypatch.setattr(database, "engine", test_engine)
     monkeypatch.setattr(database, "SessionLocal", TestSession)
     monkeypatch.setattr(strategy_save_service, "SessionLocal", TestSession)
-    monkeypatch.setattr(strategy_backtest_result_service, "SessionLocal", TestSession)
+    monkeypatch.setattr(strategy_analytics_service, "SessionLocal", TestSession)
     monkeypatch.setattr(strategy_save_service, "_strategy_save_service", None)
 
     database.Base.metadata.create_all(bind=test_engine)
@@ -156,3 +169,14 @@ class TestAutoPromote:
         response = run_graph_backtest(request)
 
         assert response.strategy_status is None
+
+    def test_universe_graph_is_rejected(self):
+        from api.services.backtest_service import run_graph_backtest
+
+        request = GraphBacktestRequest(
+            graph=_make_universe_graph(),
+            ticker="AAPL",
+        )
+
+        with pytest.raises(ValueError, match="single-ticker graphs"):
+            run_graph_backtest(request)


### PR DESCRIPTION
## Summary
- reject graph backtest requests that include universe or sector nodes instead of silently ignoring them
- keep the low-level strategy builder warning behavior intact, but enforce single-ticker scope at the graph backtest entry point
- add API and service regression tests for the rejection path and update existing auto-promote tests to use single-ticker graphs

## Testing
- python3 -m py_compile api/services/backtest_service.py api/tests/test_backtest.py tests/test_auto_promote.py
- pytest api/tests/test_backtest.py tests/test_auto_promote.py tests/test_graph_backtest.py -q
- ruff check api/services/backtest_service.py api/tests/test_backtest.py tests/test_auto_promote.py

Closes #1335
