### PR TITLE
[fix/claude-marketplace-decl] fix: 플러그인 마켓플레이스 선언 수정

### DIFF
--- a/.claude/ONBOARDING.md
+++ b/.claude/ONBOARDING.md
@@ -28,7 +28,7 @@ Claude Code 첫 실행 시 폴더 신뢰 프롬프트 → 신뢰. (보안상 자
 /plugin install codex@openai-codex
 /plugin install skill-creator@claude-plugins-official
 /plugin install chrome-devtools-mcp@claude-plugins-official
-/plugin install frontend-design@claude-code-plugins
+/plugin install frontend-design@claude-plugins-official
 ```
 
 확인: `/plugin` 또는 `/doctor`

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -43,10 +43,10 @@
         "repo": "openai/codex-plugin-cc"
       }
     },
-    "claude-code-plugins": {
+    "claude-plugins-official": {
       "source": {
         "source": "github",
-        "repo": "anthropics/claude-code"
+        "repo": "anthropics/claude-plugins-official"
       }
     }
   },
@@ -54,7 +54,7 @@
     "codex@openai-codex": true,
     "skill-creator@claude-plugins-official": true,
     "chrome-devtools-mcp@claude-plugins-official": true,
-    "frontend-design@claude-code-plugins": true
+    "frontend-design@claude-plugins-official": true
   },
   "enabledMcpjsonServers": [
     "codex",


### PR DESCRIPTION
## 목적
#1413 머지 후 발견된 버그 수정. 새 머신에서 clone 후 `/plugin install`이 실패하는 문제를 고칩니다.

## 문제 (#1413에 포함된 버그)
실제 설치 출처(`installed_plugins.json` / `known_marketplaces.json`) 대조 결과:
- `skill-creator` / `chrome-devtools-mcp`는 `@claude-plugins-official`에서 설치되는데, `extraKnownMarketplaces`에 **`claude-plugins-official` 선언이 누락**됨 → 새 머신에서 `unknown marketplace`로 install 실패.

## 수정
- `extraKnownMarketplaces`에 `claude-plugins-official` (`anthropics/claude-plugins-official`) 추가
- `frontend-design`을 `@claude-code-plugins` → `@claude-plugins-official`로 통일 (양쪽 마켓플레이스에 존재)
- 사용처가 없어진 `claude-code-plugins` 선언 제거
- ONBOARDING.md install 명령도 동일하게 수정

## 검증
- 실제 머신 `known_marketplaces.json` / `installed_plugins.json`와 1:1 대조 완료
- JSON 문법 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)