### PR TITLE
[chore/claude-config-portable] chore: Codex MCP/플러그인 설정 repo 이식

### DIFF
--- a/.claude/ONBOARDING.md
+++ b/.claude/ONBOARDING.md
@@ -1,0 +1,37 @@
+# Claude Code 온보딩 (새 머신 / clone 후 1회 설정)
+
+이 저장소를 새 머신에서 받은 뒤 Claude Code를 처음 열 때 필요한 **1회성** 설정입니다.
+설정값(MCP 서버 / 플러그인 / 마켓플레이스)은 모두 저장소에 커밋되어 있으므로 직접 입력할 필요는 없고, 아래 단계만 따라가면 됩니다.
+
+## 사전 준비
+- Node.js / `npx` — MCP 서버가 `npx`로 실행됩니다.
+- Codex 인증 — `mcp__codex__codex` 위임 도구를 쓰려면: `npx @openai/codex login`
+
+## 1. 폴더 신뢰
+Claude Code 첫 실행 시 폴더 신뢰 프롬프트 → 신뢰. (보안상 자동화 불가, 1회 클릭)
+
+## 2. MCP 서버 — 자동 연결 (작업 없음)
+`.mcp.json` + `enabledMcpjsonServers`(`.claude/settings.json`, committed)로 아래가 **자동 연결**됩니다:
+- `codex` → `mcp__codex__codex` (워크플로우 위임 도구, **핵심**)
+- `context7`, `playwright`
+
+확인: `/mcp`
+
+> 🔒 `.mcp.json`에는 secret이 없습니다(전부 `npx` 실행). API key가 필요한 MCP 서버를 추가할 경우
+> 이 커밋되는 파일이 아니라 `~/.claude.json`(user scope)에 넣으세요.
+
+## 3. 플러그인 — 수동 설치 (1회)
+> ⚠️ 플러그인 스킬은 Claude Code 한계로 committed 설정만으로는 **자동 활성화되지 않습니다**.
+> 마켓플레이스는 이미 등록돼 있으니 아래 install만 1회 실행하면 됩니다.
+
+```
+/plugin install codex@openai-codex
+/plugin install skill-creator@claude-plugins-official
+/plugin install chrome-devtools-mcp@claude-plugins-official
+/plugin install frontend-design@claude-code-plugins
+```
+
+확인: `/plugin` 또는 `/doctor`
+
+---
+플러그인 구성을 바꾸려면 `.claude/settings.json`의 `enabledPlugins`를 수정하세요. (개인 권한 설정은 `.claude/settings.local.json`)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,64 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $CLAUDE_PROJECT_DIR/.claude/hooks/memory-search.py",
+            "timeout": 8
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $CLAUDE_PROJECT_DIR/.claude/hooks/reflection.py",
+            "timeout": 8
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $CLAUDE_PROJECT_DIR/.claude/hooks/memory-store.py",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  },
+  "extraKnownMarketplaces": {
+    "openai-codex": {
+      "source": {
+        "source": "github",
+        "repo": "openai/codex-plugin-cc"
+      }
+    },
+    "claude-code-plugins": {
+      "source": {
+        "source": "github",
+        "repo": "anthropics/claude-code"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "codex@openai-codex": true,
+    "skill-creator@claude-plugins-official": true,
+    "chrome-devtools-mcp@claude-plugins-official": true,
+    "frontend-design@claude-code-plugins": true
+  },
+  "enabledMcpjsonServers": [
+    "codex",
+    "context7",
+    "playwright"
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -200,5 +200,5 @@ web/.next/
 web/.env.local
 web/.env*.local
 
-# MCP config (contains API keys)
-.mcp.json
+# MCP config — committed for portability (codex/context7/playwright are npx, no secrets).
+# Keep any secret-bearing MCP server in ~/.claude.json (user scope), NOT in this committed file.

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,16 @@
+{
+  "mcpServers": {
+    "codex": {
+      "command": "npx",
+      "args": ["-y", "@openai/codex", "mcp-server"]
+    },
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp"]
+    },
+    "playwright": {
+      "command": "npx",
+      "args": ["-y", "@playwright/mcp@latest"]
+    }
+  }
+}


### PR DESCRIPTION
## 목적
다른 머신에서 `git clone` 하면 Codex가 그대로 작동하도록, 글로벌(`~/.claude`) 의존을 제거하고 설정을 repo committed 파일로 이식합니다.

## 변경
- **`.mcp.json` 추가** — codex / context7 / playwright (전부 `npx`, secret 없음)
- **`.claude/settings.json` 추가** — `extraKnownMarketplaces`(openai-codex, claude-code-plugins) + `enabledPlugins`(codex, skill-creator, chrome-devtools-mcp, frontend-design) + `enabledMcpjsonServers`(codex, context7, playwright)
- **`.gitignore`** — `.mcp.json` ignore 해제 (현재 secret 없음. 비밀 서버는 `~/.claude.json` user scope에 두도록 주석으로 안내)
- **`.claude/ONBOARDING.md` 추가** — clone 후 1회 설정 가이드

## clone 후 동작
- ✅ **Codex MCP**(`mcp__codex__codex`) + context7/playwright → 폴더 신뢰 1클릭이면 자동 연결
- ⚠️ **플러그인 스킬**(`/codex:*` 등) → Claude Code 한계로 자동 활성화 불가 → 머신당 `/plugin install ...` 1회 필요 (ONBOARDING.md에 명령어 기재)

## 참고
- `settings.local.json`(개인 권한)은 이번 PR 범위 밖. tracked 상태 정리(`git rm --cached`)는 후속 작업으로 남겨둠.

🤖 Generated with [Claude Code](https://claude.com/claude-code)